### PR TITLE
fix: include sub-workspace config file in cache fingerprint

### DIFF
--- a/packages/nadle/src/core/caching/cache-validator.ts
+++ b/packages/nadle/src/core/caching/cache-validator.ts
@@ -18,9 +18,9 @@ type CacheValidationResult =
 interface CacheValidatorContext {
 	readonly cache: boolean;
 	readonly cacheDir: string;
-	readonly configFile: string;
 	readonly projectDir: string;
 	readonly workingDir: string;
+	readonly configFiles: string[];
 }
 
 export class CacheValidator {
@@ -46,7 +46,7 @@ export class CacheValidator {
 		const taskId = this.taskId;
 
 		const inputsFingerprints = await FileFingerprints.compute({
-			files: [this.context.configFile],
+			files: this.context.configFiles,
 			workingDir: this.context.workingDir,
 			declarations: MaybeArray.toArray(this.taskConfiguration.inputs)
 		});

--- a/packages/nadle/src/core/engine/worker.ts
+++ b/packages/nadle/src/core/engine/worker.ts
@@ -5,6 +5,7 @@ import c from "tinyrainbow";
 
 import { Nadle } from "../nadle.js";
 import { bindObject } from "../utilities/utils.js";
+import { Project } from "../models/project/project.js";
 import { type RunnerContext } from "../interfaces/task.js";
 import { CacheValidator } from "../caching/cache-validator.js";
 import { taskRegistry } from "../registration/task-registry.js";
@@ -39,10 +40,14 @@ export default async ({ port, taskId, options, env: originalEnv }: WorkerParams)
 
 	const environmentInjector = createEnvironmentInjector(originalEnv, taskConfig.env);
 
+	const rootConfigFile = nadle.options.project.rootWorkspace.configFilePath;
+	const workspace = Project.getWorkspaceById(nadle.options.project, task.workspaceId);
+	const configFiles = workspace.configFilePath ? [rootConfigFile, workspace.configFilePath] : [rootConfigFile];
+
 	const cacheValidator = new CacheValidator(taskId, taskConfig, {
 		workingDir,
+		configFiles,
 		projectDir: nadle.options.project.rootWorkspace.absolutePath,
-		configFile: nadle.options.project.rootWorkspace.configFilePath,
 		...nadle.options
 	});
 	const validationResult = await cacheValidator.validate();


### PR DESCRIPTION
## Summary
- Changed `CacheValidatorContext.configFile` (single string) to `configFiles` (string array) to support multiple config files
- In the worker, now resolves the task's workspace and includes its config file alongside the root workspace config
- Prevents false cache hits in monorepos when a sub-workspace's `nadle.config.ts` changes

Closes #430

## Test plan
- [x] TypeScript compilation passes
- [x] Root workspace tasks still include only the root config (same behavior)
- [x] Sub-workspace tasks now include both root + workspace config files in fingerprint

🤖 Generated with [Claude Code](https://claude.com/claude-code)