### PR TITLE
test: use describe.concurrent() for isolated test suites

### DIFF
--- a/packages/nadle/test/depends-on.test.ts
+++ b/packages/nadle/test/depends-on.test.ts
@@ -1,7 +1,7 @@
 import { getStdout, createExec } from "setup";
 import { it, expect, describe } from "vitest";
 
-describe("dependsOn", () => {
+describe.concurrent("dependsOn", () => {
 	const exec = createExec({ config: "depends-on" });
 
 	it("should run dependent tasks first 1", async () => {

--- a/packages/nadle/test/features/project-dir.test.ts
+++ b/packages/nadle/test/features/project-dir.test.ts
@@ -5,7 +5,7 @@ import { it, expect, describe } from "vitest";
 import { createExec, fixturesDir } from "setup";
 
 // TODO: Use --config-paths to extract project path value
-describe("projectDir", () => {
+describe.concurrent("projectDir", () => {
 	const baseDir = Path.join(fixturesDir, "project-dir");
 
 	describe("given a package.json contains nadle.root = true", () => {

--- a/packages/nadle/test/features/workspaces/workspaces-configure.test.ts
+++ b/packages/nadle/test/features/workspaces/workspaces-configure.test.ts
@@ -2,7 +2,7 @@ import { it, expect, describe } from "vitest";
 import { PACKAGE_JSON } from "src/core/utilities/constants.js";
 import { getStderr, withFixture, CONFIG_FILE, PNPM_WORKSPACE, createPackageJson, createNadleConfig, createPnpmWorkspace } from "setup";
 
-describe("workspaces configure", () => {
+describe.concurrent("workspaces configure", () => {
 	describe("when calling configure from sub-workspace configure file", () => {
 		it("should throw an error", async () => {
 			await withFixture({

--- a/packages/nadle/test/features/workspaces/workspaces-depends-on-tasks.test.ts
+++ b/packages/nadle/test/features/workspaces/workspaces-depends-on-tasks.test.ts
@@ -14,7 +14,7 @@ import {
 	createPnpmWorkspace
 } from "setup";
 
-describe("workspaces > depends on tasks", () => {
+describe.concurrent("workspaces > depends on tasks", () => {
 	describe("when declare a task without workspace", () => {
 		describe("when the declared task is not defined in the workspace", () => {
 			it("should throw an error even if having a same task in root workspace", async () => {

--- a/packages/nadle/test/logger.test.ts
+++ b/packages/nadle/test/logger.test.ts
@@ -1,7 +1,7 @@
 import { createExec } from "setup";
 import { it, expect, describe } from "vitest";
 
-describe("logger", () => {
+describe.concurrent("logger", () => {
 	const environments = [
 		{ CI: "true", TEST: "true", reporter: "BasicReporter" },
 		{ CI: "true", TEST: "false", reporter: "CIReporter" },

--- a/packages/nadle/test/options/footer.ts
+++ b/packages/nadle/test/options/footer.ts
@@ -1,7 +1,7 @@
 import { it, expect, describe } from "vitest";
 import { exec, createExec, serializeANSI } from "setup";
 
-describe("--footer", () => {
+describe.concurrent("--footer", () => {
 	it("should show in-progress summary when enable explicitly", async () => {
 		const { stdout, exitCode } = await exec`copy --footer --max-workers 2`;
 

--- a/packages/nadle/test/options/max-worker.test.ts
+++ b/packages/nadle/test/options/max-worker.test.ts
@@ -3,7 +3,7 @@ import Path from "node:path";
 import { it, expect, describe } from "vitest";
 import { getStderr, getStdout, createExec, fixturesDir } from "setup";
 
-describe("--max-workers", () => {
+describe.concurrent("--max-workers", () => {
 	const baseConfig = { autoInjectMaxWorkers: false, env: { NADLE_MAX_WORKERS: "64" }, cwd: Path.join(fixturesDir, "workers") };
 
 	describe("when not specified", () => {

--- a/packages/nadle/test/options/min-worker.test.ts
+++ b/packages/nadle/test/options/min-worker.test.ts
@@ -3,7 +3,7 @@ import Path from "node:path";
 import { it, expect, describe } from "vitest";
 import { getStderr, getStdout, createExec, fixturesDir } from "setup";
 
-describe("--min-workers", () => {
+describe.concurrent("--min-workers", () => {
 	const baseConfig = { autoInjectMaxWorkers: false, env: { NADLE_MAX_WORKERS: "64" }, cwd: Path.join(fixturesDir, "workers") };
 
 	describe("when not specified", () => {

--- a/packages/nadle/test/options/parallel.test.ts
+++ b/packages/nadle/test/options/parallel.test.ts
@@ -1,7 +1,7 @@
 import { it, expect, describe } from "vitest";
 import { getStdout, createExec } from "setup";
 
-describe("--parallel", () => {
+describe.concurrent("--parallel", () => {
 	const exec = createExec({ config: "basic" });
 
 	it("should done in order 1", async () => {

--- a/packages/nadle/test/register.test-d.ts
+++ b/packages/nadle/test/register.test-d.ts
@@ -1,7 +1,7 @@
 import { it, describe, expectTypeOf } from "vitest";
 import { tasks, Inputs, Outputs, PnpmTask, type TaskConfigurationBuilder } from "nadle";
 
-describe("tasks.register", () => {
+describe.concurrent("tasks.register", () => {
 	it("can register tasks with various signatures", () => {
 		expectTypeOf(tasks.register("check")).toEqualTypeOf<TaskConfigurationBuilder>();
 

--- a/packages/nadle/test/task-configs/env.test.ts
+++ b/packages/nadle/test/task-configs/env.test.ts
@@ -1,7 +1,7 @@
 import { getStdout, createExec } from "setup";
 import { it, expect, describe } from "vitest";
 
-describe("env", () => {
+describe.concurrent("env", () => {
 	const exec = createExec({ config: "env" });
 
 	it("can inject env to process.env from object config", async () => {

--- a/packages/nadle/test/unit/format-time.test.ts
+++ b/packages/nadle/test/unit/format-time.test.ts
@@ -2,7 +2,7 @@ import { it, expect, describe } from "vitest";
 
 import { formatTime } from "../../src/core/utilities/utils.js";
 
-describe("formatTime", () => {
+describe.concurrent("formatTime", () => {
 	it("formats short durations with ms", () => {
 		expect(formatTime(7)).toBe("7ms");
 		expect(formatTime(349)).toBe("349ms");

--- a/packages/nadle/test/unit/task-input-resolver.test.ts
+++ b/packages/nadle/test/unit/task-input-resolver.test.ts
@@ -34,7 +34,7 @@ const TasksByWorkspace = {
 	frontend: ["build", "clean", "prepare", "dev", "test"]
 };
 
-describe("TaskInputResolver", () => {
+describe.concurrent("TaskInputResolver", () => {
 	const resolver = new TaskInputResolver(defaultLogger, (ws: string) => TasksByWorkspace[ws as "backend" | "root" | "frontend"]);
 
 	it("resolves exact task names in target workspace", () => {


### PR DESCRIPTION
Closes #421

## Summary

- Add `describe.concurrent()` to **13 test files** that are safe for concurrent execution
- These files either use read-only fixtures, `withFixture()` isolation, or are pure unit tests
- Files using `toMatchSnapshot()` are excluded due to a [vitest 4.x incompatibility](https://github.com/vitest-dev/vitest/issues/5458) with concurrent snapshot writes

### Files updated

| Category | Files |
|---|---|
| Read-only CLI tests | `depends-on`, `logger`, `parallel`, `max-worker`, `min-worker`, `footer`, `env` (task-config), `project-dir` |
| `withFixture()` isolated | `workspaces-configure`, `workspaces-depends-on-tasks` |
| Pure unit tests | `format-time`, `task-input-resolver` |
| Type-level test | `register.test-d` |

### Files intentionally excluded

- **29 snapshot-using files**: `toMatchSnapshot()` causes `TypeError: Cannot read properties of undefined` under `describe.concurrent` in vitest 4.x
- **6 shared-state files**: Caching/cache-dir tests with `beforeEach`/`afterEach` on shared fixture dirs
- **3 chained modifier files**: `describe.skipIf`, `describe.each`, `describe.skip` — chaining with `.concurrent` is undocumented

## Test plan

- [x] Full test suite passes (13 concurrent files + all existing tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)