### PR TITLE
fix: resolve workspace task workingDir relative to workspace

### DIFF
--- a/packages/nadle/src/core/engine/worker.ts
+++ b/packages/nadle/src/core/engine/worker.ts
@@ -40,7 +40,8 @@ export default async ({ port, taskId, options, env: originalEnv }: WorkerParams)
 	const nadle = await getOrCreateNadle(options);
 	const task = nadle.taskRegistry.getTaskById(taskId);
 	const taskConfig = task.configResolver();
-	const workingDir = Path.resolve(options.project.rootWorkspace.absolutePath, taskConfig.workingDir ?? "");
+	const workspace = Project.getWorkspaceById(options.project, task.workspaceId);
+	const workingDir = Path.resolve(workspace.absolutePath, taskConfig.workingDir ?? "");
 
 	const context: RunnerContext = {
 		workingDir,

--- a/packages/nadle/test/features/workspaces/workspaces-working-dir.test.ts
+++ b/packages/nadle/test/features/workspaces/workspaces-working-dir.test.ts
@@ -1,0 +1,60 @@
+import Path from "node:path";
+
+import { it, expect, describe } from "vitest";
+import { PACKAGE_JSON } from "src/core/utilities/constants.js";
+import { getStdout, CONFIG_FILE, withFixture, PNPM_WORKSPACE, createPackageJson, createPnpmWorkspace } from "setup";
+
+describe("workspaces > working directory", () => {
+	it("should resolve workingDir relative to the workspace, not the root", async () => {
+		await withFixture({
+			fixtureDir: "monorepo",
+			testFn: async ({ cwd, exec }) => {
+				const stdout = await getStdout(exec`packages:lib:logDir`);
+
+				expect(stdout).toContain(Path.join(cwd, "packages", "lib"));
+			},
+			files: {
+				[PNPM_WORKSPACE]: createPnpmWorkspace(),
+				[PACKAGE_JSON]: createPackageJson("root"),
+				[CONFIG_FILE]: `import { tasks } from "nadle";\ntasks.register("build", () => { console.log("Build root"); });\n`,
+
+				packages: {
+					lib: {
+						[PACKAGE_JSON]: createPackageJson("lib"),
+						[CONFIG_FILE]: [
+							`import { tasks } from "nadle";`,
+							`tasks.register("logDir", ({ context }) => { console.log(context.workingDir); });`
+						].join("\n")
+					}
+				}
+			}
+		});
+	});
+
+	it("should resolve explicit workingDir relative to the workspace", async () => {
+		await withFixture({
+			fixtureDir: "monorepo",
+			testFn: async ({ cwd, exec }) => {
+				const stdout = await getStdout(exec`packages:lib:logDir`);
+
+				expect(stdout).toContain(Path.join(cwd, "packages", "lib", "src"));
+			},
+			files: {
+				[PNPM_WORKSPACE]: createPnpmWorkspace(),
+				[PACKAGE_JSON]: createPackageJson("root"),
+				[CONFIG_FILE]: `import { tasks } from "nadle";\ntasks.register("build", () => { console.log("Build root"); });\n`,
+
+				packages: {
+					lib: {
+						src: {},
+						[PACKAGE_JSON]: createPackageJson("lib"),
+						[CONFIG_FILE]: [
+							`import { tasks } from "nadle";`,
+							`tasks.register("logDir", ({ context }) => { console.log(context.workingDir); }).config({ workingDir: "src" });`
+						].join("\n")
+					}
+				}
+			}
+		});
+	});
+});


### PR DESCRIPTION
## Summary
- Fix worker to resolve task `workingDir` relative to the task's workspace directory instead of always using `rootWorkspace.absolutePath`
- Without this fix, workspace tasks without an explicit `workingDir` run from the project root, causing commands like `tsup` or `tsc` to fail when they expect to find configs in the workspace directory
- Add integration tests verifying both default and explicit `workingDir` resolution for workspace tasks

## Change
**`packages/nadle/src/core/engine/worker.ts`** — one-line fix:
```diff
- const workingDir = Path.resolve(options.project.rootWorkspace.absolutePath, taskConfig.workingDir ?? "");
+ const workspace = Project.getWorkspaceById(options.project, task.workspaceId);
+ const workingDir = Path.resolve(workspace.absolutePath, taskConfig.workingDir ?? "");
```

## Test plan
- [x] New test: workspace task default `workingDir` resolves to workspace directory
- [x] New test: workspace task explicit `workingDir` resolves relative to workspace
- [x] Both tests fail without fix, pass with fix
- [ ] Full test suite passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)