### PR TITLE
refactor: migrate nadle configs from ExecTask to PnpxTask

### DIFF
--- a/nadle.config.ts
+++ b/nadle.config.ts
@@ -1,4 +1,4 @@
-import { tasks, ExecTask, PnpmTask, DeleteTask } from "./node_modules/nadle/lib/index.js";
+import { tasks, PnpmTask, PnpxTask, DeleteTask } from "./node_modules/nadle/lib/index.js";
 
 // --- Maintenance ---
 
@@ -10,12 +10,13 @@ tasks
 
 // --- Checking ---
 
-tasks.register("spell", ExecTask, { command: "cspell", args: ["**", "--quiet", "--gitignore"] }).config({
+tasks.register("spell", PnpxTask, { command: "cspell", args: ["**", "--quiet", "--gitignore"] }).config({
 	group: "Checking",
 	description: "Check spelling across all files"
 });
+
 tasks
-	.register("eslint", ExecTask, {
+	.register("eslint", PnpxTask, {
 		command: "eslint",
 		args: [".", "--quiet", "--cache", "--cache-location", "node_modules/.cache/eslint/"]
 	})
@@ -24,21 +25,25 @@ tasks
 		description: "Lint all files with ESLint",
 		dependsOn: ["packages:eslint-plugin:build"]
 	});
+
 tasks
-	.register("prettier", ExecTask, {
+	.register("prettier", PnpxTask, {
 		command: "prettier",
 		args: ["--check", ".", "--cache", "--cache-location", "node_modules/.cache/prettier/.prettierCache"]
 	})
 	.config({ group: "Checking", description: "Check formatting with Prettier" });
+
 tasks.register("knip", PnpmTask, { args: ["-r", "-F", "nadle", "-F", "create-nadle", "exec", "knip"] }).config({
 	group: "Checking",
 	description: "Find unused dependencies and exports"
 });
-tasks.register("validate", ExecTask, { command: "tsx", args: ["./src/index.ts"] }).config({
+
+tasks.register("validate", PnpxTask, { command: "tsx", args: "./src/index.ts" }).config({
 	group: "Checking",
 	workingDir: "./packages/validators",
 	description: "Run package validators"
 });
+
 tasks.register("check").config({
 	group: "Checking",
 	dependsOn: ["spell", "eslint", "prettier", "knip", "validate"],
@@ -47,11 +52,12 @@ tasks.register("check").config({
 
 // --- Building (nadle-specific, kept here due to workspace self-reference limitation) ---
 
-tasks.register("typecheck", ExecTask, { command: "tsc", args: ["-b", "--noEmit"] }).config({
+tasks.register("typecheck", PnpxTask, { command: "tsc", args: ["-b", "--noEmit"] }).config({
 	group: "Building",
 	dependsOn: ["packages:nadle:build"],
 	description: "Type-check all project references"
 });
+
 tasks.register("build").config({
 	group: "Building",
 	description: "Build all packages"
@@ -67,14 +73,16 @@ tasks.register("test").config({
 
 // --- Formatting ---
 
-tasks.register("fixEslint", ExecTask, { command: "eslint", args: [".", "--quiet", "--fix"] }).config({
+tasks.register("fixEslint", PnpxTask, { command: "eslint", args: [".", "--quiet", "--fix"] }).config({
 	group: "Formatting",
 	description: "Fix lint issues with ESLint"
 });
-tasks.register("fixPrettier", ExecTask, { command: "prettier", args: ["--write", "."] }).config({
+
+tasks.register("fixPrettier", PnpxTask, { command: "prettier", args: ["--write", "."] }).config({
 	group: "Formatting",
 	description: "Format all files with Prettier"
 });
+
 tasks.register("format").config({
 	group: "Formatting",
 	dependsOn: ["fixEslint", "fixPrettier"],

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
 		"husky": "^9.1.7",
 		"jiti": "^2.6.1",
 		"knip": "^5.70.2",
-		"nadle": "https://pkg.pr.new/nadle@44434fa",
+		"nadle": "https://pkg.pr.new/nadle@2697846",
 		"prettier": "^3.7.3",
 		"rimraf": "^6.1.2",
 		"tsx": "^4.21.0",

--- a/packages/create-nadle/nadle.config.ts
+++ b/packages/create-nadle/nadle.config.ts
@@ -1,13 +1,13 @@
-import { tasks, Inputs, Outputs, ExecTask } from "../../node_modules/nadle/lib/index.js";
+import { tasks, Inputs, Outputs, PnpxTask } from "../../node_modules/nadle/lib/index.js";
 
-tasks.register("build", ExecTask, { command: "tsc", args: ["-p", "tsconfig.build.json"] }).config({
+tasks.register("build", PnpxTask, { command: "tsc", args: ["-p", "tsconfig.build.json"] }).config({
 	group: "Building",
 	inputs: [Inputs.dirs("src")],
 	outputs: [Outputs.dirs("lib")],
 	description: "Compile create-nadle with tsc"
 });
 
-tasks.register("test", ExecTask, { command: "npx", args: ["vitest", "run"] }).config({
+tasks.register("test", PnpxTask, { args: "run", command: "vitest" }).config({
 	group: "Testing",
 	dependsOn: ["build"],
 	description: "Run unit tests"

--- a/packages/docs/nadle.config.ts
+++ b/packages/docs/nadle.config.ts
@@ -1,19 +1,19 @@
-import { tasks, Inputs, Outputs, ExecTask } from "../../node_modules/nadle/lib/index.js";
+import { tasks, Inputs, Outputs, PnpxTask } from "../../node_modules/nadle/lib/index.js";
 
-tasks.register("buildSpec", ExecTask, { command: "npx", args: ["tsx", "scripts/build-spec.ts"] }).config({
+tasks.register("buildSpec", PnpxTask, { command: "tsx", args: "scripts/build-spec.ts" }).config({
 	group: "Building",
 	outputs: [Outputs.dirs("static/spec")],
 	description: "Build spec HTML from markdown",
 	inputs: [Inputs.files("../../spec/*.md"), Inputs.files("scripts/build-spec.ts")]
 });
 
-tasks.register("prepareAPIMarkdown", ExecTask, { command: "npx", args: ["tsx", "scripts/adjust-api-markdown.ts"] }).config({
+tasks.register("prepareAPIMarkdown", PnpxTask, { command: "tsx", args: "scripts/adjust-api-markdown.ts" }).config({
 	group: "Building",
 	dependsOn: ["packages:nadle:generateMarkdown"],
 	description: "Prepare API markdown for docusaurus"
 });
 
-tasks.register("build", ExecTask, { command: "npx", args: ["docusaurus", "build"] }).config({
+tasks.register("build", PnpxTask, { args: "build", command: "docusaurus" }).config({
 	group: "Building",
 	outputs: [Outputs.dirs("build")],
 	description: "Build documentation site",

--- a/packages/eslint-plugin/nadle.config.ts
+++ b/packages/eslint-plugin/nadle.config.ts
@@ -1,13 +1,13 @@
-import { tasks, Inputs, Outputs, ExecTask } from "../../node_modules/nadle/lib/index.js";
+import { tasks, Inputs, Outputs, PnpxTask } from "../../node_modules/nadle/lib/index.js";
 
-tasks.register("build", ExecTask, { command: "tsc", args: ["-p", "tsconfig.build.json"] }).config({
+tasks.register("build", PnpxTask, { command: "tsc", args: ["-p", "tsconfig.build.json"] }).config({
 	group: "Building",
 	inputs: [Inputs.dirs("src")],
 	outputs: [Outputs.dirs("lib")],
 	description: "Compile eslint-plugin with tsc"
 });
 
-tasks.register("test", ExecTask, { command: "npx", args: ["vitest", "run"] }).config({
+tasks.register("test", PnpxTask, { args: "run", command: "vitest" }).config({
 	group: "Testing",
 	dependsOn: ["build"],
 	description: "Run eslint-plugin tests"

--- a/packages/language-server/nadle.config.ts
+++ b/packages/language-server/nadle.config.ts
@@ -1,13 +1,13 @@
-import { tasks, Inputs, Outputs, ExecTask } from "../../node_modules/nadle/lib/index.js";
+import { tasks, Inputs, Outputs, PnpxTask } from "../../node_modules/nadle/lib/index.js";
 
-tasks.register("build", ExecTask, { command: "npx", args: ["tsup"] }).config({
+tasks.register("build", PnpxTask, { command: "tsup" }).config({
 	group: "Building",
 	inputs: [Inputs.dirs("src")],
 	outputs: [Outputs.dirs("lib")],
 	description: "Bundle language-server with tsup"
 });
 
-tasks.register("test", ExecTask, { command: "npx", args: ["vitest", "run"] }).config({
+tasks.register("test", PnpxTask, { args: "run", command: "vitest" }).config({
 	group: "Testing",
 	dependsOn: ["build"],
 	description: "Run LSP unit tests"

--- a/packages/nadle/nadle.config.ts
+++ b/packages/nadle/nadle.config.ts
@@ -1,27 +1,23 @@
 import Path from "node:path";
 import Fs from "node:fs/promises";
 
-import { tasks, Inputs, Outputs, ExecTask } from "../../node_modules/nadle/lib/index.js";
+import { tasks, Inputs, Outputs, PnpxTask } from "../../node_modules/nadle/lib/index.js";
 
-// NOTE: This config imports from the *published* nadle version (self-build).
-// Only use APIs available in the published version here. Once PnpxTask ships,
-// these can be migrated from ExecTask to PnpxTask.
-
-tasks.register("build", ExecTask, { args: ["tsup"], command: "npx" }).config({
+tasks.register("build", PnpxTask, { command: "tsup" }).config({
 	group: "Building",
 	inputs: [Inputs.dirs("src")],
 	outputs: [Outputs.dirs("lib")],
 	description: "Bundle nadle with tsup"
 });
 
-tasks.register("generateMarkdown", ExecTask, { command: "npx", args: ["typedoc"] }).config({
+tasks.register("generateMarkdown", PnpxTask, { command: "typedoc" }).config({
 	group: "Building",
 	description: "Generate API markdown with typedoc"
 });
 
 // --- Testing (nadle-specific, kept here due to workspace self-reference limitation) ---
 
-tasks.register("testAPI", ExecTask, { args: ["run"], command: "api-extractor" }).config({
+tasks.register("testAPI", PnpxTask, { args: ["run"], command: "api-extractor" }).config({
 	group: "Testing",
 	dependsOn: ["build"],
 	description: "Verify API surface with api-extractor"
@@ -45,7 +41,7 @@ tasks
 		description: "Ensure no API warnings or undocumented items"
 	});
 
-tasks.register("testUnit", ExecTask, { command: "npx", args: ["vitest", "run"] }).config({
+tasks.register("testUnit", PnpxTask, { args: "run", command: "vitest" }).config({
 	group: "Testing",
 	dependsOn: ["build"],
 	description: "Run unit tests"
@@ -59,7 +55,7 @@ tasks.register("test").config({
 
 // --- Maintenance (nadle-specific) ---
 
-tasks.register("updateAPI", ExecTask, { args: ["run", "--local"], command: "api-extractor" }).config({
+tasks.register("updateAPI", PnpxTask, { command: "api-extractor", args: ["run", "--local"] }).config({
 	group: "Maintenance",
 	dependsOn: ["build"],
 	description: "Update API report locally"

--- a/packages/sample-app/nadle.config.ts
+++ b/packages/sample-app/nadle.config.ts
@@ -1,7 +1,7 @@
 import Process from "node:process";
 
 import { Inputs } from "nadle";
-import { tasks, Outputs, ExecTask, CopyTask, type Task, configure } from "nadle";
+import { tasks, Outputs, PnpxTask, CopyTask, type Task, configure } from "nadle";
 
 import { createTask } from "./create-task.js";
 
@@ -64,7 +64,7 @@ tasks
 	.config({ dependsOn: ["node"] });
 
 tasks
-	.register("compileTs", ExecTask, {
+	.register("compileTs", PnpxTask, {
 		command: "tsc",
 		args: ["--project", "tsconfig.src.json"]
 	})

--- a/packages/vscode-extension/nadle.config.ts
+++ b/packages/vscode-extension/nadle.config.ts
@@ -1,11 +1,11 @@
-import { tasks, Inputs, Outputs, ExecTask } from "../../node_modules/nadle/lib/index.js";
+import { tasks, Inputs, Outputs, ExecTask, PnpxTask } from "../../node_modules/nadle/lib/index.js";
 
 tasks.register("copy-server", ExecTask, { command: "node", args: ["scripts/copy-server.mjs"] }).config({
 	group: "Building",
 	description: "Copy LSP server into extension"
 });
 
-tasks.register("build-tsup", ExecTask, { command: "npx", args: ["tsup"] }).config({
+tasks.register("build-tsup", PnpxTask, { command: "tsup" }).config({
 	group: "Building",
 	dependsOn: ["copy-server"],
 	description: "Bundle vscode extension with tsup"
@@ -19,7 +19,7 @@ tasks.register("build").config({
 	inputs: [Inputs.dirs("src"), Inputs.files("scripts/copy-server.mjs")]
 });
 
-tasks.register("package", ExecTask, { command: "npx", args: ["vsce", "package"] }).config({
+tasks.register("package", PnpxTask, { command: "vsce", args: "package" }).config({
 	group: "Building",
 	dependsOn: ["build"],
 	description: "Package vscode extension (.vsix)"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -58,8 +58,8 @@ importers:
         specifier: ^5.70.2
         version: 5.83.1(@types/node@24.6.2)(typescript@5.9.3)
       nadle:
-        specifier: https://pkg.pr.new/nadle@44434fa
-        version: https://pkg.pr.new/nadle@44434fa(@types/react@19.2.0)
+        specifier: https://pkg.pr.new/nadle@2697846
+        version: https://pkg.pr.new/nadle@2697846(@types/react@19.2.0)
       prettier:
         specifier: ^3.7.3
         version: 3.8.1
@@ -6369,8 +6369,8 @@ packages:
   mz@2.7.0:
     resolution: {integrity: sha512-z81GNO7nnYMEhrGh9LeymoE4+Yr0Wn5McHIZMK5cfQCl+NDX08sCZgUc9/6MHni9IWuFLm1Z3HTCXu2z9fN62Q==}
 
-  nadle@https://pkg.pr.new/nadle@44434fa:
-    resolution: {integrity: sha512-i42pzOH5ylKMeDX9PY3UvSTAVKmns+Qx+XUvaEPGgeI1GV/msc3izDyndsfudgYyOT3y/GQVjs3lq9Y9Gu+/nw==, tarball: https://pkg.pr.new/nadle@44434fa}
+  nadle@https://pkg.pr.new/nadle@2697846:
+    resolution: {integrity: sha512-XGJvaUs+iMYZF3Gc5FCB+QeJ/GhUZzLWHfHZIoZF3QUOcI6GDowfGVwfSuMk0HyrJ9fsJ3K+ZypvrZX84Yv2mw==, tarball: https://pkg.pr.new/nadle@2697846}
     version: 0.5.1
     engines: {node: '>=22'}
     hasBin: true
@@ -16357,7 +16357,7 @@ snapshots:
       object-assign: 4.1.1
       thenify-all: 1.6.0
 
-  nadle@https://pkg.pr.new/nadle@44434fa(@types/react@19.2.0):
+  nadle@https://pkg.pr.new/nadle@2697846(@types/react@19.2.0):
     dependencies:
       '@manypkg/find-root': 3.1.0
       '@manypkg/tools': 2.1.0


### PR DESCRIPTION
## Summary
- Update all `nadle.config.ts` files across the monorepo to use `PnpxTask` for locally-installed binaries instead of verbose `ExecTask` with `{ command: "npx", args: [...] }`
- Bump the self-build nadle dependency to the merged `@2697846` release which includes `PnpxTask`
- Keep `ExecTask` only where needed (vscode-extension `copy-server` uses `node`, not a local binary)

## Test plan
- [x] `nadle check --summary` passes locally
- [ ] CI passes on all platforms

🤖 Generated with [Claude Code](https://claude.com/claude-code)