### PR TITLE
test: unify result-awaiting behind a single settle() helper

### DIFF
--- a/packages/nadle/test/__setup__/exec.ts
+++ b/packages/nadle/test/__setup__/exec.ts
@@ -83,37 +83,51 @@ Command: ${params.command}`.trimStart();
 	return snapshot;
 }
 
+interface SettledResult {
+	cwd: string;
+	stdout: string;
+	stderr: string;
+	command: string;
+	exitCode: number | undefined;
+}
+
+/**
+ * Await a CLI result whether it succeeds or fails, returning the fields needed to
+ * build a snapshot. The single place that resolves a ResultPromise; assertions on
+ * the exit code live in the callers (getStdout/getStderr/expectPass/expectFail).
+ */
+export async function settle(resultPromise: ResultPromise): Promise<SettledResult> {
+	try {
+		const { cwd, stdout, stderr, command, exitCode } = await resultPromise;
+
+		return { cwd, command, exitCode, stdout: stdout as string, stderr: stderr as string };
+	} catch (error) {
+		const { cwd, stdout, stderr, command, exitCode } = error as Result;
+
+		return { cwd, command, exitCode, stdout: stdout as string, stderr: stderr as string };
+	}
+}
+
 export async function getStdout(resultPromise: ResultPromise, options?: { stripAnsi?: boolean; serializeAll?: boolean }): Promise<string> {
-	const { cwd, stdout, command, exitCode } = await resultPromise;
+	const { cwd, stdout, command, exitCode } = await settle(resultPromise);
 
 	expect(exitCode).toBe(0);
 
-	const output = stdout as string;
-
 	if (options?.serializeAll) {
-		return serialize(createSnapshotTemplate({ cwd, command, stdout: output }));
+		return serialize(createSnapshotTemplate({ cwd, stdout, command }));
 	}
 
 	if (options?.stripAnsi ?? true) {
-		return stripAnsi(createSnapshotTemplate({ cwd, command, stdout: output }));
+		return stripAnsi(createSnapshotTemplate({ cwd, stdout, command }));
 	}
 
-	return output;
+	return stdout;
 }
 
 export async function getStderr(resultPromise: ResultPromise, options?: { stripAnsi?: boolean }): Promise<string> {
-	let stderr = "";
+	const { stderr, exitCode } = await settle(resultPromise);
 
-	try {
-		await resultPromise;
-		throw new Error("Expected command to fail, but it succeeded.");
-	} catch (error) {
-		const execaError = error as Result;
-
-		expect(execaError.exitCode).not.toBe(0);
-
-		stderr = execaError.stderr as string;
-	}
+	expect(exitCode).not.toBe(0);
 
 	if (options?.stripAnsi ?? true) {
 		return stripAnsi(stderr);

--- a/packages/nadle/test/__setup__/expects.ts
+++ b/packages/nadle/test/__setup__/expects.ts
@@ -1,23 +1,18 @@
 import { expect } from "vitest";
-import type { Result, ResultPromise } from "execa";
+import type { ResultPromise } from "execa";
 
-import { createSnapshotTemplate } from "./exec.js";
+import { settle, createSnapshotTemplate } from "./exec.js";
 
 export async function expectFail(resultPromise: ResultPromise) {
-	try {
-		await resultPromise;
-		throw new Error("Expected command to fail, but it succeeded.");
-	} catch (error) {
-		const { cwd, stdout, stderr, command, exitCode } = error as Result;
+	const { cwd, stdout, stderr, command, exitCode } = await settle(resultPromise);
 
-		expect(exitCode).toBe(1);
-		expect(createSnapshotTemplate({ cwd, command, stdout: stdout as string, stderr: stderr as string })).toMatchSnapshot();
-	}
+	expect(exitCode).toBe(1);
+	expect(createSnapshotTemplate({ cwd, stdout, stderr, command })).toMatchSnapshot();
 }
 
 export async function expectPass(resultPromise: ResultPromise) {
-	const { cwd, stdout, stderr, command, exitCode } = await resultPromise;
+	const { cwd, stdout, stderr, command, exitCode } = await settle(resultPromise);
 
 	expect(exitCode).toBe(0);
-	expect(createSnapshotTemplate({ cwd, command, stdout: stdout as string, stderr: stderr as string })).toMatchSnapshot();
+	expect(createSnapshotTemplate({ cwd, stdout, stderr, command })).toMatchSnapshot();
 }


### PR DESCRIPTION
Part 2 of the test-setup cleanup.

## Problem
`expectPass`/`expectFail` (expects.ts) re-implemented the same "await the ResultPromise, assert the exit code, build a snapshot template" logic that `getStdout`/`getStderr` (exec.ts) already had — two forks of the same flow, including the success/failure handling.

## Change
Extract `settle(resultPromise)` as the single place that resolves a `ResultPromise` (whether it succeeds or fails) and returns `{cwd, command, stdout, stderr, exitCode}`. The four front-ends now build on it:
- `getStdout` — asserts exit 0, returns stdout template (unchanged signature)
- `getStderr` — asserts exit ≠ 0, returns stderr
- `expectPass` — asserts exit 0, snapshots stdout+stderr
- `expectFail` — asserts exit 1, snapshots stdout+stderr

No behavior change; full suite green with **byte-identical snapshots** (no regeneration).

🤖 Generated with [Claude Code](https://claude.com/claude-code)