### PR TITLE
fix: use plain CSS for footer grid layout

### DIFF
--- a/packages/docs/src/css/custom.css
+++ b/packages/docs/src/css/custom.css
@@ -141,3 +141,18 @@ ol {
 	box-shadow: none;
 	color: #64748b;
 }
+
+/* ── Footer grid ── */
+/* Plain CSS to avoid Tailwind @layer !important conflicts */
+.footer-grid {
+	display: grid;
+	grid-template-columns: 1fr;
+	gap: 2.5rem;
+}
+
+@media (min-width: 768px) {
+	.footer-grid {
+		grid-template-columns: 2fr 1fr 1fr 1fr;
+		gap: 2rem;
+	}
+}

--- a/packages/docs/src/theme/Footer/index.tsx
+++ b/packages/docs/src/theme/Footer/index.tsx
@@ -59,7 +59,7 @@ const Footer: FC = () => (
 
 		<div className="max-w-6xl mx-auto px-6 pt-12 pb-8">
 			{/* Main grid */}
-			<div className="grid grid-cols-1 md:grid-cols-[2fr_1fr_1fr_1fr] gap-10 md:gap-8">
+			<div className="footer-grid">
 				{/* Brand column */}
 				<div>
 					<h3 className="text-white text-lg font-bold mb-2">Nadle</h3>


### PR DESCRIPTION
## Summary
- Replace Tailwind grid classes (`grid grid-cols-1 md:grid-cols-[2fr_1fr_1fr_1fr]`) with a plain CSS `.footer-grid` class for the footer layout
- Tailwind v4's `@layer utilities` puts both `grid-cols-1` and the `md:` responsive variant with `!important`, causing source-order conflicts where the single-column rule always wins — even on desktop
- The new `.footer-grid` class lives outside any `@layer`, so the `@media (min-width: 768px)` responsive override works correctly

## Test plan
- [ ] `pnpm -F @nadle/internal-docs build` passes
- [ ] Footer displays as 4-column grid (brand | docs | guides | resources) on desktop
- [ ] Footer stacks vertically on mobile (<768px)

🤖 Generated with [Claude Code](https://claude.com/claude-code)