### PR TITLE
feat: add NadleError subclass hierarchy for catchable error types

### DIFF
--- a/packages/nadle/index.api.md
+++ b/packages/nadle/index.api.md
@@ -17,6 +17,11 @@ export type Awaitable<T> = T | PromiseLike<T>;
 export type Callback<T = unknown, P = void> = (params: P) => T;
 
 // @public
+export class ConfigurationError extends NadleError {
+    constructor(message: string);
+}
+
+// @public
 export function configure(options: NadleFileOptions): void;
 
 // @public
@@ -28,6 +33,11 @@ export interface CopyTaskOptions {
     readonly from: string;
     readonly include?: MaybeArray<string>;
     readonly to: string;
+}
+
+// @public
+export class CyclicDependencyError extends NadleError {
+    constructor(message: string);
 }
 
 // @public
@@ -109,7 +119,7 @@ export interface NadleBaseOptions {
 
 // @public
 export class NadleError extends Error {
-    constructor(message: string, errorCode?: number);
+    constructor(message: string, errorCode?: number, options?: ErrorOptions);
     readonly errorCode: number;
 }
 
@@ -217,9 +227,19 @@ export interface TaskConfigurationBuilder {
 export type TaskEnv = Record<string, string | number | boolean>;
 
 // @public
+export class TaskExecutionError extends NadleError {
+    constructor(message: string, options?: ErrorOptions);
+}
+
+// @public
 export type TaskFn = Callback<Awaitable<void>, {
     context: RunnerContext;
 }>;
+
+// @public
+export class TaskNotFoundError extends NadleError {
+    constructor(message: string);
+}
 
 // @public
 export const tasks: TasksAPI;

--- a/packages/nadle/src/core/engine/task-pool.ts
+++ b/packages/nadle/src/core/engine/task-pool.ts
@@ -3,11 +3,22 @@ import { type ExecutionContext } from "../context.js";
 import { TaskStatus } from "../interfaces/registered-task.js";
 import { type TaskIdentifier } from "../models/task-identifier.js";
 import { PoolExecutor, type Executor, InlineExecutor } from "./executor.js";
+import { NadleError, TaskExecutionError } from "../utilities/nadle-error.js";
 import { type Notifier, type WorkerParams, type WorkerMessage } from "./worker.js";
 
 // It seems this is the error message thrown by TinyPool when a worker is terminated
 // See: https://github.com/tinylibs/tinypool/blob/main/src/index.ts#L438
 const TERMINATING_WORKER_ERROR = "Terminating worker thread";
+
+function toTaskExecutionError(error: unknown, label: string): NadleError {
+	if (error instanceof NadleError) {
+		return error;
+	}
+
+	const message = error instanceof Error ? error.message : String(error);
+
+	return new TaskExecutionError(`Task ${label} failed: ${message}`, { cause: error });
+}
 
 export class TaskPool {
 	private readonly executor: Executor;
@@ -62,7 +73,8 @@ export class TaskPool {
 			}
 
 			await this.context.eventEmitter.onTaskFailed(task);
-			throw error;
+
+			throw toTaskExecutionError(error, task.label);
 		}
 
 		await Promise.all(Array.from(this.getNextReadyTasks(taskId)).map((readyTaskId) => this.pushTask(readyTaskId)));

--- a/packages/nadle/src/core/engine/task-scheduler.ts
+++ b/packages/nadle/src/core/engine/task-scheduler.ts
@@ -2,11 +2,11 @@ import { highlight } from "../utilities/utils.js";
 import { Messages } from "../utilities/messages.js";
 import { EnsureMap } from "../utilities/ensure-map.js";
 import { RIGHT_ARROW } from "../utilities/constants.js";
-import { NadleError } from "../utilities/nadle-error.js";
 import { MaybeArray } from "../utilities/maybe-array.js";
 import { ResolvedTask } from "../interfaces/resolved-task.js";
 import { type SchedulerDependencies } from "./scheduler-types.js";
 import { type TaskIdentifier } from "../models/task-identifier.js";
+import { CyclicDependencyError } from "../utilities/nadle-error.js";
 import { resolveImplicitDependencies } from "./implicit-dependency-resolver.js";
 
 export class TaskScheduler {
@@ -73,7 +73,7 @@ export class TaskScheduler {
 			if (startIndex !== -1) {
 				const message = Messages.CycleDetected([...paths.slice(startIndex), dependency].map(highlight).join(` ${RIGHT_ARROW} `));
 				this.deps.logger.error(message);
-				throw new NadleError(message);
+				throw new CyclicDependencyError(message);
 			}
 
 			this.detectCycle(dependency, [...paths, dependency]);

--- a/packages/nadle/src/core/options/cli-options.ts
+++ b/packages/nadle/src/core/options/cli-options.ts
@@ -6,6 +6,7 @@ import { type NadleCLIOptions } from "./types.js";
 import { Messages } from "../utilities/messages.js";
 import { SupportLogLevels } from "../utilities/consola.js";
 import { SupportReporters } from "../reporting/reporters.js";
+import { ConfigurationError } from "../utilities/nadle-error.js";
 
 export const CLIOptions = {
 	configFile: {
@@ -191,6 +192,6 @@ function createWorkerCoercer(type: "min" | "max") {
 			return workers;
 		}
 
-		throw new Error(Messages.InvalidWorkerConfig(type, workers));
+		throw new ConfigurationError(Messages.InvalidWorkerConfig(type, workers));
 	};
 }

--- a/packages/nadle/src/core/options/options-resolver.ts
+++ b/packages/nadle/src/core/options/options-resolver.ts
@@ -6,9 +6,9 @@ import { type Project, configureProject, ROOT_WORKSPACE_ID } from "@nadle/projec
 
 import { clamp } from "../utilities/utils.js";
 import { ProjectResolver } from "./project-resolver.js";
-import { NadleError } from "../utilities/nadle-error.js";
 import { TaskInputResolver } from "./task-input-resolver.js";
 import { ResolvedTask } from "../interfaces/resolved-task.js";
+import { ConfigurationError } from "../utilities/nadle-error.js";
 import { DEFAULT_CACHE_DIR_NAME } from "../utilities/constants.js";
 import { type TaskRegistry } from "../registration/task-registry.js";
 import { type DefaultLogger } from "../interfaces/defaults/default-logger.js";
@@ -78,7 +78,7 @@ export class OptionsResolver {
 		} else {
 			const message = `Invalid worker value: ${configValue}`;
 			this.logger.error(message);
-			throw new NadleError(message);
+			throw new ConfigurationError(message);
 		}
 
 		return clamp(result, 1, this.availableWorkers);

--- a/packages/nadle/src/core/options/project-resolver.ts
+++ b/packages/nadle/src/core/options/project-resolver.ts
@@ -12,6 +12,7 @@ import {
 } from "@nadle/project-resolver";
 
 import { Messages } from "../utilities/messages.js";
+import { ConfigurationError } from "../utilities/nadle-error.js";
 
 type WorkspaceInitializer = (workspaceId: string, configFilePath: string) => Promise<void>;
 
@@ -48,7 +49,7 @@ export class ProjectResolver {
 			const resolvedConfigPath = Path.resolve(projectPath, rootConfigFilePath);
 
 			if (!(await isPathExists(resolvedConfigPath))) {
-				throw new Error(Messages.SpecifiedConfigFileNotFound(resolvedConfigPath));
+				throw new ConfigurationError(Messages.SpecifiedConfigFileNotFound(resolvedConfigPath));
 			}
 
 			return resolvedConfigPath;
@@ -62,6 +63,6 @@ export class ProjectResolver {
 			}
 		}
 
-		throw new Error(Messages.ConfigFileNotFound(projectPath));
+		throw new ConfigurationError(Messages.ConfigFileNotFound(projectPath));
 	}
 }

--- a/packages/nadle/src/core/options/task-input-resolver.ts
+++ b/packages/nadle/src/core/options/task-input-resolver.ts
@@ -5,8 +5,8 @@ import { highlight } from "../utilities/utils.js";
 import { Messages } from "../utilities/messages.js";
 import { suggest } from "../utilities/suggestion.js";
 import { type Logger } from "../interfaces/logger.js";
-import { NadleError } from "../utilities/nadle-error.js";
 import { TaskIdentifier } from "../models/task-identifier.js";
+import { TaskNotFoundError } from "../utilities/nadle-error.js";
 import { type ResolvedTask } from "../interfaces/resolved-task.js";
 
 export class TaskInputResolver {
@@ -87,7 +87,7 @@ export class TaskInputResolver {
 			suggestions: formatSuggestions(resolvedTask.suggestions)
 		});
 		this.logger.error(message);
-		throw new NadleError(message);
+		throw new TaskNotFoundError(message);
 	}
 
 	private resolveWorkspace(workspaceInput: string, workspaceLabels: string[]): string {
@@ -96,7 +96,7 @@ export class TaskInputResolver {
 		if (suggestedWorkspace.result === undefined) {
 			const message = Messages.UnresolvedWorkspace(workspaceInput, formatSuggestions(suggestedWorkspace.suggestions));
 			this.logger.error(message);
-			throw new NadleError(message);
+			throw new TaskNotFoundError(message);
 		}
 
 		return suggestedWorkspace.result;

--- a/packages/nadle/src/core/registration/api.ts
+++ b/packages/nadle/src/core/registration/api.ts
@@ -2,6 +2,7 @@ import { VALID_TASK_NAME_PATTERN } from "@nadle/kernel";
 
 import { Messages } from "../utilities/messages.js";
 import { getCurrentInstance } from "../nadle-context.js";
+import { ConfigurationError } from "../utilities/nadle-error.js";
 import type { Task, RunnerContext } from "../interfaces/task.js";
 import { type RegisteredTask } from "../interfaces/registered-task.js";
 import type { Callback, Resolver, Awaitable } from "../utilities/types.js";
@@ -72,7 +73,7 @@ export const tasks: TasksAPI = {
 		validateTaskName(name);
 
 		if (taskRegistry.hasTaskName(name)) {
-			throw new Error(Messages.DuplicatedTaskName(name, taskRegistry.workspaceId ?? ""));
+			throw new ConfigurationError(Messages.DuplicatedTaskName(name, taskRegistry.workspaceId ?? ""));
 		}
 
 		let configCollector: Callback<TaskConfiguration> | TaskConfiguration = () => ({});
@@ -114,6 +115,6 @@ function computeTaskInfo(task: TaskFn | Task | undefined, optionsResolver?: Reso
 
 function validateTaskName(name: string): void {
 	if (!VALID_TASK_NAME_PATTERN.test(name)) {
-		throw new Error(Messages.InvalidTaskName(`[${name}]`));
+		throw new ConfigurationError(Messages.InvalidTaskName(`[${name}]`));
 	}
 }

--- a/packages/nadle/src/core/registration/file-option-registry.ts
+++ b/packages/nadle/src/core/registration/file-option-registry.ts
@@ -2,6 +2,7 @@ import { isRootWorkspaceId } from "@nadle/project-resolver";
 
 import { Messages } from "../utilities/messages.js";
 import { type NadleFileOptions } from "../options/types.js";
+import { ConfigurationError } from "../utilities/nadle-error.js";
 
 export class FileOptionRegistry {
 	private workspaceId: string | null = null;
@@ -17,7 +18,7 @@ export class FileOptionRegistry {
 		}
 
 		if (!isRootWorkspaceId(this.workspaceId)) {
-			throw new Error(Messages.InvalidConfigureUsage());
+			throw new ConfigurationError(Messages.InvalidConfigureUsage());
 		}
 
 		this.registry.set(this.workspaceId, options);
@@ -25,7 +26,7 @@ export class FileOptionRegistry {
 
 	public get(workspaceId: string): NadleFileOptions {
 		if (!isRootWorkspaceId(workspaceId)) {
-			throw new Error(Messages.InvalidConfigureUsage());
+			throw new ConfigurationError(Messages.InvalidConfigureUsage());
 		}
 
 		return this.registry.get(workspaceId) ?? {};

--- a/packages/nadle/src/core/registration/task-registry.ts
+++ b/packages/nadle/src/core/registration/task-registry.ts
@@ -2,6 +2,7 @@ import { type Project, getWorkspaceById, getWorkspaceByLabelOrId } from "@nadle/
 
 import { Messages } from "../utilities/messages.js";
 import { TaskIdentifier } from "../models/task-identifier.js";
+import { TaskNotFoundError } from "../utilities/nadle-error.js";
 import { type RegisteredTask } from "../interfaces/registered-task.js";
 
 interface BufferedTask extends Omit<RegisteredTask, "label"> {}
@@ -80,7 +81,7 @@ export class TaskRegistry {
 		const taskId = TaskIdentifier.create(targetWorkspace.id, taskNameInput);
 
 		if (!this.registry.has(taskId)) {
-			throw new Error(Messages.UnresolvedTaskWithoutSuggestions(taskNameInput, targetWorkspace.label));
+			throw new TaskNotFoundError(Messages.UnresolvedTaskWithoutSuggestions(taskNameInput, targetWorkspace.label));
 		}
 
 		return taskId;

--- a/packages/nadle/src/core/utilities/index.ts
+++ b/packages/nadle/src/core/utilities/index.ts
@@ -1,4 +1,4 @@
-export { NadleError } from "./nadle-error.js";
 export { MaybeArray } from "./maybe-array.js";
 export type { Callback, Awaitable, Resolver } from "./types.js";
 export { type SupportLogLevel, SupportLogLevels } from "./consola.js";
+export { NadleError, ConfigurationError, TaskNotFoundError, CyclicDependencyError, TaskExecutionError } from "./nadle-error.js";

--- a/packages/nadle/src/core/utilities/nadle-error.ts
+++ b/packages/nadle/src/core/utilities/nadle-error.ts
@@ -9,9 +9,60 @@ export class NadleError extends Error {
 	 */
 	public readonly errorCode: number;
 
-	public constructor(message: string, errorCode: number = 1) {
-		super(message);
+	public constructor(message: string, errorCode: number = 1, options?: ErrorOptions) {
+		super(message, options);
 		this.name = "NadleError";
 		this.errorCode = errorCode;
+	}
+}
+
+/**
+ * Thrown when configuration is invalid or cannot be loaded — a missing or
+ * malformed config file, invalid options, or invalid task inputs.
+ *
+ * @public
+ */
+export class ConfigurationError extends NadleError {
+	public constructor(message: string) {
+		super(message, 2);
+		this.name = "ConfigurationError";
+	}
+}
+
+/**
+ * Thrown when a requested task cannot be resolved within the project.
+ *
+ * @public
+ */
+export class TaskNotFoundError extends NadleError {
+	public constructor(message: string) {
+		super(message, 3);
+		this.name = "TaskNotFoundError";
+	}
+}
+
+/**
+ * Thrown when the task graph contains a cyclic dependency.
+ *
+ * @public
+ */
+export class CyclicDependencyError extends NadleError {
+	public constructor(message: string) {
+		super(message, 4);
+		this.name = "CyclicDependencyError";
+	}
+}
+
+/**
+ * Thrown when a task fails during execution.
+ *
+ * @public
+ */
+export class TaskExecutionError extends NadleError {
+	public constructor(message: string, options?: ErrorOptions) {
+		// Keeps the generic exit code 1 — a failing task is the baseline failure
+		// mode and changing its exit code would break existing CLI contracts.
+		super(message, 1, options);
+		this.name = "TaskExecutionError";
 	}
 }

--- a/packages/nadle/test/__snapshots__/options/stacktrace.test.ts.snap
+++ b/packages/nadle/test/__snapshots__/options/stacktrace.test.ts.snap
@@ -24,6 +24,6 @@ Command: /ROOT/nadle.mjs --max-workers 1 --no-footer throwable --stacktrace
 [log]
 <Bold><Red>RUN FAILED</Red></BoldDim> in <Bold>{duration}</BoldDim> <Dim>(<Bold>2</BoldDim><Dim> tasks executed, <Bold>1</BoldDim><Dim> task failed)</BoldDim>
 ---------- Stderr ------------
-[error] Error: This is an error
+[error] TaskExecutionError: Task throwable failed: This is an error
     {stackTrace...}
 `;

--- a/packages/nadle/test/types/utilities.test-d.ts
+++ b/packages/nadle/test/types/utilities.test-d.ts
@@ -54,6 +54,6 @@ describe.concurrent("NadleError", () => {
 	});
 
 	it("is constructable with message and optional errorCode", () => {
-		expectTypeOf(NadleError).constructorParameters.toEqualTypeOf<[string, number?]>();
+		expectTypeOf(NadleError).constructorParameters.toEqualTypeOf<[string, number?, ErrorOptions?]>();
 	});
 });

--- a/packages/nadle/test/unit/nadle-error.test.ts
+++ b/packages/nadle/test/unit/nadle-error.test.ts
@@ -1,6 +1,12 @@
 import { it, expect, describe } from "vitest";
 
-import { NadleError } from "../../src/core/utilities/nadle-error.js";
+import {
+	NadleError,
+	TaskNotFoundError,
+	ConfigurationError,
+	TaskExecutionError,
+	CyclicDependencyError
+} from "../../src/core/utilities/nadle-error.js";
 
 describe.concurrent("NadleError", () => {
 	it("extends Error", () => {
@@ -27,5 +33,39 @@ describe.concurrent("NadleError", () => {
 		expect(() => {
 			throw new NadleError("boom", 2);
 		}).toThrow("boom");
+	});
+});
+
+describe.concurrent("NadleError subclasses", () => {
+	const cases = [
+		{ errorCode: 2, name: "ConfigurationError", Subclass: ConfigurationError },
+		{ errorCode: 3, name: "TaskNotFoundError", Subclass: TaskNotFoundError },
+		{ errorCode: 4, name: "CyclicDependencyError", Subclass: CyclicDependencyError },
+		{ errorCode: 1, name: "TaskExecutionError", Subclass: TaskExecutionError }
+	];
+
+	it.each(cases)("$name extends NadleError and Error", ({ Subclass }) => {
+		const error = new Subclass("boom");
+
+		expect(error).toBeInstanceOf(NadleError);
+		expect(error).toBeInstanceOf(Error);
+	});
+
+	it.each(cases)("$name sets name and message", ({ name, Subclass }) => {
+		const error = new Subclass("something broke");
+
+		expect(error.name).toBe(name);
+		expect(error.message).toBe("something broke");
+	});
+
+	it.each(cases)("$name has errorCode $errorCode", ({ Subclass, errorCode }) => {
+		expect(new Subclass("boom").errorCode).toBe(errorCode);
+	});
+
+	it("is distinguishable via instanceof", () => {
+		const error: NadleError = new TaskNotFoundError("missing");
+
+		expect(error instanceof TaskNotFoundError).toBe(true);
+		expect(error instanceof CyclicDependencyError).toBe(false);
 	});
 });

--- a/spec/12-error-handling.md
+++ b/spec/12-error-handling.md
@@ -10,6 +10,22 @@ NadleError is a specialized error class with a numeric exit code.
 | `errorCode` | number | `1`            | Process exit code used when this error reaches the top level. |
 | `name`      | string | `"NadleError"` | Error name for stack traces.                                  |
 
+## NadleError Subclasses
+
+NadleError has a hierarchy of subclasses so consumers can catch specific error
+categories programmatically. Each subclass fixes a distinct `errorCode`.
+
+| Subclass                | `errorCode` | Raised when                                                                                                                                                                      |
+| ----------------------- | ----------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `ConfigurationError`    | `2`         | Config is missing or invalid: config file not found, invalid options or task inputs, invalid task name, duplicate task name, invalid `configure()` usage, invalid worker config. |
+| `TaskNotFoundError`     | `3`         | A requested task or workspace cannot be resolved.                                                                                                                                |
+| `CyclicDependencyError` | `4`         | The task graph contains a cycle.                                                                                                                                                 |
+| `TaskExecutionError`    | `1`         | A task throws during execution. Wraps the original error as `cause`; keeps exit code `1` to preserve the baseline failure contract.                                              |
+
+Invariant violations (states that should be impossible — unset working
+directory, project not yet configured, exhaustiveness fallbacks) remain plain
+`Error`, not NadleError subclasses.
+
 ## Error Propagation
 
 Errors flow through the system in this chain:
@@ -31,7 +47,9 @@ Task function throws
 3. The pool's `pushTask` method catches the rejection.
 4. If the error is a worker termination (cancellation), `onTaskCanceled` is emitted
    and the error is swallowed.
-5. Otherwise, `onTaskFailed` is emitted and the error is re-thrown.
+5. Otherwise, `onTaskFailed` is emitted. A NadleError is re-thrown as-is; any
+   other error is wrapped in a `TaskExecutionError` (with the original as `cause`)
+   before being re-thrown.
 6. The re-thrown error propagates to the `execute()` method.
 7. `onExecutionFailed` is emitted with the error.
 8. The process exits with the appropriate code.

--- a/spec/CHANGELOG.md
+++ b/spec/CHANGELOG.md
@@ -16,6 +16,11 @@ Versioning follows [Semantic Versioning](https://semver.org/):
   New `agent` reporter emits compact, plain, low-noise output (one line per task
   plus a summary line) for AI agents and scripts. `default` remains the
   human-oriented reporter.
+- 12-error-handling: NadleError subclass hierarchy — `ConfigurationError` (exit
+  code 2), `TaskNotFoundError` (3), `CyclicDependencyError` (4), and
+  `TaskExecutionError` (1, wraps the original task error as `cause`). Lets
+  consumers catch specific error categories. Invariant violations remain plain
+  `Error`.
 
 ## 1.6.0 — 2026-02-25
 


### PR DESCRIPTION
Closes #409.

## What

Adds typed subclasses of `NadleError` so consumers (and the CLI) can `catch` specific error categories programmatically instead of matching on messages.

| Subclass | `errorCode` | Raised when |
|----------|-------------|-------------|
| `ConfigurationError` | 2 | config not found, invalid options/task inputs, invalid/duplicate task name, invalid `configure()` usage, invalid worker config |
| `TaskNotFoundError` | 3 | unresolved task or workspace |
| `CyclicDependencyError` | 4 | cycle in the task graph |
| `TaskExecutionError` | 1 | a task throws at runtime — wraps the original as `cause` |

## Decisions

- **`TaskExecutionError` keeps exit code 1.** Changing the task-failure exit code would break the existing CLI contract (`expectFail` and friends assert exit 1). Distinct codes are reserved for resolution-time errors. The original error is preserved via `cause`.
- **Invariant violations stay plain `Error`** — unset working directory, project not yet configured, exhaustiveness fallbacks. These are bugs, not user-facing errors (per "no error handling for impossible scenarios").
- **`configure()` `TypeError` contract left intact** — it's a documented `@throws {TypeError}`.
- `NadleError` gains an optional `ErrorOptions` third param so subclasses can carry `cause`.

## Throw sites migrated

registration (`api.ts`, `task-registry.ts`, `file-option-registry.ts`), options resolution (`task-input-resolver.ts`, `options-resolver.ts`, `cli-options.ts`), project resolution (`project-resolver.ts`), scheduler (`task-scheduler.ts`), and the task-pool failure path.

## Spec / API

- `spec/12-error-handling.md` documents the hierarchy; spec bumped to 1.7.0.
- `index.api.md` regenerated — 4 new `@public` classes.

## Verification

- 192 unit + error-path tests pass locally (build, typecheck, api-extractor, eslint, prettier, cspell, knip all green via pre-commit). Full integration suite left to CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)