### PR TITLE
fix: remove duplicate re-export in core/index.ts

### DIFF
--- a/packages/nadle/src/core/index.ts
+++ b/packages/nadle/src/core/index.ts
@@ -1,5 +1,4 @@
 export * from "./models/index.js";
-export * from "./models/index.js";
 export * from "./options/index.js";
 export * from "./utilities/index.js";
 export * from "./interfaces/index.js";


### PR DESCRIPTION
## Summary
- Removed duplicate `export * from "./models/index.js"` line in `core/index.ts` (copy-paste error)

Closes #437

## Test plan
- [x] TypeScript compilation passes
- [x] No behavioral change — duplicate re-export was a no-op at runtime

🤖 Generated with [Claude Code](https://claude.com/claude-code)