### PR TITLE
refactor: remove Logger.throw() from public API

### DIFF
--- a/packages/nadle/index.api.md
+++ b/packages/nadle/index.api.md
@@ -82,7 +82,6 @@ export interface Logger {
     getColumns(): number;
     info(message: InputLogObject | string, ...args: unknown[]): void;
     log(message: InputLogObject | string, ...args: unknown[]): void;
-    throw(message: InputLogObject | string, ...args: unknown[]): never;
     warn(message: InputLogObject | string, ...args: unknown[]): void;
 }
 

--- a/packages/nadle/src/core/engine/scheduler-types.ts
+++ b/packages/nadle/src/core/engine/scheduler-types.ts
@@ -18,7 +18,7 @@ export interface SchedulerTask {
  */
 export interface SchedulerLogger {
 	debug(message: unknown, ...args: unknown[]): void;
-	throw(message: unknown, ...args: unknown[]): never;
+	error(message: unknown, ...args: unknown[]): void;
 }
 
 /**

--- a/packages/nadle/src/core/engine/task-scheduler.ts
+++ b/packages/nadle/src/core/engine/task-scheduler.ts
@@ -2,6 +2,7 @@ import { highlight } from "../utilities/utils.js";
 import { Messages } from "../utilities/messages.js";
 import { EnsureMap } from "../utilities/ensure-map.js";
 import { RIGHT_ARROW } from "../utilities/constants.js";
+import { NadleError } from "../utilities/nadle-error.js";
 import { MaybeArray } from "../utilities/maybe-array.js";
 import { ResolvedTask } from "../interfaces/resolved-task.js";
 import { type SchedulerDependencies } from "./scheduler-types.js";
@@ -70,8 +71,9 @@ export class TaskScheduler {
 			const startIndex = paths.indexOf(dependency);
 
 			if (startIndex !== -1) {
-				const cycle = [...paths.slice(startIndex), dependency].map(highlight).join(` ${RIGHT_ARROW} `);
-				this.deps.logger.throw(Messages.CycleDetected(cycle));
+				const message = Messages.CycleDetected([...paths.slice(startIndex), dependency].map(highlight).join(` ${RIGHT_ARROW} `));
+				this.deps.logger.error(message);
+				throw new NadleError(message);
 			}
 
 			this.detectCycle(dependency, [...paths, dependency]);

--- a/packages/nadle/src/core/engine/worker.ts
+++ b/packages/nadle/src/core/engine/worker.ts
@@ -61,7 +61,7 @@ export async function runTask(
 
 	const context: RunnerContext = {
 		workingDir,
-		logger: bindObject(nadle.logger, ["error", "warn", "log", "info", "debug", "getColumns", "throw"])
+		logger: bindObject(nadle.logger, ["error", "warn", "log", "info", "debug", "getColumns"])
 	};
 	const taskOptions = typeof task.optionsResolver === "function" ? task.optionsResolver(context) : task.optionsResolver;
 	const environmentInjector = createEnvironmentInjector(originalEnv, taskConfig.env);

--- a/packages/nadle/src/core/interfaces/defaults/default-logger.ts
+++ b/packages/nadle/src/core/interfaces/defaults/default-logger.ts
@@ -68,14 +68,6 @@ export class DefaultLogger implements Logger {
 	}
 
 	/**
-	 * Log an error message.
-	 */
-	public throw(message: string): never {
-		this.error(message);
-		throw new Error(message);
-	}
-
-	/**
 	 * Log a warning message.
 	 */
 	public warn(message: InputLogObject | string, ...args: unknown[]): void {

--- a/packages/nadle/src/core/interfaces/logger.ts
+++ b/packages/nadle/src/core/interfaces/logger.ts
@@ -36,14 +36,6 @@ export interface Logger {
 	debug(message: InputLogObject | string, ...args: unknown[]): void;
 
 	/**
-	 * Log and throw a user-facing error (e.g. invalid config, missing task, cycle detected).
-	 * For internal invariants / programmer errors, use `throw new Error()` directly instead.
-	 * @param message - The message or log object.
-	 * @param args - Additional arguments.
-	 */
-	throw(message: InputLogObject | string, ...args: unknown[]): never;
-
-	/**
 	 * Get the number of columns in the output stream.
 	 * @returns Number of columns, or 80 if unavailable.
 	 */

--- a/packages/nadle/src/core/options/options-resolver.ts
+++ b/packages/nadle/src/core/options/options-resolver.ts
@@ -6,6 +6,7 @@ import { type Project, configureProject, ROOT_WORKSPACE_ID } from "@nadle/projec
 
 import { clamp } from "../utilities/utils.js";
 import { ProjectResolver } from "./project-resolver.js";
+import { NadleError } from "../utilities/nadle-error.js";
 import { TaskInputResolver } from "./task-input-resolver.js";
 import { ResolvedTask } from "../interfaces/resolved-task.js";
 import { DEFAULT_CACHE_DIR_NAME } from "../utilities/constants.js";
@@ -74,7 +75,9 @@ export class OptionsResolver {
 		} else if (typeof configValue === "string") {
 			result = Math.round((Number.parseInt(configValue) / 100) * this.availableWorkers);
 		} else {
-			this.logger.throw(`Invalid worker value: ${configValue}`);
+			const message = `Invalid worker value: ${configValue}`;
+			this.logger.error(message);
+			throw new NadleError(message);
 		}
 
 		return clamp(result, 1, this.availableWorkers);

--- a/packages/nadle/src/core/options/task-input-resolver.ts
+++ b/packages/nadle/src/core/options/task-input-resolver.ts
@@ -5,6 +5,7 @@ import { highlight } from "../utilities/utils.js";
 import { Messages } from "../utilities/messages.js";
 import { suggest } from "../utilities/suggestion.js";
 import { type Logger } from "../interfaces/logger.js";
+import { NadleError } from "../utilities/nadle-error.js";
 import { TaskIdentifier } from "../models/task-identifier.js";
 import { type ResolvedTask } from "../interfaces/resolved-task.js";
 
@@ -79,21 +80,23 @@ export class TaskInputResolver {
 			}
 		}
 
-		this.logger.throw(
-			Messages.UnresolvedTaskWithSuggestions({
-				taskNameInput,
-				targetWorkspaceId,
-				fallbackWorkspaceId,
-				suggestions: formatSuggestions(resolvedTask.suggestions)
-			})
-		);
+		const message = Messages.UnresolvedTaskWithSuggestions({
+			taskNameInput,
+			targetWorkspaceId,
+			fallbackWorkspaceId,
+			suggestions: formatSuggestions(resolvedTask.suggestions)
+		});
+		this.logger.error(message);
+		throw new NadleError(message);
 	}
 
 	private resolveWorkspace(workspaceInput: string, workspaceLabels: string[]): string {
 		const suggestedWorkspace = suggest(workspaceInput, workspaceLabels, this.logger);
 
 		if (suggestedWorkspace.result === undefined) {
-			this.logger.throw(Messages.UnresolvedWorkspace(workspaceInput, formatSuggestions(suggestedWorkspace.suggestions)));
+			const message = Messages.UnresolvedWorkspace(workspaceInput, formatSuggestions(suggestedWorkspace.suggestions));
+			this.logger.error(message);
+			throw new NadleError(message);
 		}
 
 		return suggestedWorkspace.result;

--- a/packages/nadle/test/unit/implicit-dependency-resolver.test.ts
+++ b/packages/nadle/test/unit/implicit-dependency-resolver.test.ts
@@ -12,7 +12,7 @@ function createTask(name: string, workspaceId: string): SchedulerTask {
 function createDeps(tasks: SchedulerTask[], workspaceDeps: Record<string, string[]> = {}, excludedTaskIds: ReadonlySet<string> = new Set()) {
 	return {
 		excludedTaskIds,
-		logger: { debug: vi.fn(), throw: vi.fn() as never },
+		logger: { debug: vi.fn(), error: vi.fn() },
 		getWorkspaceDependencies: (wsId: string) => workspaceDeps[wsId] ?? [],
 		getTasksByName: (taskName: string) => tasks.filter((t) => t.name === taskName)
 	};

--- a/packages/nadle/test/unit/task-input-resolver.test.ts
+++ b/packages/nadle/test/unit/task-input-resolver.test.ts
@@ -10,11 +10,7 @@ const defaultLogger: Logger = {
 	warn: vi.fn(),
 	debug: vi.fn(),
 	error: vi.fn(),
-	getColumns: vi.fn(),
-	throw: (message: string) => {
-		vi.fn();
-		throw new Error(message);
-	}
+	getColumns: vi.fn()
 };
 
 const emptyPackageJson = { name: "", version: "" };

--- a/packages/nadle/test/unit/task-scheduler.test.ts
+++ b/packages/nadle/test/unit/task-scheduler.test.ts
@@ -53,15 +53,13 @@ function createMockDeps(tasks: TaskDef[], options?: MockOptions): SchedulerDepen
 			});
 
 	return {
+		logger: {
+			debug: vi.fn(),
+			error: vi.fn()
+		},
 		isRootWorkspace: (workspaceId: string) => workspaceId === "root",
 		getWorkspaceDependencies: (wsId: string) => workspaceDeps[wsId] ?? [],
 		getTasksByName: (taskName: string) => [...taskMap.values()].filter((t) => t.name === taskName),
-		logger: {
-			debug: vi.fn(),
-			throw: (message: string) => {
-				throw new Error(message);
-			}
-		},
 		parseTaskRef: (input: string, workspaceId: string) => {
 			if (input.includes(":")) {
 				return input;


### PR DESCRIPTION
## Summary
- Remove `Logger.throw()` from the public API interface, `DefaultLogger` implementation, and worker binding (#438)
- Replace all 4 internal call sites with `logger.error()` + `throw new NadleError()`, separating logging from exception throwing and using typed exit codes
- Update test mocks and regenerate `index.api.md`

## Test plan
- [x] `npx tsc -p packages/nadle/tsconfig.build.json --noEmit` passes
- [x] All 18 unit tests in `task-input-resolver.test.ts` and `task-scheduler.test.ts` pass
- [x] Pre-commit hooks (eslint, prettier, spell, knip, validate) pass
- [x] `npx nadle build` succeeds

Closes #438

🤖 Generated with [Claude Code](https://claude.com/claude-code)