### PR TITLE
fix: bundle typescript into nadle-lsp server

### DIFF
--- a/packages/nadle-lsp/tsup.config.ts
+++ b/packages/nadle-lsp/tsup.config.ts
@@ -11,7 +11,7 @@ export default defineConfig({
 		index: "src/index.ts",
 		server: "src/server.ts"
 	},
-	noExternal: ["vscode-languageserver", "vscode-languageserver-textdocument"],
+	noExternal: ["vscode-languageserver", "vscode-languageserver-textdocument", "typescript"],
 	banner: {
 		js: "import { createRequire } from 'module'; const require = createRequire(import.meta.url);"
 	}


### PR DESCRIPTION
## Summary
- Add `typescript` to `noExternal` in nadle-lsp's tsup config so it gets bundled into `server.js`
- Without this, the VS Code extension fails on startup with `ERR_MODULE_NOT_FOUND: Cannot find package 'typescript'` because the installed extension directory has no `node_modules/typescript`

## Root cause
tsup externalizes `typescript` by default since it's not in `noExternal`. The bundled `server.js` emits a bare `import ts from "typescript"` that works in the monorepo (where typescript is hoisted) but fails in the VS Code extension install directory.

## Test plan
- [ ] `pnpm -F @nadle/internal-nadle-lsp build` succeeds
- [ ] `server.js` no longer contains `from "typescript"` (it's inlined in a chunk)
- [ ] VS Code extension starts without `ERR_MODULE_NOT_FOUND`

🤖 Generated with [Claude Code](https://claude.com/claude-code)