### PR TITLE
fix: include env in cache key computation

### DIFF
--- a/packages/nadle/src/core/caching/cache-validator.ts
+++ b/packages/nadle/src/core/caching/cache-validator.ts
@@ -50,7 +50,7 @@ export class CacheValidator {
 			workingDir: this.context.workingDir,
 			declarations: MaybeArray.toArray(this.taskConfiguration.inputs)
 		});
-		const cacheKey = await CacheKey.compute({ taskId, inputsFingerprints });
+		const cacheKey = await CacheKey.compute({ taskId, inputsFingerprints, env: this.taskConfiguration.env });
 		const cacheQuery: CacheQuery = { taskId, cacheKey };
 
 		const hasCache = await this.cacheManager.hasCache(cacheQuery);

--- a/packages/nadle/src/core/models/cache/cache-key.ts
+++ b/packages/nadle/src/core/models/cache/cache-key.ts
@@ -1,10 +1,12 @@
 import { hashObject } from "../../utilities/hash.js";
 import type { FileFingerprints } from "./fingerprint.js";
 import type { TaskIdentifier } from "../task-identifier.js";
+import type { TaskEnv } from "../../interfaces/task-configuration.js";
 
 export type CacheKey = string;
 export namespace CacheKey {
 	interface Input {
+		readonly env?: TaskEnv;
 		readonly taskId: TaskIdentifier;
 		readonly inputsFingerprints: FileFingerprints;
 	}

--- a/packages/nadle/test/__fixtures__/caching-env/nadle.config.ts
+++ b/packages/nadle/test/__fixtures__/caching-env/nadle.config.ts
@@ -1,0 +1,23 @@
+import Path from "node:path";
+import Fs from "node:fs/promises";
+
+import { glob } from "glob";
+import { tasks, Inputs, Outputs } from "nadle";
+
+tasks
+	.register("bundle-resources", async ({ context }) => {
+		for (const entry of await glob("resources/**/*.txt", {})) {
+			const path = Path.join(context.workingDir, entry);
+			const content = await Fs.readFile(path, "utf-8");
+			const modifiedContent = content + " modified";
+
+			const outputPath = Path.join(context.workingDir, "dist", entry);
+			await Fs.mkdir(Path.dirname(outputPath), { recursive: true });
+			await Fs.writeFile(outputPath, modifiedContent);
+		}
+	})
+	.config(() => ({
+		outputs: [Outputs.dirs("dist")],
+		inputs: [Inputs.dirs("resources")],
+		env: { BUILD_MODE: process.env.BUILD_MODE ?? "development" }
+	}));

--- a/packages/nadle/test/__fixtures__/caching-env/package.json
+++ b/packages/nadle/test/__fixtures__/caching-env/package.json
@@ -1,0 +1,12 @@
+{
+	"name": "@nadle/internal-nadle-test-fixtures-caching-env",
+	"type": "module",
+	"private": true,
+	"dependencies": {
+		"glob": "^11.1.0",
+		"nadle": "workspace:*"
+	},
+	"nadle": {
+		"root": true
+	}
+}

--- a/packages/nadle/test/__fixtures__/caching-env/resources/a/a-input.txt
+++ b/packages/nadle/test/__fixtures__/caching-env/resources/a/a-input.txt
@@ -1,0 +1,1 @@
+a content

--- a/packages/nadle/test/__fixtures__/caching-env/resources/a/a1/a1-input.txt
+++ b/packages/nadle/test/__fixtures__/caching-env/resources/a/a1/a1-input.txt
@@ -1,0 +1,1 @@
+a1 content

--- a/packages/nadle/test/__fixtures__/caching-env/resources/a/a2/a2-input.txt
+++ b/packages/nadle/test/__fixtures__/caching-env/resources/a/a2/a2-input.txt
@@ -1,0 +1,1 @@
+a2 content

--- a/packages/nadle/test/__fixtures__/caching-env/resources/b/b-input.txt
+++ b/packages/nadle/test/__fixtures__/caching-env/resources/b/b-input.txt
@@ -1,0 +1,1 @@
+b content

--- a/packages/nadle/test/__fixtures__/caching-env/resources/main-input.txt
+++ b/packages/nadle/test/__fixtures__/caching-env/resources/main-input.txt
@@ -1,0 +1,1 @@
+main content

--- a/packages/nadle/test/features/caching/env.test.ts
+++ b/packages/nadle/test/features/caching/env.test.ts
@@ -1,0 +1,37 @@
+import Path from "node:path";
+import Fs from "node:fs/promises";
+
+import { isWindows } from "std-env";
+import { getStdout, createExec, fixturesDir } from "setup";
+import { it, expect, describe, afterEach, beforeEach } from "vitest";
+
+describe.skipIf(isWindows)("caching-env", () => {
+	const cwd = Path.join(fixturesDir, "caching-env");
+
+	beforeEach(async () => {
+		await Fs.rm(Path.join(cwd, "dist"), { force: true, recursive: true });
+		await Fs.rm(Path.join(cwd, ".nadle"), { force: true, recursive: true });
+	});
+
+	afterEach(async () => {
+		await Fs.rm(Path.join(cwd, "dist"), { force: true, recursive: true });
+		await Fs.rm(Path.join(cwd, ".nadle"), { force: true, recursive: true });
+	});
+
+	it("should be up-to-date when env does not change", async () => {
+		const exec = createExec({ cwd, env: { BUILD_MODE: "production" } });
+
+		await exec`bundle-resources`;
+
+		await expect(getStdout(exec`bundle-resources`)).resolves.toSettle("bundle-resources", "up-to-date");
+	});
+
+	it("should miss cache when env changes", async () => {
+		const execProd = createExec({ cwd, env: { BUILD_MODE: "production" } });
+		const execDev = createExec({ cwd, env: { BUILD_MODE: "development" } });
+
+		await execProd`bundle-resources`;
+
+		await expect(getStdout(execDev`bundle-resources`)).resolves.toSettle("bundle-resources", "done");
+	});
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -326,6 +326,15 @@ importers:
         specifier: workspace:*
         version: link:../../..
 
+  packages/nadle/test/__fixtures__/caching-env:
+    dependencies:
+      glob:
+        specifier: ^11.1.0
+        version: 11.1.0
+      nadle:
+        specifier: workspace:*
+        version: link:../../..
+
   packages/nadle/test/__fixtures__/caching-input:
     dependencies:
       glob:


### PR DESCRIPTION
## Summary

Closes #431.

- Include resolved `TaskConfiguration.env` values in the cache key computation, so changing environment variables correctly invalidates the cache
- Add integration tests verifying env-based cache hits and misses

The fix is a 2-line change:
- `cache-key.ts`: Add optional `env` field to `CacheKey.Input`
- `cache-validator.ts`: Pass `taskConfiguration.env` to `CacheKey.compute()`

## Test plan

- [x] New test: cache is up-to-date when env does not change
- [x] New test: cache misses when env changes
- [x] All existing caching tests still pass
- [x] Full test suite passes (203 tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)