### PR TITLE
test: add workspaceFixture() helper for workspace test fixtures

### DIFF
--- a/packages/nadle/test/__setup__/index.ts
+++ b/packages/nadle/test/__setup__/index.ts
@@ -9,3 +9,4 @@ export * from "./create-files.js";
 export * from "./blur-snapshot.js";
 export * from "./config-builder.js";
 export * from "./fixture-builder.js";
+export * from "./workspace-fixture.js";

--- a/packages/nadle/test/__setup__/workspace-fixture.ts
+++ b/packages/nadle/test/__setup__/workspace-fixture.ts
@@ -1,0 +1,91 @@
+import type fixturify from "fixturify";
+import { PACKAGE_JSON } from "@nadle/project-resolver";
+import { type PackageJson } from "@nadle/project-resolver";
+import { type NadleFileOptions, type TaskConfiguration } from "src/index.js";
+
+import { CONFIG_FILE, PNPM_WORKSPACE } from "./constants.js";
+import { createNadleConfig, createPackageJson, createPnpmWorkspace } from "./create-files.js";
+
+type PackageFields = Partial<Omit<PackageJson & { workspaces: string[] }, "name">>;
+
+interface WorkspaceSpec {
+	/** package.json name; defaults to the last segment of the workspace path. */
+	name?: string;
+	/** Write the config file verbatim instead of generating it (e.g. a task body with real code). */
+	rawConfig?: string;
+	/** package.json fields beyond `name` (version, dependencies, devDependencies, ...). */
+	pkg?: PackageFields;
+	/** Config file name; defaults to nadle.config.ts. Use for ".js" or custom-named configs. */
+	configFileName?: string;
+	/** `configure({...})` options. Pass a function alias here; it is serialized verbatim. */
+	configure?: NadleFileOptions;
+	/** Extra files/dirs to merge into this workspace (src/, lock files, nested config dirs, ...). */
+	extraFiles?: fixturify.DirJSON;
+	/** Tasks to register. Omit (and omit rawConfig) for a package-only workspace. */
+	tasks?: { name: string; config?: TaskConfiguration }[];
+}
+
+interface WorkspaceFixtureOptions {
+	root?: WorkspaceSpec;
+	/** pnpm-workspace.yaml packages globs; pass false to omit the file (npm/yarn roots). */
+	pnpmWorkspace?: string[] | false;
+	/**
+	 * Workspaces keyed by directory path relative to the root. Slash-separated paths
+	 * (e.g. "common/api") create nested directories. A `null` value writes only a
+	 * package.json (named after the last path segment) with no config.
+	 */
+	workspaces?: Record<string, WorkspaceSpec | null>;
+}
+
+function buildWorkspaceFiles(defaultName: string, spec: WorkspaceSpec): fixturify.DirJSON {
+	const files: fixturify.DirJSON = {
+		[PACKAGE_JSON]: createPackageJson(spec.name ?? defaultName, spec.pkg)
+	};
+
+	if (spec.rawConfig !== undefined) {
+		files[spec.configFileName ?? CONFIG_FILE] = spec.rawConfig;
+	} else if (spec.tasks || spec.configure) {
+		files[spec.configFileName ?? CONFIG_FILE] = createNadleConfig({ tasks: spec.tasks, configure: spec.configure });
+	}
+
+	return { ...files, ...spec.extraFiles };
+}
+
+function setNestedDir(root: fixturify.DirJSON, path: string, contents: fixturify.DirJSON): void {
+	const parts = path.split("/");
+	let current = root;
+
+	for (const part of parts.slice(0, -1)) {
+		if (typeof current[part] !== "object") {
+			current[part] = {};
+		}
+
+		current = current[part] as fixturify.DirJSON;
+	}
+
+	current[parts.at(-1)!] = contents;
+}
+
+/**
+ * Build a monorepo fixture tree: a root workspace plus N nested workspaces, each
+ * with a package.json and (optionally) a nadle config. Replaces the hand-rolled
+ * createPnpmWorkspace + createPackageJson + createNadleConfig triplet repeated
+ * across the workspace tests.
+ */
+export function workspaceFixture(options: WorkspaceFixtureOptions = {}): fixturify.DirJSON {
+	const { root = {}, workspaces = {}, pnpmWorkspace = ["./**"] } = options;
+
+	const files: fixturify.DirJSON = { ...buildWorkspaceFiles("root", root) };
+
+	if (pnpmWorkspace !== false) {
+		files[PNPM_WORKSPACE] = createPnpmWorkspace(pnpmWorkspace);
+	}
+
+	for (const [path, spec] of Object.entries(workspaces)) {
+		const name = path.split("/").at(-1)!;
+
+		setNestedDir(files, path, buildWorkspaceFiles(name, spec ?? {}));
+	}
+
+	return files;
+}

--- a/packages/nadle/test/features/workspaces/workspaces-alias.test.ts
+++ b/packages/nadle/test/features/workspaces/workspaces-alias.test.ts
@@ -1,6 +1,5 @@
 import { it, describe } from "vitest";
