### PR TITLE
test: isolate fixture-mutating tests with hashed temp copies

### DIFF
--- a/packages/nadle/test/features/caching/basic.test.ts
+++ b/packages/nadle/test/features/caching/basic.test.ts
@@ -1,74 +1,105 @@
-import Path from "node:path";
-import Fs from "node:fs/promises";
-
 import { isWindows } from "std-env";
-import { it, expect, describe, afterEach, beforeEach } from "vitest";
-import { getStdout, createExec, fixturesDir, createFileModifier } from "setup";
+import { it, expect, describe } from "vitest";
+import { getStdout, withFixture, createFileModifier } from "setup";
 
-describe.skipIf(isWindows)("basic caching", () => {
-	const cwd = Path.join(fixturesDir, "caching");
-	const exec = createExec({ cwd });
-	const fileModifier = createFileModifier(Path.join(cwd));
+describe.concurrent.skipIf(isWindows)("basic caching", () => {
+	it("should execute in the first run", () =>
+		withFixture({
+			copyAll: true,
+			fixtureDir: "caching",
+			testFn: async ({ exec }) => {
+				await expect(getStdout(exec`bundle-resources`)).resolves.toSettle("bundle-resources", "done");
+			}
+		}));
 
-	beforeEach(async () => {
-		await Fs.rm(Path.join(cwd, "dist"), { force: true, recursive: true });
-		await Fs.rm(Path.join(cwd, ".nadle"), { force: true, recursive: true });
-	});
+	it("should be up-to-date in the second run if inputs do not change", () =>
+		withFixture({
+			copyAll: true,
+			fixtureDir: "caching",
+			testFn: async ({ exec }) => {
+				await exec`bundle-resources`;
 
-	afterEach(async () => {
-		await Fs.rm(Path.join(cwd, "dist"), { force: true, recursive: true });
-		await Fs.rm(Path.join(cwd, ".nadle"), { force: true, recursive: true });
-		await fileModifier.restore();
-	});
+				await expect(getStdout(exec`bundle-resources`)).resolves.toSettle("bundle-resources", "up-to-date");
+			}
+		}));
 
-	it("should execute in the first run", async () => {
-		await expect(getStdout(exec`bundle-resources`)).resolves.toSettle("bundle-resources", "done");
-	});
+	it("should re-execute in the second run if inputs change", () =>
+		withFixture({
+			copyAll: true,
+			fixtureDir: "caching",
+			testFn: async ({ cwd, exec }) => {
+				const fileModifier = createFileModifier(cwd);
 
-	it("should be up-to-date in the second run if inputs do not change", async () => {
-		await exec`bundle-resources`;
+				await exec`bundle-resources`;
+				await fileModifier.apply([{ type: "modify", newContent: "new content", path: "resources/main-input.txt" }]);
 
-		await expect(getStdout(exec`bundle-resources`)).resolves.toSettle("bundle-resources", "up-to-date");
-	});
+				await expect(getStdout(exec`bundle-resources`)).resolves.toSettle("bundle-resources", "done");
+			}
+		}));
 
-	it("should re-execute in the second run if inputs change", async () => {
-		await exec`bundle-resources`;
-		await fileModifier.apply([{ type: "modify", newContent: "new content", path: "resources/main-input.txt" }]);
+	it("should re-execute in the second run if a input file is deleted", () =>
+		withFixture({
+			copyAll: true,
+			fixtureDir: "caching",
+			testFn: async ({ cwd, exec }) => {
+				const fileModifier = createFileModifier(cwd);
 
-		await expect(getStdout(exec`bundle-resources`)).resolves.toSettle("bundle-resources", "done");
-	});
+				await exec`bundle-resources`;
+				await fileModifier.apply([{ type: "delete", path: "resources/main-input.txt" }]);
 
-	it("should re-execute in the second run if a input file is deleted", async () => {
-		await exec`bundle-resources`;
-		await fileModifier.apply([{ type: "delete", path: "resources/main-input.txt" }]);
+				await expect(getStdout(exec`bundle-resources`)).resolves.toSettle("bundle-resources", "done");
+			}
+		}));
 
-		await expect(getStdout(exec`bundle-resources`)).resolves.toSettle("bundle-resources", "done");
-	});
+	it("should re-execute in the second run if a new file is added", () =>
+		withFixture({
+			copyAll: true,
+			fixtureDir: "caching",
+			testFn: async ({ cwd, exec }) => {
+				const fileModifier = createFileModifier(cwd);
 
-	it("should re-execute in the second run if a new file is added", async () => {
-		await exec`bundle-resources`;
-		await fileModifier.apply([{ type: "add", content: "new file added", path: "resources/main-input-2.txt" }]);
+				await exec`bundle-resources`;
+				await fileModifier.apply([{ type: "add", content: "new file added", path: "resources/main-input-2.txt" }]);
 
-		await expect(getStdout(exec`bundle-resources`)).resolves.toSettle("bundle-resources", "done");
-	});
+				await expect(getStdout(exec`bundle-resources`)).resolves.toSettle("bundle-resources", "done");
+			}
+		}));
 
-	it("should restore from cache in the third run if a file is added before and deleted after the second run", async () => {
-		await exec`bundle-resources`;
+	it("should restore from cache in the third run if a file is added before and deleted after the second run", () =>
+		withFixture({
+			copyAll: true,
+			fixtureDir: "caching",
+			testFn: async ({ cwd, exec }) => {
+				const fileModifier = createFileModifier(cwd);
 
-		await fileModifier.apply([{ type: "add", content: "new file added", path: "resources/main-input-3.txt" }]);
-		await exec`bundle-resources`;
-		await fileModifier.apply([{ type: "delete", path: "resources/main-input-3.txt" }]);
+				await exec`bundle-resources`;
 
-		await expect(getStdout(exec`bundle-resources`)).resolves.toSettle("bundle-resources", "from-cache");
-	});
+				await fileModifier.apply([{ type: "add", content: "new file added", path: "resources/main-input-3.txt" }]);
+				await exec`bundle-resources`;
+				await fileModifier.apply([{ type: "delete", path: "resources/main-input-3.txt" }]);
 
-	it("should miss cache when config file changes", async () => {
-		await exec`bundle-resources`;
+				await expect(getStdout(exec`bundle-resources`)).resolves.toSettle("bundle-resources", "from-cache");
+			}
+		}));
 
-		await fileModifier.apply([
-			{ type: "modify", path: "nadle.config.ts", newContent: (currentContent) => `${currentContent}\ntasks.register("build");` }
-		]);
+	it("should miss cache when config file changes", () =>
+		withFixture({
+			copyAll: true,
+			fixtureDir: "caching",
+			testFn: async ({ cwd, exec }) => {
+				const fileModifier = createFileModifier(cwd);
 
-		await expect(getStdout(exec`bundle-resources`)).resolves.toSettle("bundle-resources", "done");
-	});
+				await exec`bundle-resources`;
+
+				await fileModifier.apply([
+					{
+						type: "modify",
+						path: "nadle.config.ts",
+						newContent: (currentContent) => `${currentContent}\ntasks.register("build");`
+					}
+				]);
+
+				await expect(getStdout(exec`bundle-resources`)).resolves.toSettle("bundle-resources", "done");
+			}
+		}));
 });

--- a/packages/nadle/test/features/caching/input.test.ts
+++ b/packages/nadle/test/features/caching/input.test.ts
@@ -1,30 +1,19 @@
-import Path from "node:path";
-import Fs from "node:fs/promises";
-
 import { isWindows } from "std-env";
-import { it, expect, describe, afterEach, beforeEach } from "vitest";
-import { getStdout, createExec, fixturesDir, createFileModifier } from "setup";
+import { it, expect, describe } from "vitest";
+import { getStdout, withFixture, createFileModifier } from "setup";
 
 describe.skipIf(isWindows)("caching-input", () => {
-	const cwd = Path.join(fixturesDir, "caching-input");
-	const exec = createExec({ cwd });
-	const fileModifier = createFileModifier(Path.join(cwd, "resources"));
+	it("should allow to specify inputs with braces", () =>
+		withFixture({
+			copyAll: true,
+			fixtureDir: "caching-input",
+			testFn: async ({ cwd, exec }) => {
+				const fileModifier = createFileModifier(cwd);
 
-	beforeEach(async () => {
-		await Fs.rm(Path.join(cwd, "dist"), { force: true, recursive: true });
-		await Fs.rm(Path.join(cwd, ".nadle"), { force: true, recursive: true });
-	});
+				await exec`bundle-resources --stacktrace`;
+				await fileModifier.apply([{ type: "modify", newContent: "new content", path: "resources/a-input.txt" }]);
 
-	afterEach(async () => {
-		await Fs.rm(Path.join(cwd, "dist"), { force: true, recursive: true });
-		await Fs.rm(Path.join(cwd, ".nadle"), { force: true, recursive: true });
-		await fileModifier.restore();
-	});
-
-	it("should allow to specify inputs with braces", async () => {
-		await exec`bundle-resources --stacktrace`;
-		await fileModifier.apply([{ type: "modify", path: "a-input.txt", newContent: "new content" }]);
-
-		await expect(getStdout(exec`bundle-resources`)).resolves.toSettle("bundle-resources", "up-to-date");
-	});
+				await expect(getStdout(exec`bundle-resources`)).resolves.toSettle("bundle-resources", "up-to-date");
+			}
+		}));
 });

--- a/packages/nadle/test/options/cache-dir.test.ts
+++ b/packages/nadle/test/options/cache-dir.test.ts
@@ -1,13 +1,10 @@
 import Path from "node:path";
-import Fs from "node:fs/promises";
 
-import fg from "fast-glob";
-import { createExec, fixturesDir } from "setup";
-import { it, expect, describe, afterEach } from "vitest";
+import { withFixture } from "setup";
+import { it, expect, describe } from "vitest";
 
 import { isPathExists } from "../../src/core/utilities/fs.js";
 
-const baseDir = Path.join(fixturesDir, "cache-dir");
 const DEFAULT_CACHE_DIR = ".nadle";
 const VIA_FILE_CACHE_DIR = ".nadle-custom-by-file";
 const VIA_CLI_CACHE_DIR = ".nadle-custom-by-cli";
@@ -15,37 +12,34 @@ const VIA_CLI_CACHE_DIR = ".nadle-custom-by-cli";
 const cacheDirNames = [DEFAULT_CACHE_DIR, VIA_FILE_CACHE_DIR, VIA_CLI_CACHE_DIR];
 
 const testCases = [
-	{ withCLI: true, fixtureDir: "with-config", expectedCacheDir: VIA_CLI_CACHE_DIR },
-	{ withCLI: true, fixtureDir: "without-config", expectedCacheDir: VIA_CLI_CACHE_DIR },
-	{ withCLI: false, fixtureDir: "with-config", expectedCacheDir: VIA_FILE_CACHE_DIR },
-	{ withCLI: false, fixtureDir: "without-config", expectedCacheDir: DEFAULT_CACHE_DIR }
+	{ withCLI: true, fixtureDir: "cache-dir/with-config", expectedCacheDir: VIA_CLI_CACHE_DIR },
+	{ withCLI: true, expectedCacheDir: VIA_CLI_CACHE_DIR, fixtureDir: "cache-dir/without-config" },
+	{ withCLI: false, fixtureDir: "cache-dir/with-config", expectedCacheDir: VIA_FILE_CACHE_DIR },
+	{ withCLI: false, expectedCacheDir: DEFAULT_CACHE_DIR, fixtureDir: "cache-dir/without-config" }
 ];
 
-describe("--cache-dir", () => {
-	afterEach(async () => {
-		for (const dir of await fg(`./*/{dist,${cacheDirNames.join(",")}}`, { cwd: baseDir, absolute: true, onlyDirectories: true })) {
-			await Fs.rm(dir, { force: true, recursive: true });
-		}
-	});
-
+describe.concurrent("--cache-dir", () => {
 	describe.each(testCases)("given $fixtureDir fixture, when run build with --cache-dir = $withCLI", ({ withCLI, fixtureDir, expectedCacheDir }) => {
-		it(`should create the ${expectedCacheDir} cache directory`, async () => {
-			const cwd = Path.join(fixturesDir, "cache-dir", fixtureDir);
+		it(`should create the ${expectedCacheDir} cache directory`, () =>
+			withFixture({
+				fixtureDir,
+				copyAll: true,
+				testFn: async ({ cwd, exec }) => {
+					for (const cacheDirName of cacheDirNames) {
+						await expect(isPathExists(Path.join(cwd, cacheDirName))).resolves.toBe(false);
+					}
 
-			for (const cacheDirName of cacheDirNames) {
-				await expect(isPathExists(Path.join(cwd, cacheDirName))).resolves.toBe(false);
-			}
+					await exec`build ${withCLI ? "--cache-dir " + VIA_CLI_CACHE_DIR : ""}`;
 
-			await createExec({ cwd })`build ${withCLI ? "--cache-dir " + VIA_CLI_CACHE_DIR : ""}`;
+					await expect(isPathExists(Path.join(cwd, expectedCacheDir))).resolves.toBe(true);
 
-			await expect(isPathExists(Path.join(cwd, expectedCacheDir))).resolves.toBe(true);
-
-			for (const cacheDirName of cacheDirNames) {
-				if (cacheDirName !== expectedCacheDir) {
-					// eslint-disable-next-line vitest/no-conditional-expect
-					await expect(isPathExists(Path.join(cwd, cacheDirName))).resolves.toBe(false);
+					for (const cacheDirName of cacheDirNames) {
+						if (cacheDirName !== expectedCacheDir) {
+							// eslint-disable-next-line vitest/no-conditional-expect
+							await expect(isPathExists(Path.join(cwd, cacheDirName))).resolves.toBe(false);
+						}
+					}
 				}
-			}
-		});
+			}));
 	});
 });

--- a/packages/nadle/test/options/clean-cache.test.ts
+++ b/packages/nadle/test/options/clean-cache.test.ts
@@ -1,55 +1,51 @@
 import Path from "node:path";
-import Fs from "node:fs/promises";
 
-import fg from "fast-glob";
-import { createExec, fixturesDir } from "setup";
-import { it, expect, describe, afterEach } from "vitest";
+import { it, expect, describe } from "vitest";
+import { createExec, withFixture } from "setup";
 
 import { isPathExists } from "../../src/core/utilities/fs.js";
 
-const cwd = Path.join(fixturesDir, "clean-cache");
 const DEFAULT_CACHE_DIR = ".nadle";
 const CUSTOM_CACHE_DIR = ".nadle-custom";
 
 const cacheDirNames = [DEFAULT_CACHE_DIR, CUSTOM_CACHE_DIR];
 
-describe("--clean-cache", () => {
-	afterEach(async () => {
-		for (const dir of await fg(`./*/{.nadle,.nadle-custom}`, { cwd: cwd, absolute: true, onlyDirectories: true })) {
-			await Fs.rm(dir, { force: true, recursive: true });
-		}
-	});
-	const exec = createExec({ cwd });
+describe.concurrent("--clean-cache", () => {
+	it("should remove the default cache directory", () =>
+		withFixture({
+			copyAll: true,
+			fixtureDir: "clean-cache",
+			testFn: async ({ cwd, exec }) => {
+				for (const cacheDirName of cacheDirNames) {
+					await expect(isPathExists(Path.join(cwd, cacheDirName))).resolves.toBe(false);
+				}
 
-	describe("given the default cache directory", () => {
-		it("should remove the cache directory", async () => {
-			for (const cacheDirName of cacheDirNames) {
-				await expect(isPathExists(Path.join(cwd, cacheDirName))).resolves.toBe(false);
+				await exec`build`;
+
+				await expect(isPathExists(Path.join(cwd, DEFAULT_CACHE_DIR))).resolves.toBe(true);
+
+				await createExec({ cwd })`--clean-cache`;
+
+				await expect(isPathExists(Path.join(cwd, DEFAULT_CACHE_DIR))).resolves.toBe(false);
 			}
+		}));
 
-			await exec`build`;
+	it("should remove the custom cache directory", () =>
+		withFixture({
+			copyAll: true,
+			fixtureDir: "clean-cache",
+			testFn: async ({ cwd, exec }) => {
+				for (const cacheDirName of cacheDirNames) {
+					await expect(isPathExists(Path.join(cwd, cacheDirName))).resolves.toBe(false);
+				}
 
-			await expect(isPathExists(Path.join(cwd, DEFAULT_CACHE_DIR))).resolves.toBe(true);
+				await exec`build --cache-dir ${CUSTOM_CACHE_DIR}`;
 
-			await createExec({ cwd })`--clean-cache`;
+				await expect(isPathExists(Path.join(cwd, CUSTOM_CACHE_DIR))).resolves.toBe(true);
 
-			await expect(isPathExists(Path.join(cwd, DEFAULT_CACHE_DIR))).resolves.toBe(false);
-		});
-	});
+				await createExec({ cwd })`--clean-cache --cache-dir ${CUSTOM_CACHE_DIR}`;
 
-	describe("given the custom cache directory", () => {
-		it("should remove the cache directory", async () => {
-			for (const cacheDirName of cacheDirNames) {
-				await expect(isPathExists(Path.join(cwd, cacheDirName))).resolves.toBe(false);
+				await expect(isPathExists(Path.join(cwd, CUSTOM_CACHE_DIR))).resolves.toBe(false);
 			}
-
-			await exec`build --cache-dir ${CUSTOM_CACHE_DIR}`;
-
-			await expect(isPathExists(Path.join(cwd, CUSTOM_CACHE_DIR))).resolves.toBe(true);
-
-			await createExec({ cwd })`--clean-cache --cache-dir ${CUSTOM_CACHE_DIR}`;
-
-			await expect(isPathExists(Path.join(cwd, CUSTOM_CACHE_DIR))).resolves.toBe(false);
-		});
-	});
+		}));
 });


### PR DESCRIPTION
## Summary
- Add `copyAll` option to `withFixture` helper that copies the entire fixture directory into an isolated hashed temp directory, preventing parallel test interference
- Refactor 6 test files (`cache-dir`, `clean-cache`, `no-cache`, `basic caching`, `env caching`, `input caching`) to use `withFixture({ copyAll: true })` instead of directly mutating shared fixtures
- Enable `describe.concurrent` in all refactored test files for safe parallel execution

## Test plan
- [x] All 21 affected tests pass locally
- [x] Pre-commit hooks pass (eslint, prettier, cspell, knip)

Closes #421

🤖 Generated with [Claude Code](https://claude.com/claude-code)