### PR TITLE
chore: skip lint/check step on non-Linux CI runners

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -46,6 +46,7 @@ jobs:
           node-version: ${{ matrix.node-version }}
 
       - name: Check
+        if: runner.os == 'Linux'
         run: npx nadle check
 
       - name: Build


### PR DESCRIPTION
## Summary
- Only run `nadle check` (eslint, prettier, knip, spell, validate) on Linux runners
- macOS and Windows runners now only run build + test, saving ~5-10 min per run

## Test plan
- [x] Check step uses `if: runner.os == 'Linux'` condition
- [x] Linux runners (Node 22 + 24) still run the full pipeline
- [x] macOS and Windows skip linting but still verify build + test

🤖 Generated with [Claude Code](https://claude.com/claude-code)