### PR TITLE
chore: shard test suite and lift typecheck/API off the build-to-test path

### DIFF
--- a/.github/actions/setup/action.yml
+++ b/.github/actions/setup/action.yml
@@ -10,7 +10,7 @@ runs:
   using: composite
   steps:
     - name: Setup pnpm
-      uses: pnpm/action-setup@41ff72655975bd51cab0327fa583b6e92b6d3061 # v4.2.0
+      uses: pnpm/action-setup@0e279bb959325dab635dd2c09392533439d90093 # v6.0.8
       with:
         run_install: false
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -75,11 +75,10 @@ jobs:
       - name: Check
         run: nadle check
 
-      - name: Typecheck
-        run: pnpm exec tsc -b --noEmit
-
-      - name: Verify API surface
-        run: nadle packages:nadle:testNoWarningsAndUndocumentedAPI
+      # typecheck + the API-surface tasks both depend on the package build, so
+      # run them together — nadle dedupes the shared build within one invocation.
+      - name: Typecheck and verify API surface
+        run: nadle typecheck packages:nadle:testNoWarningsAndUndocumentedAPI
 
   test:
     name: Test Node ${{ matrix.node-version }} on ${{ matrix.os }} (shard ${{ matrix.shard }}/3)

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,14 +25,18 @@ concurrency:
 
 # Job dependency graph:
 #
-#   check ─────────────────────────────────────────────┐
-#                                                       │
-#           ┌── test (Ubuntu 22) ──────────────────────┤
-#           ├── test (macOS 22) ───────────────────────┤
-#   build ──┼── test (Windows 22) ─────────────────────┼── status
-#           └── test (Ubuntu 24) ──────────────────────┤
-#                                                       │
-#   (release-any-commit runs independently)  ──────────┘
+#   check (lint + typecheck + API surface) ─────────────┐
+#                                                        │
+#           ┌── test (Ubuntu 22, shards 1..3) ──────────┤
+#           ├── test (macOS 22, shards 1..3) ───────────┤
+#   build ──┼── test (Windows 22, shards 1..3) ─────────┼── status
+#           └── test (Ubuntu 24, shards 1..3) ──────────┤
+#                                                        │
+#   (release-any-commit runs independently)  ───────────┘
+#
+# build no longer typechecks or verifies the API surface — those moved to the
+# check job so they run in parallel instead of extending the build→test path.
+# The nadle suite (the slow leg) is split across 3 shards via vitest --shard.
 
 jobs:
   build:
@@ -46,18 +50,6 @@ jobs:
 
       - name: Build
         run: nadle build
-
-      - name: Typecheck
-        run: pnpm exec tsc -b --noEmit
-
-      - name: Verify API surface
-        working-directory: packages/nadle
-        run: |
-          pnpm exec api-extractor run
-          if grep -qE "Warning:|undocumented" index.api.md; then
-            echo "::error::API documentation contains warnings or undocumented items"
-            exit 1
-          fi
 
       - name: Upload build artifacts
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
@@ -83,8 +75,14 @@ jobs:
       - name: Check
         run: nadle check
 
+      - name: Typecheck
+        run: pnpm exec tsc -b --noEmit
+
+      - name: Verify API surface
+        run: nadle packages:nadle:testNoWarningsAndUndocumentedAPI
+
   test:
-    name: Test Node ${{ matrix.node-version }} on ${{ matrix.os }}
+    name: Test Node ${{ matrix.node-version }} on ${{ matrix.os }} (shard ${{ matrix.shard }}/3)
     if: ${{ github.event.pull_request.draft != true }}
     needs: [build]
     runs-on: ${{ matrix.os }}
@@ -97,9 +95,17 @@ jobs:
           - macos-latest
           - windows-latest
         node-version: ["22"]
+        shard: [1, 2, 3]
         include:
           - os: ubuntu-latest
             node-version: "24"
+            shard: 1
+          - os: ubuntu-latest
+            node-version: "24"
+            shard: 2
+          - os: ubuntu-latest
+            node-version: "24"
+            shard: 3
 
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
@@ -113,19 +119,25 @@ jobs:
           name: build-output
           path: packages
 
+      # The nadle suite dominates wall-clock, so split it across shards. The small
+      # packages run once (on shard 1) instead of redundantly on every shard.
+      - name: Test nadle
+        run: pnpm -F nadle exec vitest run --shard=${{ matrix.shard }}/3
+
       - name: Test kernel
+        if: ${{ matrix.shard == 1 }}
         run: pnpm -F @nadle/kernel exec vitest run
 
       - name: Test project
+        if: ${{ matrix.shard == 1 }}
         run: pnpm -F @nadle/project-resolver exec vitest run
 
-      - name: Test nadle
-        run: pnpm -F nadle exec vitest run
-
       - name: Test eslint-plugin
+        if: ${{ matrix.shard == 1 }}
         run: pnpm -F eslint-plugin-nadle exec vitest run
 
       - name: Test create-nadle
+        if: ${{ matrix.shard == 1 }}
         run: pnpm -F create-nadle exec vitest run
 
   status:


### PR DESCRIPTION
## Problem

CI critical path was **Build (70s) → slowest test leg (Windows 532s) ≈ 10 min**. Measured from run [27054814162](https://github.com/nadlejs/nadle/actions/runs/27054814162):

| Job | Time | Note |
|-----|------|------|
| Lint | 56s | already parallel, off critical path |
| Build | 70s | includes 9s typecheck + API that tests don't use |
| Test (Windows) | 532s | `Test nadle` step alone = **428s**; other 4 packages = 27s |
| Test (Ubuntu) | 295s | |

`vitest.config.ts` sets `fileParallelism: false` on CI, so the 77-file nadle suite runs serially in one process — sharding across runners is the way to parallelize it.

## Changes

- **Shard the nadle suite** across 3 shards per matrix leg (`vitest run --shard=i/3`). Windows `Test nadle` ~428s → ~140s. The small packages (kernel, project-resolver, eslint-plugin, create-nadle) run **once** on shard 1, not redundantly per shard.
- **Move Typecheck + API-surface verification** from the build job to the check job (parallel, off the build→test path). API check now routes through the existing `packages:nadle:testNoWarningsAndUndocumentedAPI` task instead of a hand-rolled build + grep.
- **Bump** `pnpm/action-setup` v4.2.0 → v6.0.8.

Lint was deliberately **not** split into per-task jobs — measurement showed it finishes at 56s, long before tests, so splitting it saves ~0 wall-clock and only multiplies per-job setup cost.

## Expected

Critical path ≈ Build(70s) → sharded test leg (~140-180s) instead of ~600s.

## Verification

- `vitest run --shard=2/3` locally → 28/77 files, 79s, green (one known graceful-cancellation flake #417 retried green).
- `prettier --check` on the workflow passes.
- Dry-run confirms `packages:nadle:testNoWarningsAndUndocumentedAPI` builds nadle + runs api-extractor + asserts no warnings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)