### PR TITLE
refactor: replace `any` with `unknown` in source type annotations

### DIFF
--- a/packages/nadle/src/core/options/cli-options-resolver.ts
+++ b/packages/nadle/src/core/options/cli-options-resolver.ts
@@ -27,7 +27,7 @@ const exclude =
 	};
 
 const transform =
-	(targetKey: string, options: { transformKey?: string; transformValue?: (value: any) => any }): ArgTransformer =>
+	(targetKey: string, options: { transformKey?: string; transformValue?: (value: unknown) => unknown }): ArgTransformer =>
 	(arg) => {
 		if (arg.key !== targetKey) {
 			return arg;

--- a/packages/nadle/src/core/reporting/reporter.ts
+++ b/packages/nadle/src/core/reporting/reporter.ts
@@ -201,7 +201,7 @@ export class DefaultReporter implements Listener {
 		);
 	}
 
-	public async onExecutionFailed(error: any) {
+	public async onExecutionFailed(error: unknown) {
 		this.renderer.finish();
 		this.nadle.logger.info("Execution failed");
 
@@ -217,7 +217,7 @@ export class DefaultReporter implements Listener {
 				`\nFor more details, re-run the command with the ${c.yellow("--stacktrace")} option to display the full error and help identify the root cause.`
 			);
 		} else {
-			this.nadle.logger.error(error instanceof Error ? error.stack : error);
+			this.nadle.logger.error(error instanceof Error ? (error.stack ?? error.message) : String(error));
 		}
 	}
 

--- a/packages/nadle/src/core/utilities/stringify.ts
+++ b/packages/nadle/src/core/utilities/stringify.ts
@@ -1,3 +1,3 @@
-export function stringify(value: any) {
+export function stringify(value: unknown) {
 	return JSON.stringify(value, null, 2);
 }


### PR DESCRIPTION
## Summary
- Replace 3 actionable `any` type annotations with `unknown` across `reporter.ts`, `stringify.ts`, and `cli-options-resolver.ts`
- Add proper type narrowing in `onExecutionFailed` (`error.stack ?? error.message` for `Error`, `String(error)` for non-Error values)
- 2 intentional `any` usages in `utils.ts` kept as-is (idiomatic TS conditional type pattern + known TS limitation)

Closes #411

## Test plan
- [x] `npx tsc -p packages/nadle/tsconfig.build.json --noEmit` — type check passes
- [x] `npx eslint packages/nadle/src/ --quiet` — no lint errors
- [x] `pnpm -F nadle test` — all tests pass (4 pre-existing failures on main unrelated to these changes)

🤖 Generated with [Claude Code](https://claude.com/claude-code)