### PR TITLE
feat: allow omitting optionsResolver for tasks with no required options

### DIFF
--- a/packages/nadle/index.api.md
+++ b/packages/nadle/index.api.md
@@ -247,8 +247,8 @@ export const tasks: TasksAPI;
 // @public
 export interface TasksAPI {
     register(name: string): TaskConfigurationBuilder;
+    register<Options>(name: string, optTask: Task<Options>, ...optionsResolver: {} extends Options ? [optionsResolver?: Resolver<Options>] : [optionsResolver: Resolver<Options>]): TaskConfigurationBuilder;
     register(name: string, fnTask: TaskFn): TaskConfigurationBuilder;
-    register<Options>(name: string, optTask: Task<Options>, optionsResolver: Resolver<Options>): TaskConfigurationBuilder;
 }
 
 // (No @packageDocumentation comment for this package)

--- a/packages/nadle/src/core/registration/api.ts
+++ b/packages/nadle/src/core/registration/api.ts
@@ -23,21 +23,28 @@ export interface TasksAPI {
 	register(name: string): TaskConfigurationBuilder;
 
 	/**
+	 * Register a task with options and a resolver.
+	 *
+	 * The resolver may be omitted when the task's options have no required fields
+	 * (i.e. an empty object satisfies `Options`); otherwise it is mandatory.
+	 * @param name - The unique name of the task.
+	 * @param optTask - The task definition with options.
+	 * @param optionsResolver - A resolver for the task's options.
+	 * @returns ConfigBuilder for further configuration.
+	 */
+	register<Options>(
+		name: string,
+		optTask: Task<Options>,
+		...optionsResolver: {} extends Options ? [optionsResolver?: Resolver<Options>] : [optionsResolver: Resolver<Options>]
+	): TaskConfigurationBuilder;
+
+	/**
 	 * Register a task with a task function.
 	 * @param name - The unique name of the task.
 	 * @param fnTask - The function to execute for this task.
 	 * @returns ConfigBuilder for further configuration.
 	 */
 	register(name: string, fnTask: TaskFn): TaskConfigurationBuilder;
-
-	/**
-	 * Register a task with options and a resolver.
-	 * @param name - The unique name of the task.
-	 * @param optTask - The task definition with options.
-	 * @param optionsResolver - A resolver for the task's options.
-	 * @returns ConfigBuilder for further configuration.
-	 */
-	register<Options>(name: string, optTask: Task<Options>, optionsResolver: Resolver<Options>): TaskConfigurationBuilder;
 }
 
 /**
@@ -106,11 +113,7 @@ function computeTaskInfo(task: TaskFn | Task | undefined, optionsResolver?: Reso
 		return { run: task, empty: false, optionsResolver: undefined };
 	}
 
-	if (optionsResolver === undefined) {
-		throw new Error("Option builder is required for option task");
-	}
-
-	return { ...task, empty: false, optionsResolver };
+	return { ...task, empty: false, optionsResolver: optionsResolver ?? (() => ({})) };
 }
 
 function validateTaskName(name: string): void {

--- a/packages/nadle/test/features/optional-task-options.test.ts
+++ b/packages/nadle/test/features/optional-task-options.test.ts
@@ -1,0 +1,35 @@
+import { it, expect, describe } from "vitest";
+import { fixture, getStdout, withGeneratedFixture } from "setup";
+
+/**
+ * A task whose options have no required fields can be registered without an
+ * options resolver. At runtime the resolver defaults to `() => ({})`, so the
+ * task receives an empty options object.
+ */
+const config = `import { tasks, type Task } from "nadle";
+
+interface GreetOptions {
+	readonly name?: string;
+}
+
+const GreetTask: Task<GreetOptions> = {
+	run: ({ options, context }) => {
+		context.logger.log(\`Hello \${options.name ?? "world"}\`);
+	}
+};
+
+tasks.register("greet", GreetTask);
+`;
+
+describe.concurrent("optional task options", () => {
+	it("runs an options task registered without a resolver", () =>
+		withGeneratedFixture({
+			files: fixture().packageJson("optional-options").configRaw(config).build(),
+			testFn: async ({ exec }) => {
+				const stdout = await getStdout(exec`greet`);
+
+				expect(stdout).toRun("greet");
+				expect(stdout).toContain("Hello world");
+			}
+		}));
+});

--- a/packages/nadle/test/types/register.test-d.ts
+++ b/packages/nadle/test/types/register.test-d.ts
@@ -1,5 +1,11 @@
 import { it, describe, expectTypeOf } from "vitest";
