### PR TITLE
feat: add documentSymbol support to the language server

### DIFF
--- a/packages/docs/docs/getting-started/features/editor-support.md
+++ b/packages/docs/docs/getting-started/features/editor-support.md
@@ -45,6 +45,10 @@ Hovering over a task name in a `dependsOn` value shows a tooltip with the task's
 
 Ctrl+click (Cmd+click on macOS) a task name in a `dependsOn` value to jump to its `tasks.register()` call in the same file.
 
+### File Structure / Outline
+
+The outline view lists every task registered in the file (one entry per `tasks.register()` call), so you can navigate large config files and jump straight to a task. Typed tasks also show their task type (e.g. `ExecTask`).
+
 ## Supported File Formats
 
 The LSP activates on all Nadle config file formats:

--- a/packages/language-server/src/document-symbols.ts
+++ b/packages/language-server/src/document-symbols.ts
@@ -1,0 +1,28 @@
+import { SymbolKind, type DocumentSymbol } from "vscode-languageserver";
+
+import type { DocumentAnalysis } from "./analyzer.js";
+
+/**
+ * Builds the document outline (File Structure) for a nadle config file: one
+ * symbol per `tasks.register(...)` call. Registrations whose name could not be
+ * statically resolved (dynamic/computed names) are omitted.
+ */
+export function getDocumentSymbols(analysis: DocumentAnalysis): DocumentSymbol[] {
+	const symbols: DocumentSymbol[] = [];
+
+	for (const registration of analysis.registrations) {
+		if (registration.name === null) {
+			continue;
+		}
+
+		symbols.push({
+			name: registration.name,
+			kind: SymbolKind.Function,
+			range: registration.registrationRange,
+			selectionRange: registration.nameRange,
+			detail: registration.taskObjectName ?? undefined
+		});
+	}
+
+	return symbols;
+}

--- a/packages/language-server/src/index.ts
+++ b/packages/language-server/src/index.ts
@@ -1,4 +1,5 @@
 export { analyzeDocument } from "./analyzer.js";
 export { getReferences } from "./references.js";
 export { DocumentStore } from "./document-store.js";
+export { getDocumentSymbols } from "./document-symbols.js";
 export type { DependencyRef, DocumentAnalysis, TaskConfigInfo, TaskRegistration } from "./analyzer.js";

--- a/packages/language-server/src/server.ts
+++ b/packages/language-server/src/server.ts
@@ -12,6 +12,7 @@ import { getCompletions } from "./completions.js";
 import type { LspContext } from "./lsp-context.js";
 import { DocumentStore } from "./document-store.js";
 import { computeDiagnostics } from "./diagnostics.js";
+import { getDocumentSymbols } from "./document-symbols.js";
 import { type ProjectContext, discoverProjectContext } from "./project-context.js";
 
 const DEBOUNCE_MS = 200;
