### PR TITLE
perf: skip redundant project resolution in worker threads

### DIFF
--- a/packages/nadle/src/core/engine/worker.ts
+++ b/packages/nadle/src/core/engine/worker.ts
@@ -30,7 +30,7 @@ let workerNadle: Nadle | null = null;
 
 async function getOrCreateNadle(options: NadleResolvedOptions): Promise<Nadle> {
 	if (!workerNadle) {
-		workerNadle = await new Nadle({ ...options, tasks: [], excludedTasks: [] }).init();
+		workerNadle = await new Nadle({ ...options, tasks: [], excludedTasks: [] }).initForWorker(options);
 	}
 
 	return workerNadle;

--- a/packages/nadle/src/core/nadle.ts
+++ b/packages/nadle/src/core/nadle.ts
@@ -10,8 +10,10 @@ import { TaskRegistry } from "./registration/task-registry.js";
 import { OptionsResolver } from "./options/options-resolver.js";
 import { type State, type ExecutionContext } from "./context.js";
 import { ExecutionTracker } from "./models/execution-tracker.js";
+import { RootWorkspace } from "./models/project/root-workspace.js";
 import { DefaultLogger } from "./interfaces/defaults/default-logger.js";
 import { FileOptionRegistry } from "./registration/file-option-registry.js";
+import { DefaultFileReader } from "./interfaces/defaults/default-file-reader.js";
 import { type NadleCLIOptions, type NadleResolvedOptions } from "./options/types.js";
 
 export class Nadle implements ExecutionContext {
@@ -37,6 +39,34 @@ export class Nadle implements ExecutionContext {
 		await this.eventEmitter.onInitialize();
 
 		return this;
+	}
+
+	public async initForWorker(resolvedOptions: NadleResolvedOptions): Promise<this> {
+		this.#options = resolvedOptions;
+		this.logger.configure(resolvedOptions);
+		this.logger.debug("Worker init: loading config files (skipping project resolution)");
+
+		await runWithInstance(this, () => this.loadConfigFiles(resolvedOptions));
+		this.taskRegistry.configure(resolvedOptions.project);
+
+		return this;
+	}
+
+	private async loadConfigFiles(resolvedOptions: NadleResolvedOptions) {
+		const { project } = resolvedOptions;
+		const fileReader = new DefaultFileReader();
+
+		this.taskRegistry.onConfigureWorkspace(RootWorkspace.ID);
+		this.fileOptionRegistry.onConfigureWorkspace(RootWorkspace.ID);
+		await fileReader.read(project.rootWorkspace.configFilePath);
+
+		for (const workspace of project.workspaces) {
+			if (workspace.configFilePath) {
+				this.taskRegistry.onConfigureWorkspace(workspace.id);
+				this.fileOptionRegistry.onConfigureWorkspace(workspace.id);
+				await fileReader.read(workspace.configFilePath);
+			}
+		}
 	}
 
 	public async execute() {

--- a/spec/04-execution.md
+++ b/spec/04-execution.md
@@ -47,9 +47,12 @@ There is **no explicit "done" message**. Completion is inferred:
 
 ## Worker Execution Flow
 
-1. Initialize Nadle in the worker thread on the first task dispatch. The instance is
-   cached at module scope and reused for subsequent dispatches within the same thread,
-   so config files are loaded at most once per worker thread lifetime.
+1. Initialize Nadle in the worker thread on the first task dispatch using a lightweight
+   path: the worker receives the fully resolved options (including the project structure)
+   from the main thread, loads config files to populate task function closures and the
+   task registry, but skips project resolution, option merging, and task input resolution.
+   The instance is cached at module scope and reused for subsequent dispatches within
+   the same thread, so config files are loaded at most once per worker thread lifetime.
 2. Look up the task by ID in the registry.
 3. Resolve the task's configuration and options.
 4. Resolve the working directory (relative to project root).

--- a/spec/CHANGELOG.md
+++ b/spec/CHANGELOG.md
@@ -8,6 +8,14 @@ Versioning follows [Semantic Versioning](https://semver.org/):
 - **MINOR**: New concept, new section, or materially expanded rules
 - **PATCH**: Clarifications, corrections, wording improvements
 
+## 1.2.0 — 2026-02-18
+
+### Changed
+
+- 04-execution: Worker threads now use a lightweight initialization path that reuses
+  resolved options from the main thread and only loads config files, skipping project
+  resolution, option merging, and task input resolution.
+
 ## 1.1.0 — 2026-02-18
 
 ### Changed

--- a/spec/README.md
+++ b/spec/README.md
@@ -1,6 +1,6 @@
 # Nadle Specification
 
-**Version**: 1.1.0
+**Version**: 1.2.0
 
 This directory contains the language-agnostic specification for Nadle, a type-safe,
 Gradle-inspired task runner for Node.js.

--- a/specs/003-skip-worker-reinit/checklists/requirements.md
+++ b/specs/003-skip-worker-reinit/checklists/requirements.md
@@ -1,0 +1,36 @@
+# Specification Quality Checklist: Skip Redundant Worker Re-Initialization
+
+**Purpose**: Validate specification completeness and quality before proceeding to planning
+**Created**: 2026-02-18
+**Feature**: [spec.md](../spec.md)
+
+## Content Quality
+
+- [x] No implementation details (languages, frameworks, APIs)
+- [x] Focused on user value and business needs
+- [x] Written for non-technical stakeholders
+- [x] All mandatory sections completed
+
+## Requirement Completeness
+
+- [x] No [NEEDS CLARIFICATION] markers remain
+- [x] Requirements are testable and unambiguous
+- [x] Success criteria are measurable
+- [x] Success criteria are technology-agnostic (no implementation details)
+- [x] All acceptance scenarios are defined
+- [x] Edge cases are identified
+- [x] Scope is clearly bounded
+- [x] Dependencies and assumptions identified
+
+## Feature Readiness
+
+- [x] All functional requirements have clear acceptance criteria
+- [x] User scenarios cover primary flows
+- [x] Feature meets measurable outcomes defined in Success Criteria
+- [x] No implementation details leak into specification
+
+## Notes
+
+- All items pass validation. Spec is ready for `/speckit.clarify` or `/speckit.plan`.
+- This is a purely internal optimization — no user-facing API or behavior changes.
+- The Documentation Impact section was intentionally omitted since there are no user-facing changes.

--- a/specs/003-skip-worker-reinit/plan.md
+++ b/specs/003-skip-worker-reinit/plan.md
@@ -1,0 +1,119 @@
+# Implementation Plan: Skip Redundant Worker Re-Initialization
+
+**Branch**: `003-skip-worker-reinit` | **Date**: 2026-02-18 | **Spec**: [spec.md](spec.md)
+**Input**: Feature specification from `/specs/003-skip-worker-reinit/spec.md`
+
+## Summary
+
+Worker threads currently run the full `OptionsResolver.resolve()` pipeline on first dispatch,
+which includes filesystem walks for workspace discovery, monorepo tool detection, option
+merging, worker count resolution, and task input resolution — all of which the main thread
+already completed. This plan introduces a lightweight `initForWorker(resolvedOptions)` method
+on the `Nadle` class that bypasses redundant work and only loads config files (for task
+function closures) using the already-resolved project structure from the main thread.
+
+## Technical Context
+
+**Language/Version**: TypeScript, ESM, targeting Node 22+
+**Primary Dependencies**: tinypool (worker threads), jiti (config file loading), AsyncLocalStorage (instance binding)
+**Storage**: N/A (filesystem cache unchanged)
+**Testing**: vitest, integration-first (CLI via execa), 326+ tests
+**Target Platform**: Linux, macOS, Windows (cross-platform)
+**Project Type**: Monorepo (pnpm workspaces)
+**Performance Goals**: Eliminate redundant filesystem walks and option resolution per worker thread
+**Constraints**: <200 lines/file, <50 lines/function, <10 complexity, <3 params, 140 KB bundle limit
+**Scale/Scope**: 2 source files modified, 1 spec file updated
+
+## Constitution Check
+
+*GATE: Must pass before Phase 0 research. Re-check after Phase 1 design.*
+
+| Principle | Status | Notes |
+|-----------|--------|-------|
+| I. Code Over Configuration | PASS | No configuration changes; all logic remains in TypeScript |
+| II. Type Safety First | PASS | New method is fully typed; no public API changes |
+| III. Lightweight and Focused | PASS | No new dependencies; reduces work done at runtime |
+| IV. Integration-First Testing | PASS | Validated by existing 326+ integration tests |
+| V. Self-Hosting (Dogfooding) | PASS | Nadle builds itself; change is transparent |
+| VI. Modern ESM and Strict Conventions | PASS | ESM only, PascalCase node imports, no process.cwd() |
+| VII. Cross-Platform Correctness | PASS | No platform-specific code; paths from resolved options |
+
+All gates pass. No violations to justify.
+
+## Project Structure
+
+### Documentation (this feature)
+
+```text
+specs/003-skip-worker-reinit/
+├── plan.md              # This file
+├── research.md          # Phase 0 output
+├── spec.md              # Feature specification
+└── tasks.md             # Phase 2 output (via /speckit.tasks)
+```
+
+### Source Code (files to modify)
+
+```text
+packages/nadle/src/core/
+├── nadle.ts                        # Add initForWorker() method
+└── engine/
+    └── worker.ts                   # Update getOrCreateNadle() to use initForWorker()
+
+spec/
+├── 04-execution.md                 # Update worker execution flow description
+└── CHANGELOG.md                    # Add entry for this change
+```
+
+**Structure Decision**: No new files or directories. This is a surgical modification to
+two existing source files plus a spec update.
+
+## Architecture: Current vs Optimized Init Path
+
+### Current Worker Init (per first dispatch per thread)
+
+```
+getOrCreateNadle(options)
+  └── new Nadle(cliOptions).init()
+        └── OptionsResolver.resolve(cliOptions)
+              ├── logger.configure()
+              ├── ProjectResolver.resolve()          ← REDUNDANT
+              │     ├── initProject()                 ← filesystem walks, monorepo detection
+              │     ├── initializeRootWorkspace()     ← find config file + load via jiti
+              │     ├── initializeSubWorkspaces()     ← loop workspaces + load configs
+              │     └── resolveCurrentWorkspaceId()   ← not needed in worker
+              ├── taskRegistry.configure(project)
+              ├── resolveWorkers()                    ← REDUNDANT (already resolved)
+              └── resolveTasks()                      ← REDUNDANT (worker uses task IDs)
+```
+
+### Optimized Worker Init (per first dispatch per thread)
+
+```
+getOrCreateNadle(options)
+  └── new Nadle(cliOptions).initForWorker(resolvedOptions)
+        ├── this.#options = resolvedOptions           ← direct assignment
+        ├── logger.configure(resolvedOptions)
+        └── runWithInstance(this, async () => {
+              ├── onConfigureWorkspace(rootId)
+              ├── fileReader.read(rootConfigFile)     ← load config (task closures)
+              ├── for each workspace with config:
+              │     ├── onConfigureWorkspace(wsId)
+              │     └── fileReader.read(wsConfigFile)
+              └── taskRegistry.configure(project)     ← flush buffer to registry
+            })
+```
+
+**What is eliminated**:
+- `ProjectResolver.initProject()` — filesystem walks, `findUp`, `@manypkg/find-root`, monorepo tool detection
+- `ProjectResolver.resolveCurrentWorkspaceId()` — cwd-to-workspace mapping (irrelevant in worker)
+- `OptionsResolver.resolveWorkers()` — re-resolving min/max worker counts
+- `OptionsResolver.resolveTasks()` — re-resolving task inputs from CLI args
+- `FileOptionRegistry` usage — option merging is skipped entirely
+- Config file path searching — paths are already known from resolved project
+
+**What is preserved**:
+- Config file loading via jiti — task functions are closures that must be loaded per thread
+- `runWithInstance()` / AsyncLocalStorage — routes `tasks.register()` to the correct instance
+- `taskRegistry.configure(project)` — flushes buffered tasks to final registry with labels
+- Per-thread Nadle caching — `getOrCreateNadle` still checks `workerNadle` before init

--- a/specs/003-skip-worker-reinit/quickstart.md
+++ b/specs/003-skip-worker-reinit/quickstart.md
@@ -1,0 +1,46 @@
+# Quickstart: Verifying Worker Init Optimization
+
+## Prerequisite
+
+Build the project after the change:
+
+```bash
+pnpm -F nadle build:tsup
+```
+
+## Verify: All Tests Pass (SC-001)
+
+```bash
+pnpm -F nadle test
+```
+
+Expected: All 326+ tests pass without modification.
+
+## Verify: Type Check Clean
+
+```bash
+npx tsc -p packages/nadle/tsconfig.build.json --noEmit
+```
+
+Expected: No type errors.
+
+## Verify: Debug Logging Shows Optimized Path (US3)
+
+Run the sample-app with debug logging:
+
+```bash
+cd packages/sample-app
+npx nadle build --parallel --log-level debug
+```
+
+Look for log output indicating config file loading without project resolution messages.
+Workers should log config file loading but NOT project discovery/monorepo detection.
+
+## Verify: Bundle Size Within Limit (SC-004)
+
+```bash
+cd packages/nadle
+npx size-limit
+```
+
+Expected: Bundle size remains under 140 KB.

--- a/specs/003-skip-worker-reinit/research.md
+++ b/specs/003-skip-worker-reinit/research.md
@@ -1,0 +1,59 @@
+# Research: Skip Redundant Worker Re-Initialization
+
+## Decision 1: Lightweight Init Method vs Bypassing Nadle Class
+
+**Decision**: Add `Nadle.initForWorker(resolvedOptions)` method on the existing class.
+
+**Rationale**: The worker already uses the `Nadle` interface throughout (`nadle.taskRegistry`,
+`nadle.logger`, `nadle.options`). Introducing a separate lightweight worker context would
+require changing all call sites in worker.ts and diverging the interface. A new method on the
+existing class preserves the interface and keeps the change minimal.
+
+**Alternatives considered**:
+- **Separate WorkerContext class**: Rejected because worker.ts accesses `nadle.taskRegistry`,
+  `nadle.logger`, `nadle.options` — replicating this interface creates unnecessary duplication.
+- **Factory function returning a plain object**: Rejected for the same interface reasons and
+  because `Nadle` already has the right field declarations.
+
+## Decision 2: Config File Loading Strategy
+
+**Decision**: Load config files using the workspace config file paths already available in
+`NadleResolvedOptions.project` (the resolved `Project` object).
+
+**Rationale**: The resolved `Project` contains `rootWorkspace.configFilePath` and
+`workspaces[*].configFilePath` — the exact paths that `ProjectResolver` would have discovered
+via filesystem walks. Using these directly skips all filesystem discovery while loading the
+same files in the same order.
+
+**Alternatives considered**:
+- **Serialize task registry from main thread**: Rejected because task functions are closures
+  that cannot be serialized via the structured clone algorithm. Config files must still be
+  loaded to define the function bodies.
+- **Skip config loading entirely**: Rejected for the same reason — task functions live in
+  those config files and must be imported per thread.
+
+## Decision 3: FileOptionRegistry in Workers
+
+**Decision**: The `FileOptionRegistry` in workers will be populated during config loading
+(since `configure()` calls in config files are still executed), but its contents are never
+consumed — option merging is skipped because the worker uses resolved options directly.
+
+**Rationale**: The `configure()` DSL function delegates to `getCurrentInstance().fileOptionRegistry`.
+When a config file containing `configure()` is loaded in a worker, the call still executes and
+stores options in the worker's `FileOptionRegistry`. This is harmless — the data is simply
+unused. Attempting to prevent these calls would require modifying the `configure()` function
+to detect worker context, adding unnecessary complexity.
+
+**Alternatives considered**:
+- **No-op FileOptionRegistry in workers**: Rejected because it would require a conditional
+  branch in the `configure()` function or a subclass, adding complexity for no benefit.
+
+## Decision 4: Spec Updates
+
+**Decision**: Update `spec/04-execution.md` to document that workers use a lightweight
+initialization path that reuses resolved options from the main thread and only loads config
+files. Bump spec to 1.2.0 (minor — expanded behavioral rules for worker initialization).
+
+**Rationale**: The spec currently says workers "initialize Nadle on first dispatch" but
+doesn't specify what initialization entails. The optimization changes what "initialize" means,
+so the spec should be explicit about the lightweight path.

--- a/specs/003-skip-worker-reinit/spec.md
+++ b/specs/003-skip-worker-reinit/spec.md
@@ -1,0 +1,136 @@
+# Feature Specification: Skip Redundant Worker Re-Initialization
+
+**Feature Branch**: `003-skip-worker-reinit`
+**Created**: 2026-02-18
+**Status**: Draft
+**Input**: User description: "fix #428 based on this branch"
+**Related Issue**: [#428 — Eliminate redundant Nadle re-initialization in worker threads](https://github.com/nadlejs/nadle/issues/428)
+**Builds On**: `002-instance-scoped-registries` (instance-scoped registries with per-thread Nadle caching)
+
+## Context
+
+With instance-scoped registries (branch 002), each worker thread creates and caches a Nadle
+instance on first task dispatch. That instance is reused for subsequent dispatches within the
+same thread, so config files are loaded at most once per worker thread lifetime.
+
+However, the first initialization per worker still performs the full option resolution
+pipeline: filesystem walks for workspace discovery, option merging, worker count resolution,
+and task input resolution. All of this work was already completed by the main thread and is
+redundant — the worker only needs to load config files (to populate task function closures)
+and populate the task registry.
+
+## User Scenarios & Testing
+
+### User Story 1 — Faster Worker Startup (Priority: P1)
+
+As a developer using parallel task execution, I want worker threads to start executing tasks
+faster by skipping redundant initialization work that the main thread already completed.
+
+**Why this priority**: This is the core value proposition. Every parallel task execution pays
+the cost of redundant project resolution and option merging in each worker thread. For projects
+with many workspaces, the filesystem walk overhead is especially significant.
+
+**Independent Test**: Run a project with parallel tasks. Compare per-worker startup time before
+and after the change. Workers should reach task execution faster.
+
+**Acceptance Scenarios**:
+
+1. **Given** a project with parallel tasks, **When** tasks are dispatched to worker threads,
+   **Then** workers do not re-resolve the project structure (no redundant filesystem walks).
+2. **Given** fully resolved options from the main thread, **When** a worker initializes,
+   **Then** the worker reuses those resolved options without re-merging defaults, file options,
+   and CLI flags.
+3. **Given** a multi-workspace project, **When** a worker thread starts, **Then** config files
+   are still loaded (to populate task function closures and the task registry), but workspace
+   discovery and dependency resolution are skipped.
+
+---
+
+### User Story 2 — Behavioral Parity (Priority: P1)
+
+As a developer, I expect the optimization to be transparent — all tasks must produce the same
+results regardless of whether they run in the main thread's Nadle instance or a worker's
+lightweight instance.
+
+**Why this priority**: Correctness is non-negotiable. This is a performance optimization that
+must not change observable behavior.
+
+**Independent Test**: Run the full existing test suite. All tests must pass without modification.
+
+**Acceptance Scenarios**:
+
+1. **Given** the complete existing test suite (326+ tests), **When** all tests run after the
+   change, **Then** all tests pass without modification.
+2. **Given** a task with cache validation, **When** it runs in a worker, **Then** cache
+   fingerprinting and validation produce identical results to the previous implementation.
+3. **Given** a task with custom environment variables, **When** it runs in a worker, **Then**
+   environment injection and restoration behave identically.
+
+---
+
+### User Story 3 — Observable Improvement (Priority: P2)
+
+As a contributor or user curious about performance, I want to verify through debug logging
+that workers are actually skipping redundant work.
+
+**Why this priority**: Observability helps validate the optimization and diagnose future issues,
+but it is not a correctness requirement.
+
+**Independent Test**: Run with `--log-level debug` and verify log output shows that workers
+skip project resolution.
+
+**Acceptance Scenarios**:
+
+1. **Given** debug logging enabled, **When** a worker initializes its Nadle instance, **Then**
+   log output confirms config files are loaded but project resolution is skipped.
+
+---
+
+### Edge Cases
+
+- What happens when the main thread's resolved options reference paths that are relative to
+  the project root? Workers must resolve these paths consistently.
+- What happens if a config file has side effects beyond task registration (e.g., modifying
+  global state)? Config files are still loaded per worker, so side effects still occur once
+  per worker thread.
+- What happens in sequential (non-parallel) mode? Sequential tasks run in the main thread,
+  so this optimization does not apply. Behavior must be unchanged.
+
+## Requirements
+
+### Functional Requirements
+
+- **FR-001**: Workers MUST reuse the fully resolved options passed from the main thread
+  instead of re-running the option resolution pipeline.
+- **FR-002**: Workers MUST skip project structure resolution (workspace discovery, dependency
+  resolution, filesystem walks) since the resolved project is already available in the
+  passed options.
+- **FR-003**: Workers MUST still load config files to populate task function closures and
+  the task registry, since function references cannot be serialized across threads.
+- **FR-004**: Workers MUST still be able to look up any task by ID, resolve its configuration,
+  and execute its function after the lightweight initialization.
+- **FR-005**: Cache validation in workers MUST produce identical results — the same config
+  files, working directory, and project directory must be used for fingerprinting.
+- **FR-006**: The per-thread Nadle caching (from branch 002) MUST be preserved — config files
+  are loaded at most once per worker thread lifetime, not on every task dispatch.
+
+## Success Criteria
+
+### Measurable Outcomes
+
+- **SC-001**: All existing tests (326+) pass without modification after the change.
+- **SC-002**: Worker first-dispatch initialization skips project resolution and option
+  merging — measurable as fewer filesystem operations per worker startup.
+- **SC-003**: No new dependencies or public API changes are introduced (the optimization
+  is purely internal).
+- **SC-004**: Bundle size remains within the existing 140 KB limit.
+
+## Assumptions
+
+- Config files must still be loaded in each worker thread because task runner functions are
+  closures defined in those config files and cannot be serialized across thread boundaries.
+- The resolved options (including the nested project structure) are already serializable via
+  the structured clone algorithm used by worker threads, since they consist of plain objects,
+  strings, numbers, and arrays.
+- The existing per-thread Nadle caching from branch 002 provides the foundation — this feature
+  narrows the scope of what happens during that one-time per-thread initialization.

--- a/specs/003-skip-worker-reinit/tasks.md
+++ b/specs/003-skip-worker-reinit/tasks.md
@@ -1,0 +1,109 @@
+# Tasks: Skip Redundant Worker Re-Initialization
+
+**Input**: Design documents from `/specs/003-skip-worker-reinit/`
+**Prerequisites**: plan.md, spec.md, research.md
+
+**Organization**: Tasks are grouped by user story. US1 and US2 share the same
+implementation (lightweight worker init); US2 is validated by running the existing test
+suite. US3 (observability) is a separate layer on top.
+
+## Format: `[ID] [P?] [Story] Description`
+
+- **[P]**: Can run in parallel (different files, no dependencies)
+- **[Story]**: Which user story this task belongs to (US1, US2, US3)
+- Include exact file paths in descriptions
+
+---
+
+## Phase 1: User Story 1+2 — Lightweight Worker Init + Behavioral Parity (Priority: P1)
+
+**Goal**: Workers skip redundant project resolution and option merging by using a new
+`initForWorker(resolvedOptions)` method that directly assigns resolved options and only
+loads config files for task function closures. All existing tests pass unchanged.
+
+**Independent Test**: Build the project (`pnpm -F nadle build:tsup`) and run all existing
+tests (`pnpm -F nadle test`). All must pass without modification (SC-001).
+
+### Implementation for User Story 1+2
+
+- [x] T001 [US1] Add `initForWorker(resolvedOptions: NadleResolvedOptions)` method to `Nadle` class in packages/nadle/src/core/nadle.ts — this method directly assigns `this.#options = resolvedOptions`, configures the logger from resolved options, then runs within `runWithInstance(this, ...)` to load config files using paths from `resolvedOptions.project` (rootWorkspace.configFilePath and workspaces[*].configFilePath). For each workspace config file, set workspace context via `taskRegistry.onConfigureWorkspace(workspaceId)` and `fileOptionRegistry.onConfigureWorkspace(workspaceId)`, then load the file via `DefaultFileReader.read()`. After all files are loaded, call `taskRegistry.configure(resolvedOptions.project)` to flush the buffer. Return `this`. (FR-001, FR-002, FR-003)
+- [x] T002 [US1] Update `getOrCreateNadle()` in packages/nadle/src/core/engine/worker.ts — change from `new Nadle({ ...options, tasks: [], excludedTasks: [] }).init()` to `new Nadle({ ...options, tasks: [], excludedTasks: [] }).initForWorker(options)`. The `Nadle` constructor still takes `NadleCLIOptions` (needed for field declarations), but `initForWorker` bypasses `OptionsResolver` entirely and uses the passed resolved options directly. (FR-001, FR-004, FR-006)
+- [x] T003 [US2] Build and verify behavioral parity — run `pnpm -F nadle build:tsup` then `pnpm -F nadle test` to confirm all existing tests pass without modification (SC-001). Also run `npx tsc -p packages/nadle/tsconfig.build.json --noEmit` for type checking.
+
+**Checkpoint**: US1+US2 complete. Workers skip redundant init. All tests pass.
+
+---
+
+## Phase 2: User Story 3 — Observable Improvement (Priority: P2)
+
+**Goal**: Debug logging confirms workers use the lightweight init path.
+
+**Independent Test**: Run a parallel project with `--log-level debug` and verify log output
+shows config loading without project resolution.
+
+### Implementation for User Story 3
+
+- [x] T004 [US3] Add a debug log statement in `initForWorker()` in packages/nadle/src/core/nadle.ts — log a message via `this.logger.debug()` indicating the worker is using the lightweight init path (e.g., "Worker init: loading config files (skipping project resolution)"). This is sufficient for verifying the optimized path is active.
+
+**Checkpoint**: US3 complete. Debug logging confirms lightweight init.
+
+---
+
+## Phase 3: Polish & Cross-Cutting Concerns
+
+**Purpose**: Update project specification and run final validation
+
+- [x] T005 [P] Update spec/04-execution.md — expand step 1 of Worker Execution Flow to describe the lightweight initialization: worker receives resolved options from the main thread, loads config files to populate task function closures and the task registry, but skips project resolution, option merging, and task input resolution.
+- [x] T006 [P] Update spec/CHANGELOG.md with an entry for this change, and bump spec/README.md version to 1.2.0 (minor — expanded worker initialization rules)
+- [x] T007 Final validation — run `npx tsc -p packages/nadle/tsconfig.build.json --noEmit` for type checking, `pnpm -F nadle build:tsup` for build, `pnpm -F nadle test` for all tests. Verify ESLint clean. Verify bundle size within 140 KB limit (SC-004).
+
+---
+
+## Dependencies & Execution Order
+
+### Phase Dependencies
+
+- **US1+US2 (Phase 1)**: No dependencies — can start immediately
+- **US3 (Phase 2)**: Depends on Phase 1 (adds logging to the method created in T001)
+- **Polish (Phase 3)**: Depends on Phase 2 completion
+
+### Task Dependencies
+
+```
+T001 ──→ T002 ──→ T003 ──→ T004 ──→ T005 ──┐
+                                    T006 ──┼──→ T007
+                                           ┘
+```
+
+### Parallel Opportunities
+
+Within Phase 3:
+- T005 and T006 can run in parallel (different files)
+
+---
+
+## Implementation Strategy
+
+### MVP First (US1+US2 Only)
+
+1. Complete Phase 1: US1+US2 (T001-T003)
+2. **STOP and VALIDATE**: Build + test, verify all 326+ tests pass
+3. This is a viable stopping point — core optimization is delivered
+
+### Full Delivery
+
+1. Complete MVP above
+2. Add Phase 2: US3 (T004) — debug logging
+3. Complete Phase 3: Polish (T005-T007) — spec updates, final validation
+4. Feature complete
+
+---
+
+## Notes
+
+- [P] tasks = different files, no dependencies
+- [Story] label maps task to specific user story for traceability
+- All existing test fixture config files should work without modification since the
+  `tasks` and `configure` export signatures are unchanged
+- The `index.api.md` should not change — `initForWorker` is not exported in the public API
+- Commit after each phase checkpoint for easy rollback


### PR DESCRIPTION
## Summary

- Workers now use `Nadle.initForWorker(resolvedOptions)` which directly assigns resolved options from the main thread and only loads config files for task function closures
- Skips project resolution (filesystem walks, monorepo detection), option merging, worker count resolution, and task input resolution — all redundant since the main thread already completed them
- Per-thread Nadle caching from #435 is preserved; this narrows what happens during that one-time init

Closes #428

## Key changes

- `packages/nadle/src/core/nadle.ts` — added `initForWorker()` and `loadConfigFiles()` methods
- `packages/nadle/src/core/engine/worker.ts` — one-line change: `.init()` → `.initForWorker(options)`
- `spec/04-execution.md` — updated worker execution flow description
- Spec bumped to v1.2.0

## Test plan

- [x] Type check clean (`tsc --noEmit`)
- [x] ESLint clean on modified files
- [x] All 326 existing tests pass without modification
- [x] Build succeeds (`tsup`)
- [ ] Debug logging shows "Worker init: loading config files (skipping project resolution)"

🤖 Generated with [Claude Code](https://claude.com/claude-code)