### PR TITLE
test: add randomized parallelism ordering test

### DIFF
--- a/packages/nadle/test/options/random-parallel.test.ts
+++ b/packages/nadle/test/options/random-parallel.test.ts
@@ -1,0 +1,58 @@
+import { it, expect, describe } from "vitest";
+import { fixture, getStdout, withGeneratedFixture } from "setup";
+
+/**
+ * Generates a random DAG of `size` tasks. Task `i` may depend on any subset of
+ * tasks with a smaller index, which guarantees the graph stays acyclic.
+ * Returns the config source and the list of `[dependency, dependent]` edges.
+ */
+function randomGraph(size: number): { config: string; edges: [string, string][] } {
+	const names = Array.from({ length: size }, (_, index) => `task${index}`);
+	const edges: [string, string][] = [];
+	const lines = ['import { tasks } from "nadle";', ""];
+
+	for (let index = 0; index < size; index++) {
+		const dependencies = names.slice(0, index).filter(() => Math.random() < 0.5);
+
+		for (const dependency of dependencies) {
+			edges.push([dependency, names[index]!]);
+		}
+
+		if (dependencies.length === 0) {
+			lines.push(`tasks.register("${names[index]}");`);
+		} else {
+			lines.push(`tasks.register("${names[index]}").config({ dependsOn: ${JSON.stringify(dependencies)} });`);
+		}
+	}
+
+	return { edges, config: lines.join("\n") + "\n" };
+}
+
+describe.concurrent("--parallel (randomized)", () => {
+	for (let iteration = 1; iteration <= 5; iteration++) {
+		it(`respects dependency order under parallel execution ${iteration}`, async () => {
+			const size = 6 + Math.floor(Math.random() * 5); // 6..10 tasks
+			const maxWorkers = 1 + Math.floor(Math.random() * 4); // 1..4 workers
+			const { edges, config } = randomGraph(size);
+
+			const files = fixture().packageJson("random-parallel").configRaw(config).build();
+			const targets = Array.from({ length: size }, (_, index) => `task${index}`).join(" ");
+
+			await withGeneratedFixture({
+				files,
+				testFn: async ({ exec }) => {
+					const stdout = await getStdout(exec`${targets} --parallel --max-workers ${String(maxWorkers)}`);
+
+					for (const [dependency, dependent] of edges) {
+						const dependencyDone = stdout.indexOf(`Task ${dependency} DONE`);
+						const dependentDone = stdout.indexOf(`Task ${dependent} DONE`);
+
+						expect(dependencyDone, `'${dependency}' should finish before '${dependent}' (graph: ${JSON.stringify(edges)})`).toBeLessThan(
+							dependentDone
+						);
+					}
+				}
+			});
+		});
+	}
+});


### PR DESCRIPTION
Closes #32.

## What

Adds a property-style test that generates a **random task DAG** and verifies the scheduler always respects dependency order under parallel execution.

Each of 5 iterations:
- builds a graph of 6–10 tasks where task `i` may depend on any subset of lower-indexed tasks (keeps the graph acyclic by construction),
- runs every task with `--parallel --max-workers <1..4>`,
- asserts each dependency's `DONE` line precedes its dependent's.

This complements the fixed `parallel.test.ts` (two hard-coded tasks) by exercising varied graph shapes and worker-pool sizes. The failure message embeds the generated edge list for reproducibility.

## Verification

`pnpm -F nadle exec vitest run random-parallel` — 5/5 pass, no type errors. eslint + prettier clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)