### PR TITLE
chore: hold vitest at 4.0.x in dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -16,6 +16,14 @@ updates:
       interval: "weekly"
     pull-request-branch-name:
       separator: "-"
+    # vitest 4.1.x ships a broken internal package resolution: @vitest/utils imports
+    # `createDOMElementFilter` from @vitest/pretty-format, which no longer exports it,
+    # crashing every test on startup. Hold at 4.0.x until the 4.1 line is fixed.
+    ignore:
+      - dependency-name: "vitest"
+        versions: ["4.1.x"]
+      - dependency-name: "@vitest/*"
+        versions: ["4.1.x"]
     groups:
       security-updates:
         applies-to: security-updates


### PR DESCRIPTION
## Why
The current dependabot PRs (#566/#567/#568) all bundle vitest `4.0.18 → 4.1.8` and fail because vitest 4.1.x has a broken internal package resolution:

```
SyntaxError: The requested module '@vitest/pretty-format' does not provide
an export named 'createDOMElementFilter'
  at @vitest/utils/dist/display.js
```

Every test crashes on startup. (#567 additionally hits an `import.meta.dirname` type regression from the transitive vite 7.3 bump.) These are upstream issues, not nadle code.

## Change
Add a dependabot `ignore` for the vitest `4.1.x` line (`vitest` + `@vitest/*`) so the groups stop pulling it. The non-vitest bumps in each group can then land. Revisit when 4.1.x resolution is fixed (or 4.2 ships).

🤖 Generated with [Claude Code](https://claude.com/claude-code)