@@ -39,6 +40,7 @@ connection.onInitialize((params): InitializeResult => {
 			hoverProvider: true,
 			definitionProvider: true,
 			referencesProvider: true,
+			documentSymbolProvider: true,
 			textDocumentSync: TextDocumentSyncKind.Incremental,
 			completionProvider: {
 				resolveProvider: false,
@@ -171,6 +173,16 @@ connection.onReferences(({ context, position, textDocument }) => {
 	}
 
 	return getReferences(store.getAllAnalyses(), position, doc, context);
+});
+
+connection.onDocumentSymbol(({ textDocument }) => {
+	const analysis = store.getAnalysis(textDocument.uri);
+
+	if (!analysis) {
+		return [];
+	}
+
+	return getDocumentSymbols(analysis);
 });
 
 connection.onNotification("nadle/refreshProject", () => {

--- a/packages/language-server/test/document-symbols.test.ts
+++ b/packages/language-server/test/document-symbols.test.ts
@@ -1,0 +1,60 @@
+import Path from "node:path";
+import Fs from "node:fs/promises";
+
+import { it, expect, describe } from "vitest";
+import { analyzeDocument } from "src/analyzer.js";
+import { SymbolKind } from "vscode-languageserver";
+import { getDocumentSymbols } from "src/document-symbols.js";
+
+const fixturesDir = Path.resolve(import.meta.dirname, "__fixtures__");
+
+async function analyzeFixture(name: string) {
+	const content = await Fs.readFile(Path.resolve(fixturesDir, name), "utf-8");
+
+	return { ...analyzeDocument(content, name), uri: `file:///${name}` };
+}
+
+describe("getDocumentSymbols", () => {
+	it("returns one Function symbol per task registration", async () => {
+		const analysis = await analyzeFixture("valid.ts");
+		const symbols = getDocumentSymbols(analysis);
+
+		expect(symbols.map((s) => s.name)).toEqual(["clean-cache", "compile", "deploy", "lint", "build", "release", "clean"]);
+		expect(symbols.every((s) => s.kind === SymbolKind.Function)).toBe(true);
+	});
+
+	it("uses the registration range as range and the name range as selectionRange", async () => {
+		const analysis = await analyzeFixture("valid.ts");
+		const symbols = getDocumentSymbols(analysis);
+
+		const compile = symbols.find((s) => s.name === "compile")!;
+		const compileReg = analysis.registrations.find((r) => r.name === "compile")!;
+
+		expect(compile.range).toEqual(compileReg.registrationRange);
+		expect(compile.selectionRange).toEqual(compileReg.nameRange);
+	});
+
+	it("sets detail to the task object name for typed tasks", async () => {
+		const analysis = await analyzeFixture("valid.ts");
+		const symbols = getDocumentSymbols(analysis);
+
+		expect(symbols.find((s) => s.name === "compile")!.detail).toBe("ExecTask");
+		expect(symbols.find((s) => s.name === "clean")!.detail).toBe("DeleteTask");
+		// No-op and function forms have no task object.
+		expect(symbols.find((s) => s.name === "clean-cache")!.detail).toBeUndefined();
+		expect(symbols.find((s) => s.name === "deploy")!.detail).toBeUndefined();
+	});
+
+	it("skips registrations with non-literal (dynamic) names", async () => {
+		const analysis = await analyzeFixture("dynamic-names.ts");
+		const symbols = getDocumentSymbols(analysis);
+
+		expect(symbols.map((s) => s.name)).toEqual(["lint"]);
+	});
+
+	it("returns an empty list for a file with no registrations", () => {
+		const analysis = { ...analyzeDocument("export const x = 1;\n", "empty.ts"), uri: "file:///empty.ts" };
+
+		expect(getDocumentSymbols(analysis)).toEqual([]);
+	});
+});


### PR DESCRIPTION
Closes #529.

## What

Implements `textDocument/documentSymbol` so editors render a **File Structure / Outline** view for `nadle.config.*` files — one symbol per `tasks.register(...)` call.

| Property | Value |
|----------|-------|
| `name` | the task name |
| `kind` | `SymbolKind.Function` |
| `range` | the full `tasks.register(...)` call |
| `selectionRange` | the task-name string literal |
| `detail` | the task object name for typed tasks (e.g. `ExecTask`), else unset |

Registrations whose name is non-literal (variable, template, call) are skipped, matching how hover/references already treat dynamic names.

## How

The analyzer already produces `TaskRegistration[]` with `name`, `nameRange`, `registrationRange`, and `taskObjectName`, so the handler is a pure map over `analysis.registrations` — same shape as `references.ts`/`definitions.ts`.

- new `src/document-symbols.ts` (exported from the package index)
- `documentSymbolProvider: true` capability + `connection.onDocumentSymbol` in `server.ts`
- no VS Code client change needed — the standard LSP client advertises documentSymbol automatically

This lets the IntelliJ plugin (and any editor) drop custom regex-based structure views in favor of the analyzer's AST data.

## Verification

`pnpm -F @nadle/language-server test` — 77 pass (5 new): per-task symbols, range/selectionRange mapping, typed-task `detail`, dynamic-name skip, empty file. Typecheck + eslint + prettier green.

Docs: editor-support page gains a File Structure / Outline section.

🤖 Generated with [Claude Code](https://claude.com/claude-code)