-import { PACKAGE_JSON } from "@nadle/project-resolver";
-import { expectPass, withFixture, CONFIG_FILE, PNPM_WORKSPACE, createPackageJson, createNadleConfig, createPnpmWorkspace } from "setup";
+import { expectPass, withFixture, workspaceFixture } from "setup";
 
 describe("workspaces alias", () => {
 	it("object style", async () => {
@@ -9,22 +8,13 @@ describe("workspaces alias", () => {
 			testFn: async ({ exec }) => {
 				await expectPass(exec`build`);
 			},
-			files: {
-				[PNPM_WORKSPACE]: createPnpmWorkspace(),
-				[PACKAGE_JSON]: createPackageJson("root"),
-				[CONFIG_FILE]: createNadleConfig({ tasks: [{ name: "build" }], configure: { alias: { "packages/one": "one" } } }),
-
-				packages: {
-					one: {
-						[PACKAGE_JSON]: createPackageJson("one"),
-						[CONFIG_FILE]: createNadleConfig({ tasks: [{ name: "build" }] })
-					},
-					two: {
-						[PACKAGE_JSON]: createPackageJson("two"),
-						[CONFIG_FILE]: createNadleConfig({ tasks: [{ name: "build" }] })
-					}
+			files: workspaceFixture({
+				root: { tasks: [{ name: "build" }], configure: { alias: { "packages/one": "one" } } },
+				workspaces: {
+					"packages/one": { tasks: [{ name: "build" }] },
+					"packages/two": { tasks: [{ name: "build" }] }
 				}
-			}
+			})
 		});
 	});
 
@@ -34,10 +24,12 @@ describe("workspaces alias", () => {
 			testFn: async ({ exec }) => {
 				await expectPass(exec`build`);
 			},
-			files: {
-				[PNPM_WORKSPACE]: createPnpmWorkspace(),
-				[PACKAGE_JSON]: createPackageJson("root"),
-				[CONFIG_FILE]: createNadleConfig({
+			files: workspaceFixture({
+				workspaces: {
+					"packages/one": { tasks: [{ name: "build" }] },
+					"packages/two": { tasks: [{ name: "build" }] }
+				},
+				root: {
 					tasks: [{ name: "build" }],
 					configure: {
 						alias: (workspacePath) => {
@@ -46,19 +38,8 @@ describe("workspaces alias", () => {
 							}
 						}
 					}
-				}),
-
-				packages: {
-					one: {
-						[PACKAGE_JSON]: createPackageJson("one"),
-						[CONFIG_FILE]: createNadleConfig({ tasks: [{ name: "build" }] })
-					},
-					two: {
-						[PACKAGE_JSON]: createPackageJson("two"),
-						[CONFIG_FILE]: createNadleConfig({ tasks: [{ name: "build" }] })
-					}
 				}
-			}
+			})
 		});
 	});
 
@@ -68,23 +49,12 @@ describe("workspaces alias", () => {
 			testFn: async ({ exec }) => {
 				await expectPass(exec`build`);
 			},
-			files: {
-				[PNPM_WORKSPACE]: createPnpmWorkspace(),
-				[PACKAGE_JSON]: createPackageJson("root"),
-				[CONFIG_FILE]: createNadleConfig({
-					tasks: [{ name: "build" }],
-					configure: {
-						alias: { ".": "my-root" }
-					}
-				}),
-
-				packages: {
-					one: {
-						[PACKAGE_JSON]: createPackageJson("one"),
-						[CONFIG_FILE]: createNadleConfig({ tasks: [{ name: "build" }] })
-					}
-				}
-			}
+			files: workspaceFixture({
+				workspaces: {
+					"packages/one": { tasks: [{ name: "build" }] }
+				},
+				root: { tasks: [{ name: "build" }], configure: { alias: { ".": "my-root" } } }
+			})
 		});
 	});
 

--- a/packages/nadle/test/features/workspaces/workspaces-basic-tasks.test.ts
+++ b/packages/nadle/test/features/workspaces/workspaces-basic-tasks.test.ts
@@ -2,42 +2,17 @@ import Path from "node:path";
 
 import type fixturify from "fixturify";
 import { it, expect, describe } from "vitest";
-import { PACKAGE_JSON } from "@nadle/project-resolver";
-import {
-	getStderr,
-	createExec,
-	expectPass,
-	CONFIG_FILE,
-	withFixture,
-	PNPM_WORKSPACE,
-	createNadleConfig,
-	createPackageJson,
-	createPnpmWorkspace
-} from "setup";
+import { getStderr, createExec, expectPass, withFixture, workspaceFixture } from "setup";
 
 describe("workspaces basic tasks", () => {
-	const project: fixturify.DirJSON = {
-		[PNPM_WORKSPACE]: createPnpmWorkspace(),
-		[PACKAGE_JSON]: createPackageJson("root"),
-		[CONFIG_FILE]: createNadleConfig({
-			tasks: [{ name: "build" }, { name: "test" }]
-		}),
-
-		packages: {
-			one: {
-				[PACKAGE_JSON]: createPackageJson("one"),
-				[CONFIG_FILE]: createNadleConfig({ tasks: [{ name: "build" }] })
-			},
-			two: {
-				[PACKAGE_JSON]: createPackageJson("two"),
-				[CONFIG_FILE]: createNadleConfig({ tasks: [{ name: "build" }] })
-			},
-			three: {
-				[PACKAGE_JSON]: createPackageJson("three"),
-				[CONFIG_FILE]: createNadleConfig({ tasks: [{ name: "build" }] })
-			}
+	const project: fixturify.DirJSON = workspaceFixture({
+		root: { tasks: [{ name: "build" }, { name: "test" }] },
+		workspaces: {
+			"packages/one": { tasks: [{ name: "build" }] },
+			"packages/two": { tasks: [{ name: "build" }] },
+			"packages/three": { tasks: [{ name: "build" }] }
 		}
-	};
+	});
 
 	it("should register all tasks from all config files", async () => {
 		await withFixture({

--- a/packages/nadle/test/features/workspaces/workspaces-configure.test.ts
+++ b/packages/nadle/test/features/workspaces/workspaces-configure.test.ts
@@ -1,6 +1,5 @@
 import { it, expect, describe } from "vitest";
-import { PACKAGE_JSON } from "@nadle/project-resolver";
-import { getStderr, withFixture, CONFIG_FILE, PNPM_WORKSPACE, createPackageJson, createNadleConfig, createPnpmWorkspace } from "setup";
+import { getStderr, withFixture, workspaceFixture } from "setup";
 
 describe.concurrent("workspaces configure", () => {
 	describe("when calling configure from sub-workspace configure file", () => {
@@ -10,18 +9,12 @@ describe.concurrent("workspaces configure", () => {
 				testFn: async ({ exec }) => {
 					await expect(getStderr(exec`build`)).resolves.toContain(`configure function can only be called from the root workspace.`);
 				},
-				files: {
-					[PNPM_WORKSPACE]: createPnpmWorkspace(),
-					[PACKAGE_JSON]: createPackageJson("root"),
-					[CONFIG_FILE]: createNadleConfig({ tasks: [{ name: "build" }], configure: { alias: { "packages/one": "one" } } }),
-
-					packages: {
-						two: {
-							[PACKAGE_JSON]: createPackageJson("two"),
-							[CONFIG_FILE]: createNadleConfig({ configure: { maxWorkers: 3 } })
-						}
-					}
-				}
+				files: workspaceFixture({
+					workspaces: {
+						"packages/two": { configure: { maxWorkers: 3 } }
+					},
+					root: { tasks: [{ name: "build" }], configure: { alias: { "packages/one": "one" } } }
+				})
 			});
 		});
 	});

--- a/packages/nadle/test/features/workspaces/workspaces-depends-on-tasks.test.ts
+++ b/packages/nadle/test/features/workspaces/workspaces-depends-on-tasks.test.ts
@@ -1,18 +1,7 @@
 import Path from "node:path";
 
 import { it, expect, describe } from "vitest";
-import { PACKAGE_JSON } from "@nadle/project-resolver";
-import {
-	getStderr,
-	getStdout,
-	createExec,
-	CONFIG_FILE,
-	withFixture,
-	PNPM_WORKSPACE,
-	createNadleConfig,
-	createPackageJson,
-	createPnpmWorkspace
-} from "setup";
+import { getStderr, getStdout, createExec, withFixture, workspaceFixture } from "setup";
 
 describe.concurrent("workspaces > depends on tasks", () => {
 	describe("when declare a task without workspace", () => {
@@ -20,25 +9,17 @@ describe.concurrent("workspaces > depends on tasks", () => {
 			it("should throw an error even if having a same task in root workspace", async () => {
 				await withFixture({
 					fixtureDir: "monorepo",
+					files: workspaceFixture({
+						root: { tasks: [{ name: "build" }] },
+						workspaces: {
+							"packages/one": { tasks: [{ name: "check", config: { dependsOn: ["build"] } }] }
+						}
+					}),
 					testFn: async ({ cwd }) => {
 						// TODO: Should we enable --stacktrace by default?
 						await expect(getStderr(createExec({ cwd: Path.join(cwd, "packages", "one") })`check --stacktrace`)).resolves.toContain(
 							`Task build not found in packages:one workspace.`
 						);
-					},
-					files: {
-						[PNPM_WORKSPACE]: createPnpmWorkspace(),
-						[PACKAGE_JSON]: createPackageJson("root"),
-						[CONFIG_FILE]: createNadleConfig({ tasks: [{ name: "build" }] }),
-
-						packages: {
-							one: {
-								[PACKAGE_JSON]: createPackageJson("one"),
-								[CONFIG_FILE]: createNadleConfig({
-									tasks: [{ name: "check", config: { dependsOn: ["build"] } }]
-								})
-							}
-						}
 					}
 				});
 			});
@@ -48,24 +29,16 @@ describe.concurrent("workspaces > depends on tasks", () => {
 			it("should throw an error instead of trying to correct it", async () => {
 				await withFixture({
 					fixtureDir: "monorepo",
+					files: workspaceFixture({
+						root: { tasks: [{ name: "build" }] },
+						workspaces: {
+							"packages/one": { tasks: [{ name: "build" }, { name: "check", config: { dependsOn: ["buidl"] } }] }
+						}
+					}),
 					testFn: async ({ cwd }) => {
 						await expect(getStderr(createExec({ cwd: Path.join(cwd, "packages", "one") })`check --stacktrace`)).resolves.toContain(
 							`Task buidl not found in packages:one workspace.`
 						);
-					},
-					files: {
-						[PNPM_WORKSPACE]: createPnpmWorkspace(),
-						[PACKAGE_JSON]: createPackageJson("root"),
-						[CONFIG_FILE]: createNadleConfig({ tasks: [{ name: "build" }] }),
-
-						packages: {
-							one: {
-								[PACKAGE_JSON]: createPackageJson("one"),
-								[CONFIG_FILE]: createNadleConfig({
-									tasks: [{ name: "build" }, { name: "check", config: { dependsOn: ["buidl"] } }]
-								})
-							}
-						}
 					}
 				});
 			});
@@ -75,24 +48,16 @@ describe.concurrent("workspaces > depends on tasks", () => {
 			it("should run the declared task first", async () => {
 				await withFixture({
 					fixtureDir: "monorepo",
+					files: workspaceFixture({
+						root: { tasks: [{ name: "build" }] },
+						workspaces: {
+							"packages/one": { tasks: [{ name: "build" }, { name: "check", config: { dependsOn: ["build"] } }] }
+						}
+					}),
 					testFn: async ({ cwd }) => {
 						const stdout = await getStdout(createExec({ cwd: Path.join(cwd, "packages", "one") })`check`);
 
 						expect(stdout).toRunInOrder("packages:one:build", "packages:one:check");
-					},
-					files: {
-						[PNPM_WORKSPACE]: createPnpmWorkspace(),
-						[PACKAGE_JSON]: createPackageJson("root"),
-						[CONFIG_FILE]: createNadleConfig({ tasks: [{ name: "build" }] }),
-
-						packages: {
-							one: {
-								[PACKAGE_JSON]: createPackageJson("one"),
-								[CONFIG_FILE]: createNadleConfig({
-									tasks: [{ name: "build" }, { name: "check", config: { dependsOn: ["build"] } }]
-								})
-							}
-						}
 					}
 				});
 			});
@@ -112,35 +77,21 @@ describe.concurrent("workspaces > depends on tasks", () => {
 						expect(stdout).toRunInOrder("packages:one:check", "packages:one:build");
 						expect(stdout).toRunInOrder("build", "packages:one:build");
 					},
-					files: {
-						[PNPM_WORKSPACE]: createPnpmWorkspace(),
-						[PACKAGE_JSON]: createPackageJson("root"),
-						[CONFIG_FILE]: createNadleConfig({
-							tasks: [{ name: "build" }],
-							configure: { alias: { "packages/two": "two" } }
-						}),
-
-						packages: {
-							two: {
-								[PACKAGE_JSON]: createPackageJson("two"),
-								[CONFIG_FILE]: createNadleConfig({
-									tasks: [{ name: "build" }, { name: "check" }]
-								})
-							},
-							one: {
-								[PACKAGE_JSON]: createPackageJson("one"),
-								[CONFIG_FILE]: createNadleConfig({
-									tasks: [
-										{ name: "check" },
-										{
-											name: "build",
-											config: { dependsOn: ["packages:two:build", "two:check", "check", "root:build"] }
-										}
-									]
-								})
+					files: workspaceFixture({
+						root: { tasks: [{ name: "build" }], configure: { alias: { "packages/two": "two" } } },
+						workspaces: {
+							"packages/two": { tasks: [{ name: "build" }, { name: "check" }] },
+							"packages/one": {
+								tasks: [
+									{ name: "check" },
+									{
+										name: "build",
+										config: { dependsOn: ["packages:two:build", "two:check", "check", "root:build"] }
+									}
+								]
 							}
 						}
-					}
+					})
 				});
 			});
 		});
@@ -166,26 +117,13 @@ describe.concurrent("workspaces > depends on tasks", () => {
 						testFn: async ({ cwd }) => {
 							await expect(getStderr(createExec({ cwd: Path.join(cwd, "packages", "one") })`build --stacktrace`)).resolves.toContain(expectedError);
 						},
-						files: {
-							[PNPM_WORKSPACE]: createPnpmWorkspace(),
-							[PACKAGE_JSON]: createPackageJson("root"),
-							[CONFIG_FILE]: createNadleConfig({ tasks: [{ name: "build" }] }),
-
-							packages: {
-								two: {
-									[PACKAGE_JSON]: createPackageJson("two"),
-									[CONFIG_FILE]: createNadleConfig({
-										tasks: [{ name: "build" }]
-									})
-								},
-								one: {
-									[PACKAGE_JSON]: createPackageJson("one"),
-									[CONFIG_FILE]: createNadleConfig({
-										tasks: [{ name: "build", config: { dependsOn: dependency } }]
-									})
-								}
+						files: workspaceFixture({
+							root: { tasks: [{ name: "build" }] },
+							workspaces: {
+								"packages/two": { tasks: [{ name: "build" }] },
+								"packages/one": { tasks: [{ name: "build", config: { dependsOn: dependency } }] }
 							}
-						}
+						})
 					});
 				});
 			}

--- a/packages/nadle/test/features/workspaces/workspaces-excluded-tasks.test.ts
+++ b/packages/nadle/test/features/workspaces/workspaces-excluded-tasks.test.ts
@@ -1,8 +1,7 @@
 import Path from "node:path";
 
 import { it, describe } from "vitest";
-import { PACKAGE_JSON } from "@nadle/project-resolver";
-import { createExec, expectPass, CONFIG_FILE, withFixture, PNPM_WORKSPACE, createNadleConfig, createPackageJson, createPnpmWorkspace } from "setup";
+import { createExec, expectPass, withFixture, workspaceFixture } from "setup";
 
 describe("workspaces > excluded tasks", () => {
 	it("should not run excluded tasks", async () => {
@@ -15,26 +14,14 @@ describe("workspaces > excluded tasks", () => {
 				await expectPass(exec`check --exclude two:build`);
 				await expectPass(exec`check --exclude packages:two:build`);
 			},
-			files: {
-				[PNPM_WORKSPACE]: createPnpmWorkspace(),
-				[PACKAGE_JSON]: createPackageJson("root"),
-				[CONFIG_FILE]: createNadleConfig({ tasks: [{ name: "build" }], configure: { alias: { "packages/two": "two" } } }),
-
-				packages: {
-					two: {
-						[PACKAGE_JSON]: createPackageJson("one"),
-						[CONFIG_FILE]: createNadleConfig({
-							tasks: [{ name: "build" }, { name: "check", config: { dependsOn: ["build"] } }]
-						})
-					},
-					one: {
-						[PACKAGE_JSON]: createPackageJson("one"),
-						[CONFIG_FILE]: createNadleConfig({
-							tasks: [{ name: "build" }, { name: "check", config: { dependsOn: ["build", "two:build", "root:build"] } }]
-						})
-					}
+			files: workspaceFixture({
+				root: { tasks: [{ name: "build" }], configure: { alias: { "packages/two": "two" } } },
+				workspaces: {
+					// Both workspaces intentionally share the package name "one".
+					"packages/two": { name: "one", tasks: [{ name: "build" }, { name: "check", config: { dependsOn: ["build"] } }] },
+					"packages/one": { tasks: [{ name: "build" }, { name: "check", config: { dependsOn: ["build", "two:build", "root:build"] } }] }
 				}
-			}
+			})
 		});
 	});
 });

--- a/packages/nadle/test/features/workspaces/workspaces-implicit-deps.test.ts
+++ b/packages/nadle/test/features/workspaces/workspaces-implicit-deps.test.ts
@@ -1,6 +1,5 @@
 import { it, expect, describe } from "vitest";
-import { PACKAGE_JSON } from "@nadle/project-resolver";
-import { getStdout, getStderr, CONFIG_FILE, withFixture, PNPM_WORKSPACE, createNadleConfig, createPackageJson, createPnpmWorkspace } from "setup";
+import { getStdout, getStderr, withFixture, workspaceFixture } from "setup";
 
 describe("workspaces > implicit dependencies", () => {
 	describe("linear chain", () => {
@@ -12,26 +11,13 @@ describe("workspaces > implicit dependencies", () => {
 
 					expect(stdout).toRunInOrder("packages:lib:build", "packages:app:build");
 				},
-				files: {
-					[PNPM_WORKSPACE]: createPnpmWorkspace(),
-					[PACKAGE_JSON]: createPackageJson("root"),
-					[CONFIG_FILE]: createNadleConfig({
-						tasks: [{ name: "build" }]
-					}),
-
-					packages: {
-						lib: {
-							[PACKAGE_JSON]: createPackageJson("lib"),
-							[CONFIG_FILE]: createNadleConfig({ tasks: [{ name: "build" }] })
-						},
-						app: {
-							[CONFIG_FILE]: createNadleConfig({ tasks: [{ name: "build" }] }),
-							[PACKAGE_JSON]: createPackageJson("app", {
-								dependencies: { lib: "workspace:*" }
-							})
-						}
+				files: workspaceFixture({
+					root: { tasks: [{ name: "build" }] },
+					workspaces: {
+						"packages/lib": { tasks: [{ name: "build" }] },
+						"packages/app": { tasks: [{ name: "build" }], pkg: { dependencies: { lib: "workspace:*" } } }
 					}
-				}
+				})
 			});
 		});
 	});
@@ -48,38 +34,15 @@ describe("workspaces > implicit dependencies", () => {
 					expect(stdout).toRunInOrder("packages:lib-a:build", "packages:app:build");
 					expect(stdout).toRunInOrder("packages:lib-b:build", "packages:app:build");
 				},
-				files: {
-					[PNPM_WORKSPACE]: createPnpmWorkspace(),
-					[PACKAGE_JSON]: createPackageJson("root"),
-					[CONFIG_FILE]: createNadleConfig({
-						tasks: [{ name: "build" }]
-					}),
-
-					packages: {
-						core: {
-							[PACKAGE_JSON]: createPackageJson("core"),
-							[CONFIG_FILE]: createNadleConfig({ tasks: [{ name: "build" }] })
-						},
-						"lib-a": {
-							[CONFIG_FILE]: createNadleConfig({ tasks: [{ name: "build" }] }),
-							[PACKAGE_JSON]: createPackageJson("lib-a", {
-								dependencies: { core: "workspace:*" }
-							})
-						},
-						"lib-b": {
-							[CONFIG_FILE]: createNadleConfig({ tasks: [{ name: "build" }] }),
-							[PACKAGE_JSON]: createPackageJson("lib-b", {
-								dependencies: { core: "workspace:*" }
-							})
-						},
-						app: {
-							[CONFIG_FILE]: createNadleConfig({ tasks: [{ name: "build" }] }),
-							[PACKAGE_JSON]: createPackageJson("app", {
-								dependencies: { "lib-a": "workspace:*", "lib-b": "workspace:*" }
-							})
-						}
+				files: workspaceFixture({
+					root: { tasks: [{ name: "build" }] },
+					workspaces: {
+						"packages/core": { tasks: [{ name: "build" }] },
+						"packages/lib-a": { tasks: [{ name: "build" }], pkg: { dependencies: { core: "workspace:*" } } },
+						"packages/lib-b": { tasks: [{ name: "build" }], pkg: { dependencies: { core: "workspace:*" } } },
+						"packages/app": { tasks: [{ name: "build" }], pkg: { dependencies: { "lib-a": "workspace:*", "lib-b": "workspace:*" } } }
 					}
-				}
+				})
 			});
 		});
 	});
@@ -94,26 +57,13 @@ describe("workspaces > implicit dependencies", () => {
 					// app:build should run even though lib has no build task
 					expect(stdout).toContain("Task packages:app:build DONE");
 				},
-				files: {
-					[PNPM_WORKSPACE]: createPnpmWorkspace(),
-					[PACKAGE_JSON]: createPackageJson("root"),
-					[CONFIG_FILE]: createNadleConfig({
-						tasks: [{ name: "build" }]
-					}),
-
-					packages: {
-						lib: {
-							[PACKAGE_JSON]: createPackageJson("lib"),
-							[CONFIG_FILE]: createNadleConfig({ tasks: [{ name: "test" }] })
-						},
-						app: {
-							[CONFIG_FILE]: createNadleConfig({ tasks: [{ name: "build" }] }),
-							[PACKAGE_JSON]: createPackageJson("app", {
-								dependencies: { lib: "workspace:*" }
-							})
-						}
+				files: workspaceFixture({
+					root: { tasks: [{ name: "build" }] },
+					workspaces: {
+						"packages/lib": { tasks: [{ name: "test" }] },
+						"packages/app": { tasks: [{ name: "build" }], pkg: { dependencies: { lib: "workspace:*" } } }
 					}
-				}
+				})
 			});
 		});
 	});
@@ -129,27 +79,13 @@ describe("workspaces > implicit dependencies", () => {
 					expect(stdout).toContain("Task packages:lib:build DONE");
 					expect(stdout).toContain("Task packages:app:build DONE");
 				},
-				files: {
-					[PNPM_WORKSPACE]: createPnpmWorkspace(),
-					[PACKAGE_JSON]: createPackageJson("root"),
-					[CONFIG_FILE]: createNadleConfig({
-						tasks: [{ name: "build" }],
-						configure: { implicitDependencies: false }
-					}),
-
-					packages: {
-						lib: {
-							[PACKAGE_JSON]: createPackageJson("lib"),
-							[CONFIG_FILE]: createNadleConfig({ tasks: [{ name: "build" }] })
-						},
-						app: {
-							[CONFIG_FILE]: createNadleConfig({ tasks: [{ name: "build" }] }),
-							[PACKAGE_JSON]: createPackageJson("app", {
-								dependencies: { lib: "workspace:*" }
-							})
-						}
+				files: workspaceFixture({
+					root: { tasks: [{ name: "build" }], configure: { implicitDependencies: false } },
+					workspaces: {
+						"packages/lib": { tasks: [{ name: "build" }] },
+						"packages/app": { tasks: [{ name: "build" }], pkg: { dependencies: { lib: "workspace:*" } } }
 					}
-				}
+				})
 			});
 		});
 	});
@@ -163,28 +99,16 @@ describe("workspaces > implicit dependencies", () => {
 
 					expect(stdout).toRunInOrder("packages:lib:build", "packages:app:build");
 				},
-				files: {
-					[PNPM_WORKSPACE]: createPnpmWorkspace(),
-					[PACKAGE_JSON]: createPackageJson("root"),
-					[CONFIG_FILE]: createNadleConfig({
-						tasks: [{ name: "build" }]
-					}),
-
-					packages: {
-						lib: {
-							[PACKAGE_JSON]: createPackageJson("lib"),
-							[CONFIG_FILE]: createNadleConfig({ tasks: [{ name: "build" }] })
-						},
-						app: {
-							[PACKAGE_JSON]: createPackageJson("app", {
-								dependencies: { lib: "workspace:*" }
-							}),
-							[CONFIG_FILE]: createNadleConfig({
-								tasks: [{ name: "build", config: { dependsOn: ["packages:lib:build"] } }]
-							})
+				files: workspaceFixture({
+					root: { tasks: [{ name: "build" }] },
+					workspaces: {
+						"packages/lib": { tasks: [{ name: "build" }] },
+						"packages/app": {
+							pkg: { dependencies: { lib: "workspace:*" } },
+							tasks: [{ name: "build", config: { dependsOn: ["packages:lib:build"] } }]
 						}
 					}
-				}
+				})
 			});
 		});
 	});