-import { tasks, Inputs, Outputs, PnpmTask, type TaskConfigurationBuilder } from "nadle";
+import { tasks, Inputs, Outputs, CopyTask, PnpmTask, type Task, type TaskConfigurationBuilder } from "nadle";
+
+interface OptionalOptions {
+	readonly flag?: boolean;
+}
+
+const optionalTask: Task<OptionalOptions> = { run: () => {} };
 
 describe.concurrent("tasks.register", () => {
 	it("can register tasks with various signatures", () => {
@@ -10,6 +16,16 @@ describe.concurrent("tasks.register", () => {
 
 		expectTypeOf(tasks.register("eslint", PnpmTask, { args: ["eslint"] })).toEqualTypeOf<TaskConfigurationBuilder>();
 		expectTypeOf(tasks.register("eslint", PnpmTask, { args: "eslint" })).toEqualTypeOf<TaskConfigurationBuilder>();
+	});
+
+	it("can omit the resolver when the task options have no required fields", () => {
+		expectTypeOf(tasks.register("opt", optionalTask)).toEqualTypeOf<TaskConfigurationBuilder>();
+		expectTypeOf(tasks.register("opt", optionalTask, { flag: true })).toEqualTypeOf<TaskConfigurationBuilder>();
+	});
+
+	it("still requires the resolver when the task options have required fields", () => {
+		// @ts-expect-error CopyTaskOptions requires `from` and `to`, so the resolver cannot be omitted.
+		tasks.register("copy", CopyTask);
 	});
 
 	it("can configure task metadata", () => {

--- a/spec/01-task.md
+++ b/spec/01-task.md
@@ -10,11 +10,16 @@ config file loading, calls to `tasks.register()` delegate to the active Nadle in
 via an `AsyncLocalStorage` context. Each Nadle instance owns its own task registry,
 ensuring full isolation between instances. There are three registration forms:
 
-| Form       | Parameters                              | Description                                                                                             |
-| ---------- | --------------------------------------- | ------------------------------------------------------------------------------------------------------- |
-| No-op      | `name`                                  | Registers a lifecycle-only task with no function body. Useful as an aggregation point for dependencies. |
-| Function   | `name`, `taskFn`                        | Registers a task with a function that receives a runner context.                                        |
-| Typed task | `name`, `taskObject`, `optionsResolver` | Registers a reusable task type with typed options and a resolver.                                       |
+| Form       | Parameters                               | Description                                                                                             |
+| ---------- | ---------------------------------------- | ------------------------------------------------------------------------------------------------------- |
+| No-op      | `name`                                   | Registers a lifecycle-only task with no function body. Useful as an aggregation point for dependencies. |
+| Function   | `name`, `taskFn`                         | Registers a task with a function that receives a runner context.                                        |
+| Typed task | `name`, `taskObject`, `optionsResolver?` | Registers a reusable task type with typed options. The resolver provides those options.                 |
+
+For the typed-task form, the `optionsResolver` is **optional when the options type has no
+required fields** (an empty object satisfies it); in that case the options default to an
+empty object (`{}`). When the options type has at least one required field, the resolver is
+mandatory.
 
 All three forms return a **configuration builder** that exposes a `.config()` method
 (see [02-task-configuration.md](02-task-configuration.md)).

--- a/spec/CHANGELOG.md
+++ b/spec/CHANGELOG.md
@@ -8,6 +8,14 @@ Versioning follows [Semantic Versioning](https://semver.org/):
 - **MINOR**: New concept, new section, or materially expanded rules
 - **PATCH**: Clarifications, corrections, wording improvements
 
+## 1.8.0 — 2026-06-07
+
+### Changed
+
+- 01-task: Typed-task registration — `optionsResolver` is now optional when the
+  options type has no required fields (an empty object satisfies it), defaulting
+  to `{}`. It remains mandatory when any field is required.
+
 ## 1.7.0 — 2026-06-07
 
 ### Added

--- a/spec/README.md
+++ b/spec/README.md
@@ -1,6 +1,6 @@
 # Nadle Specification
 
-**Version**: 1.7.0
+**Version**: 1.8.0
 
 This directory contains the language-agnostic specification for Nadle, a type-safe,
 Gradle-inspired task runner for Node.js.


### PR DESCRIPTION
Closes #90.

## What

A typed task whose options type has **no required fields** can now be registered without an options resolver:

```ts
interface GreetOptions { readonly name?: string }
const GreetTask: Task<GreetOptions> = { run: ({ options }) => { /* ... */ } };

tasks.register("greet", GreetTask);            // ✅ resolver optional now
tasks.register("greet", GreetTask, { name: "x" }); // ✅ still allowed
```

When the options type has a required field, the resolver stays **mandatory**:

```ts
tasks.register("copy", CopyTask);              // ❌ type error — `from`/`to` required
```

## How

- **Type**: the typed-task overload uses a conditional-rest parameter — `...optionsResolver: {} extends Options ? [optionsResolver?: Resolver<Options>] : [optionsResolver: Resolver<Options>]`. `{} extends Options` is true only when every field is optional.
- **Overload order**: moved the typed-task overload ahead of the function overload so a 2-arg `register(name, taskObject)` resolves to the typed form instead of failing against `TaskFn`.
- **Runtime**: `computeTaskInfo` defaults the resolver to `() => ({})` when omitted (previously threw "Option builder is required").

## Spec / API / docs

- `spec/01-task.md`: typed-task resolver documented as optional-when-no-required-fields; spec bumped to 1.8.0.
- `index.api.md` regenerated (api-extractor green).
- Typedoc API page regenerates from the updated TSDoc on build.

## Verification

- Type test (`register.test-d.ts`): omit allowed for optional-only options; `@ts-expect-error` confirms `CopyTask` still needs a resolver.
- Integration test (`optional-task-options.test.ts`): a no-resolver options task runs and receives `{}`.
- `testAPI`, typecheck, eslint, prettier all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)