### PR TITLE
refactor: remove eslint-disable overrides for line/complexity/params limits

### DIFF
--- a/packages/nadle/src/core/options/task-input-resolver.ts
+++ b/packages/nadle/src/core/options/task-input-resolver.ts
@@ -32,9 +32,19 @@ export class TaskInputResolver {
 				const suggestedWorkspaceLabelOrId = this.resolveWorkspace(workspaceInput, workspaces);
 
 				const workspace = Project.getWorkspaceByLabelOrId(project, suggestedWorkspaceLabelOrId);
-				resolvedTask = this.resolveTask(project, taskNameInput, workspace.id, undefined);
+				resolvedTask = this.resolveTask({
+					project,
+					taskNameInput,
+					fallbackWorkspaceId: undefined,
+					targetWorkspaceId: workspace.id
+				});
 			} else {
-				resolvedTask = this.resolveTask(project, taskNameInput, targetWorkspace, fallbackWorkspace);
+				resolvedTask = this.resolveTask({
+					project,
+					taskNameInput,
+					targetWorkspaceId: targetWorkspace,
+					fallbackWorkspaceId: fallbackWorkspace
+				});
 			}
 
 			const corrected =
@@ -46,8 +56,13 @@ export class TaskInputResolver {
 		});
 	}
 
-	// eslint-disable-next-line max-params
-	private resolveTask(project: Project, taskNameInput: string, targetWorkspaceId: string, fallbackWorkspaceId: string | undefined): string {
+	private resolveTask(options: {
+		project: Project;
+		taskNameInput: string;
+		targetWorkspaceId: string;
+		fallbackWorkspaceId: string | undefined;
+	}): string {
+		const { project, taskNameInput, targetWorkspaceId, fallbackWorkspaceId } = options;
 		const resolvedTask = suggest(taskNameInput, this.taskNamesGetter(targetWorkspaceId), this.logger);
 
 		if (resolvedTask.result !== undefined) {
@@ -65,7 +80,12 @@ export class TaskInputResolver {
 		}
 
 		this.logger.throw(
-			Messages.UnresolvedTaskWithSuggestions(taskNameInput, targetWorkspaceId, fallbackWorkspaceId, formatSuggestions(resolvedTask.suggestions))
+			Messages.UnresolvedTaskWithSuggestions({
+				taskNameInput,
+				targetWorkspaceId,
+				fallbackWorkspaceId,
+				suggestions: formatSuggestions(resolvedTask.suggestions)
+			})
 		);
 	}
 

--- a/packages/nadle/src/core/utilities/messages.ts
+++ b/packages/nadle/src/core/utilities/messages.ts
@@ -18,9 +18,13 @@ export const Messages = {
 		`Task ${highlight(taskNameInput)} not found in ${highlight(targetWorkspaceId)} workspace.`,
 	InvalidTaskName: (taskName: string) =>
 		`Invalid task name: ${highlight(taskName)}. Task names must contain only letters, numbers, and dashes; start with a letter, and not end with a dash.`,
-	// eslint-disable-next-line max-params
-	UnresolvedTaskWithSuggestions: (taskNameInput: string, targetWorkspaceId: string, fallbackWorkspaceId: string | undefined, suggestions: string) =>
-		`Task ${highlight(taskNameInput)} not found in ${highlight(targetWorkspaceId)}${fallbackWorkspaceId ? ` nor ${highlight(fallbackWorkspaceId)}` : ""} workspace. ${suggestions}`,
+	UnresolvedTaskWithSuggestions: (options: {
+		suggestions: string;
+		taskNameInput: string;
+		targetWorkspaceId: string;
+		fallbackWorkspaceId: string | undefined;
+	}) =>
+		`Task ${highlight(options.taskNameInput)} not found in ${highlight(options.targetWorkspaceId)}${options.fallbackWorkspaceId ? ` nor ${highlight(options.fallbackWorkspaceId)}` : ""} workspace. ${options.suggestions}`,
 
 	EmptyWorkspaceLabel: (workspaceId: string) => `Workspace ${highlight(workspaceId)} alias can not be empty.`,
 	UnresolvedWorkspace: (workspaceInput: string, suggestions: string) => `Workspace ${highlight(workspaceInput)} not found. ${suggestions}`,

--- a/packages/nadle/src/core/views/tasks-selection.tsx
+++ b/packages/nadle/src/core/views/tasks-selection.tsx
@@ -28,7 +28,6 @@ namespace TasksSelection {
 	}
 }
 
-// eslint-disable-next-line max-lines-per-function
 const TasksSelection: React.FC<TasksSelection.Props> = ({ tasks, onSubmit }) => {
 	const [cursor, setCursor] = useState(0);
 	const [selectedTasks, setSelectedTasks] = useState<string[]>([]);
@@ -36,7 +35,7 @@ const TasksSelection: React.FC<TasksSelection.Props> = ({ tasks, onSubmit }) => 
 	const [isCommandMode, setIsCommandMode] = useState(false);
 	const [commandBuffer, setCommandBuffer] = useState("");
 
-	const searchingTasks = useSearching(tasks, searchText, selectedTasks, cursor);
+	const searchingTasks = useSearching({ tasks, cursor, searchText, selectedTasks });
 
 	const { exit } = useApp();
 
@@ -68,6 +67,32 @@ const TasksSelection: React.FC<TasksSelection.Props> = ({ tasks, onSubmit }) => 
 			}
 		}
 	});