@@ -198,26 +122,13 @@ describe("workspaces > implicit dependencies", () => {
 
 					expect(stdout).toRunInOrder("packages:lib:build", "packages:app:build");
 				},
-				files: {
-					[PNPM_WORKSPACE]: createPnpmWorkspace(),
-					[PACKAGE_JSON]: createPackageJson("root"),
-					[CONFIG_FILE]: createNadleConfig({
-						tasks: [{ name: "build" }]
-					}),
-
-					packages: {
-						lib: {
-							[PACKAGE_JSON]: createPackageJson("lib"),
-							[CONFIG_FILE]: createNadleConfig({ tasks: [{ name: "build" }] })
-						},
-						app: {
-							[CONFIG_FILE]: createNadleConfig({ tasks: [{ name: "build" }] }),
-							[PACKAGE_JSON]: createPackageJson("app", {
-								devDependencies: { lib: "workspace:*" }
-							})
-						}
+				files: workspaceFixture({
+					root: { tasks: [{ name: "build" }] },
+					workspaces: {
+						"packages/lib": { tasks: [{ name: "build" }] },
+						"packages/app": { tasks: [{ name: "build" }], pkg: { devDependencies: { lib: "workspace:*" } } }
 					}
-				}
+				})
 			});
 		});
 	});
