### PR TITLE
fix: narrow catch clauses in cache metadata reads to ENOENT

### DIFF
--- a/packages/nadle/src/core/caching/cache-manager.ts
+++ b/packages/nadle/src/core/caching/cache-manager.ts
@@ -30,8 +30,12 @@ export class CacheManager {
 			const raw = await Fs.readFile(path, "utf8");
 
 			return JSON.parse(raw);
-		} catch {
-			return null;
+		} catch (error) {
+			if (isFileNotFoundError(error)) {
+				return null;
+			}
+
+			throw error;
 		}
 	}
 
@@ -93,8 +97,12 @@ export class CacheManager {
 			const { latest } = JSON.parse(raw) as TaskCacheMetadata;
 
 			return this.readRunMetadata({ taskId, cacheKey: latest });
-		} catch {
-			return null;
+		} catch (error) {
+			if (isFileNotFoundError(error)) {
+				return null;
+			}
+
+			throw error;
 		}
 	}
 
@@ -118,4 +126,8 @@ async function ensureDirectories(dirs: string[]): Promise<void> {
 	const unique = [...new Set(dirs)];
 
 	await Promise.all(unique.map((dir) => Fs.mkdir(dir, { recursive: true })));
+}
+
+function isFileNotFoundError(error: unknown): boolean {
+	return error instanceof Error && "code" in error && error.code === "ENOENT";
 }


### PR DESCRIPTION
## Summary
- Narrowed catch clauses in `readRunMetadata()` and `readLatestRunMetadata()` to only suppress `ENOENT` (file not found) errors
- Unexpected errors (permission issues, corrupted JSON, disk errors) are now properly propagated instead of silently returning null

Closes #439

## Test plan
- [x] TypeScript compilation passes
- [x] File-not-found cases still return `null` (same behavior as before)
- [x] Genuine errors (corrupt JSON, permission denied) will now propagate to callers

🤖 Generated with [Claude Code](https://claude.com/claude-code)