+
+	return (
+		<TasksSelectionView
+			commandBuffer={commandBuffer}
+			isCommandMode={isCommandMode}
+			searchText={searchText}
+			searchingTasks={searchingTasks}
+			selectedTasks={selectedTasks}
+			tasks={tasks}
+		/>
+	);
+};
+
+namespace TasksSelectionView {
+	export interface Props {
+		readonly searchText: string;
+		readonly commandBuffer: string;
+		readonly isCommandMode: boolean;
+		readonly selectedTasks: string[];
+		readonly tasks: InteractiveTask[];
+		readonly searchingTasks: VisibleTask[];
+	}
+}
+
+const TasksSelectionView: React.FC<TasksSelectionView.Props> = (props) => {
+	const { tasks, searchText, selectedTasks, isCommandMode, commandBuffer, searchingTasks } = props;
 
 	return (
 		<Box flexDirection="column" padding={1} borderStyle="round" borderColor={PRIMARY_COLOR}>

--- a/packages/nadle/src/core/views/use-searching.tsx
+++ b/packages/nadle/src/core/views/use-searching.tsx
@@ -7,8 +7,16 @@ import { HIGHLIGHT_COLOR, type InteractiveTask } from "./tasks-selection.js";
 
 const VISIBLE_TASKS_LIMIT = 5;
 
-// eslint-disable-next-line max-params
-export function useSearching(tasks: InteractiveTask[], searchText: string, selectedTasks: string[], cursor: number): VisibleTask[] {
+interface UseSearchingOptions {
+	readonly cursor: number;
+	readonly searchText: string;
+	readonly selectedTasks: string[];
+	readonly tasks: InteractiveTask[];
+}
+
+export function useSearching(options: UseSearchingOptions): VisibleTask[] {
+	const { tasks, cursor, searchText, selectedTasks } = options;
+
 	return React.useMemo(() => {
 		if (!searchText) {
 			const visibleTasks = tasks.slice(0, VISIBLE_TASKS_LIMIT);


### PR DESCRIPTION
## Summary
- Split `CopyTask.run()` into `copyDirectory()` and `copySingleFile()` helpers using a shared `CopyContext` interface, removing `max-lines-per-function` and `complexity` overrides
- Convert `UnresolvedTaskWithSuggestions`, `resolveTask`, and `useSearching` from positional params to options objects, removing `max-params` overrides
- Extract `TasksSelectionView` presentational sub-component from `TasksSelection`, removing `max-lines-per-function` override

Closes #412

## Test plan
- [x] `npx eslint packages/nadle/src/ --quiet` — no errors
- [x] `npx tsc -p packages/nadle/tsconfig.build.json --noEmit` — type check passes
- [x] `pnpm -F nadle test` — all relevant tests pass (pre-existing failures in `unknown-task` snapshots and `clean-cache` are unrelated)

🤖 Generated with [Claude Code](https://claude.com/claude-code)