@@ -226,29 +137,18 @@ describe("workspaces > implicit dependencies", () => {
 		it("should run root build after all child workspace builds", async () => {
 			await withFixture({
 				fixtureDir: "monorepo",
+				files: workspaceFixture({
+					root: { tasks: [{ name: "build" }] },
+					workspaces: {
+						"packages/lib": { tasks: [{ name: "build" }] },
+						"packages/app": { tasks: [{ name: "build" }] }
+					}
+				}),
 				testFn: async ({ exec }) => {
 					const stdout = await getStdout(exec`build --parallel`);
 
 					expect(stdout).toRunInOrder("packages:lib:build", "build");
 					expect(stdout).toRunInOrder("packages:app:build", "build");
-				},
-				files: {
-					[PNPM_WORKSPACE]: createPnpmWorkspace(),
-					[PACKAGE_JSON]: createPackageJson("root"),
-					[CONFIG_FILE]: createNadleConfig({
-						tasks: [{ name: "build" }]
-					}),
-
-					packages: {
-						lib: {
-							[PACKAGE_JSON]: createPackageJson("lib"),
-							[CONFIG_FILE]: createNadleConfig({ tasks: [{ name: "build" }] })
-						},
-						app: {
-							[PACKAGE_JSON]: createPackageJson("app"),
-							[CONFIG_FILE]: createNadleConfig({ tasks: [{ name: "build" }] })
-						}
-					}
 				}
 			});
 		});
@@ -256,32 +156,19 @@ describe("workspaces > implicit dependencies", () => {
 		it("should combine aggregation with implicit workspace deps", async () => {
 			await withFixture({
 				fixtureDir: "monorepo",
+				files: workspaceFixture({
+					root: { tasks: [{ name: "build" }] },
+					workspaces: {
+						"packages/lib": { tasks: [{ name: "build" }] },
+						"packages/app": { tasks: [{ name: "build" }], pkg: { dependencies: { lib: "workspace:*" } } }
+					}
+				}),
 				testFn: async ({ exec }) => {
 					const stdout = await getStdout(exec`build --parallel`);
 
 					// lib before app (implicit dep), both before root (aggregation)
 					expect(stdout).toRunInOrder("packages:lib:build", "packages:app:build");
 					expect(stdout).toRunInOrder("packages:app:build", "build");
-				},
-				files: {
-					[PNPM_WORKSPACE]: createPnpmWorkspace(),
-					[PACKAGE_JSON]: createPackageJson("root"),
-					[CONFIG_FILE]: createNadleConfig({
-						tasks: [{ name: "build" }]
-					}),
-
-					packages: {
-						lib: {
-							[PACKAGE_JSON]: createPackageJson("lib"),
-							[CONFIG_FILE]: createNadleConfig({ tasks: [{ name: "build" }] })
-						},
-						app: {
-							[CONFIG_FILE]: createNadleConfig({ tasks: [{ name: "build" }] }),
-							[PACKAGE_JSON]: createPackageJson("app", {
-								dependencies: { lib: "workspace:*" }
-							})
-						}
-					}
 				}
 			});
 		});
@@ -289,6 +176,13 @@ describe("workspaces > implicit dependencies", () => {
 		it("should not aggregate when implicitDependencies is false", async () => {
 			await withFixture({
 				fixtureDir: "monorepo",
+				files: workspaceFixture({
+					root: { tasks: [{ name: "build" }], configure: { implicitDependencies: false } },
+					workspaces: {
+						"packages/lib": { tasks: [{ name: "build" }] },
+						"packages/app": { tasks: [{ name: "build" }] }
+					}
+				}),
 				testFn: async ({ exec }) => {
 					const stdout = await getStdout(exec`build --parallel`);
 
@@ -296,25 +190,6 @@ describe("workspaces > implicit dependencies", () => {
 					expect(stdout).toContain("Task build DONE");
 					expect(stdout).toContain("Task packages:lib:build DONE");
 					expect(stdout).toContain("Task packages:app:build DONE");
-				},
-				files: {
-					[PNPM_WORKSPACE]: createPnpmWorkspace(),
-					[PACKAGE_JSON]: createPackageJson("root"),
-					[CONFIG_FILE]: createNadleConfig({
-						tasks: [{ name: "build" }],
-						configure: { implicitDependencies: false }
-					}),
-
-					packages: {
-						lib: {
-							[PACKAGE_JSON]: createPackageJson("lib"),
-							[CONFIG_FILE]: createNadleConfig({ tasks: [{ name: "build" }] })
-						},
-						app: {
-							[PACKAGE_JSON]: createPackageJson("app"),
-							[CONFIG_FILE]: createNadleConfig({ tasks: [{ name: "build" }] })
-						}
-					}
 				}
 			});
 		});
@@ -331,32 +206,13 @@ describe("workspaces > implicit dependencies", () => {
 					expect(stderr).toContain("packages:a:build");
 					expect(stderr).toContain("packages:b:build");
 				},
-				files: {
-					[PNPM_WORKSPACE]: createPnpmWorkspace(),
-					[PACKAGE_JSON]: createPackageJson("root"),
-					[CONFIG_FILE]: createNadleConfig({
-						tasks: [{ name: "build" }]
-					}),
-
-					packages: {
-						a: {
-							[CONFIG_FILE]: createNadleConfig({
-								tasks: [{ name: "build" }]
-							}),
-							[PACKAGE_JSON]: createPackageJson("a", {
-								dependencies: { b: "workspace:*" }
-							})
-						},
-						b: {
-							[CONFIG_FILE]: createNadleConfig({
-								tasks: [{ name: "build" }]
-							}),
-							[PACKAGE_JSON]: createPackageJson("b", {
-								dependencies: { a: "workspace:*" }
-							})
-						}
+				files: workspaceFixture({
+					root: { tasks: [{ name: "build" }] },
+					workspaces: {
+						"packages/a": { tasks: [{ name: "build" }], pkg: { dependencies: { b: "workspace:*" } } },
+						"packages/b": { tasks: [{ name: "build" }], pkg: { dependencies: { a: "workspace:*" } } }
 					}
-				}
+				})
 			});
 		});
 
@@ -368,70 +224,32 @@ describe("workspaces > implicit dependencies", () => {
 
 					expect(stdout).toContain("Task packages:a:build DONE");
 				},
-				files: {
-					[PNPM_WORKSPACE]: createPnpmWorkspace(),
-					[PACKAGE_JSON]: createPackageJson("root"),
-					[CONFIG_FILE]: createNadleConfig({
-						tasks: [{ name: "build" }]
-					}),
-
-					packages: {
-						b: {
-							[CONFIG_FILE]: createNadleConfig({
-								tasks: [{ name: "test" }]
-							}),
-							[PACKAGE_JSON]: createPackageJson("b", {
-								dependencies: { a: "workspace:*" }
-							})
-						},
-						a: {
-							[CONFIG_FILE]: createNadleConfig({
-								tasks: [{ name: "build" }]
-							}),
-							[PACKAGE_JSON]: createPackageJson("a", {
-								dependencies: { b: "workspace:*" }
-							})
-						}
+				files: workspaceFixture({
+					root: { tasks: [{ name: "build" }] },
+					workspaces: {
+						"packages/b": { tasks: [{ name: "test" }], pkg: { dependencies: { a: "workspace:*" } } },
+						"packages/a": { tasks: [{ name: "build" }], pkg: { dependencies: { b: "workspace:*" } } }
 					}
-				}
+				})
 			});
 		});
 
 		it("should show workspace-qualified names in cycle error", async () => {
 			await withFixture({
 				fixtureDir: "monorepo",
+				files: workspaceFixture({
+					root: { tasks: [{ name: "build" }] },
+					workspaces: {
+						"packages/a": { tasks: [{ name: "build" }], pkg: { dependencies: { b: "workspace:*" } } },
+						"packages/b": { tasks: [{ name: "build" }], pkg: { dependencies: { a: "workspace:*" } } }
+					}
+				}),
 				testFn: async ({ exec }) => {
 					const stderr = await getStderr(exec`build --parallel`);
 
 					expect(stderr).toContain("Cycle detected");
 					// Error message should include fully qualified workspace:task names
 					expect(stderr).toMatch(/packages:a:build.*packages:b:build|packages:b:build.*packages:a:build/);
-				},
-				files: {
-					[PNPM_WORKSPACE]: createPnpmWorkspace(),
-					[PACKAGE_JSON]: createPackageJson("root"),
-					[CONFIG_FILE]: createNadleConfig({
-						tasks: [{ name: "build" }]
-					}),
-
-					packages: {
-						a: {
-							[CONFIG_FILE]: createNadleConfig({
-								tasks: [{ name: "build" }]
-							}),
-							[PACKAGE_JSON]: createPackageJson("a", {
-								dependencies: { b: "workspace:*" }
-							})
-						},
-						b: {
-							[CONFIG_FILE]: createNadleConfig({
-								tasks: [{ name: "build" }]
-							}),
-							[PACKAGE_JSON]: createPackageJson("b", {
-								dependencies: { a: "workspace:*" }
-							})
-						}
-					}
 				}
 			});
 		});
@@ -441,36 +259,19 @@ describe("workspaces > implicit dependencies", () => {
 		it("should show implicit dependency annotation in dry-run output", async () => {
 			await withFixture({
 				fixtureDir: "monorepo",
+				files: workspaceFixture({
+					root: { tasks: [{ name: "build" }] },
+					workspaces: {
+						"packages/lib": { tasks: [{ name: "build" }] },
+						"packages/app": { tasks: [{ name: "build" }], pkg: { dependencies: { lib: "workspace:*" } } }
+					}
+				}),
 				testFn: async ({ exec }) => {
 					const stdout = await getStdout(exec`build --parallel --dry-run`);
 
 					expect(stdout).toContain("Execution plan");
 					// app:build should show implicit dep on lib:build
 					expect(stdout).toMatch(/packages:app:build.*implicit/);
-				},
-				files: {
-					[PNPM_WORKSPACE]: createPnpmWorkspace(),
-					[PACKAGE_JSON]: createPackageJson("root"),
-					[CONFIG_FILE]: createNadleConfig({
-						tasks: [{ name: "build" }]
-					}),
-
-					packages: {
-						lib: {
-							[PACKAGE_JSON]: createPackageJson("lib"),
-							[CONFIG_FILE]: createNadleConfig({
-								tasks: [{ name: "build" }]
-							})
-						},
-						app: {
-							[CONFIG_FILE]: createNadleConfig({
-								tasks: [{ name: "build" }]
-							}),
-							[PACKAGE_JSON]: createPackageJson("app", {
-								dependencies: { lib: "workspace:*" }
-							})
-						}
-					}
 				}
 			});
 		});
@@ -478,36 +279,19 @@ describe("workspaces > implicit dependencies", () => {
 		it("should not show implicit annotation for explicit deps", async () => {
 			await withFixture({
 				fixtureDir: "monorepo",
+				files: workspaceFixture({
+					root: { tasks: [{ name: "build" }] },
+					workspaces: {
+						"packages/lib": { tasks: [{ name: "build" }] },
+						"packages/app": { tasks: [{ name: "build" }], pkg: { dependencies: { lib: "workspace:*" } } }
+					}
+				}),
 				testFn: async ({ exec }) => {
 					const stdout = await getStdout(exec`build --parallel --dry-run`);
 
 					expect(stdout).toContain("Execution plan");
 					// lib:build line itself should not have implicit annotation
 					expect(stdout).toMatch(/Task packages:lib:build\s*$/m);
-				},
-				files: {
-					[PNPM_WORKSPACE]: createPnpmWorkspace(),
-					[PACKAGE_JSON]: createPackageJson("root"),
-					[CONFIG_FILE]: createNadleConfig({
-						tasks: [{ name: "build" }]
-					}),
-
-					packages: {
-						lib: {
-							[PACKAGE_JSON]: createPackageJson("lib"),
-							[CONFIG_FILE]: createNadleConfig({
-								tasks: [{ name: "build" }]
-							})
-						},
-						app: {
-							[CONFIG_FILE]: createNadleConfig({
-								tasks: [{ name: "build" }]
-							}),
-							[PACKAGE_JSON]: createPackageJson("app", {
-								dependencies: { lib: "workspace:*" }
-							})
-						}
-					}
 				}
 			});
 		});

--- a/packages/nadle/test/features/workspaces/workspaces-resolve-tasks.test.ts
+++ b/packages/nadle/test/features/workspaces/workspaces-resolve-tasks.test.ts
@@ -1,36 +1,17 @@
 import type fixturify from "fixturify";
 import { it, expect, describe } from "vitest";
-import { PACKAGE_JSON } from "@nadle/project-resolver";
-import { getStderr, expectPass, CONFIG_FILE, withFixture, PNPM_WORKSPACE, createNadleConfig, createPackageJson, createPnpmWorkspace } from "setup";
+import { getStderr, expectPass, withFixture, workspaceFixture } from "setup";
 
 describe("workspaces resolve tasks", () => {
-	const project: fixturify.DirJSON = {
-		[PNPM_WORKSPACE]: createPnpmWorkspace(),
-		[PACKAGE_JSON]: createPackageJson("root"),
-		[CONFIG_FILE]: createNadleConfig({
-			tasks: [{ name: "build" }, { name: "test" }]
-		}),
-
-		backend: {
-			[PACKAGE_JSON]: createPackageJson("backend"),
-			[CONFIG_FILE]: createNadleConfig({ tasks: [{ name: "build" }] })
-		},
-		frontend: {
-			[PACKAGE_JSON]: createPackageJson("frontend"),
-			[CONFIG_FILE]: createNadleConfig({ tasks: [{ name: "build" }] })
-		},
-
-		common: {
-			api: {
-				[PACKAGE_JSON]: createPackageJson("api"),
-				[CONFIG_FILE]: createNadleConfig({ tasks: [{ name: "build" }] })
-			},
-			utils: {
-				[PACKAGE_JSON]: createPackageJson("utils"),
-				[CONFIG_FILE]: createNadleConfig({ tasks: [{ name: "build" }] })
-			}
+	const project: fixturify.DirJSON = workspaceFixture({
+		root: { tasks: [{ name: "build" }, { name: "test" }] },
+		workspaces: {
+			backend: { tasks: [{ name: "build" }] },
+			frontend: { tasks: [{ name: "build" }] },
+			"common/api": { tasks: [{ name: "build" }] },
+			"common/utils": { tasks: [{ name: "build" }] }
 		}
-	};
+	});
 
 	it("should correct typo tasks", async () => {
 		await withFixture({


### PR DESCRIPTION
Part 3 of the test-setup cleanup.

## Problem
The workspace tests each hand-rolled the same triplet — `createPnpmWorkspace()` + `createPackageJson()` + `createNadleConfig()` — for a root plus N (sometimes nested) workspaces. The `files` object was 20-30 lines of boilerplate per test, repeated across the suite.

## Change
Add `workspaceFixture({ root, workspaces, pnpmWorkspace })` that builds the monorepo tree from a declarative spec:
- `workspaces` keyed by directory path; slash-separated paths (`"common/api"`) nest automatically
- per-workspace `tasks`, `configure`, `pkg` (deps/devDeps/version), `name` override
- `null` (or no tasks/config) → package-only workspace
- escape hatches for the edge cases: `rawConfig`, `configFileName`, `extraFiles`, `pnpmWorkspace: false`

Migrated 7 of the workspace test files (alias, basic-tasks, configure, depends-on-tasks, excluded-tasks, implicit-deps, resolve-tasks). **Net -280 lines.** Snapshots unchanged (the helper produces the same trees).

Left as-is: `detection`, `dependencies`, `working-dir`, `list` — these need escape-hatch-heavy shapes (empty/`.js` configs, npm/yarn lock files, raw config bodies, nested+preserve) where the explicit fixtures stay clearer.

## Verification
Full `nadle test` suite green; all 11 workspace files pass with byte-identical snapshots (no regeneration).

🤖 Generated with [Claude Code](https://claude.com/claude-code)