### PR TITLE
feat: add filter option to PnpmTask for workspace scoping

### DIFF
--- a/packages/nadle/index.api.md
+++ b/packages/nadle/index.api.md
@@ -166,6 +166,7 @@ export const PnpmTask: Task<PnpmTaskOptions>;
 // @public
 export interface PnpmTaskOptions {
     readonly args: MaybeArray<string>;
+    readonly filter?: MaybeArray<string>;
 }
 
 // @public

--- a/packages/nadle/src/builtin-tasks/pnpm-task.ts
+++ b/packages/nadle/src/builtin-tasks/pnpm-task.ts
@@ -9,16 +9,21 @@ import { defineTask } from "../core/registration/define-task.js";
 export interface PnpmTaskOptions {
 	/** Arguments to pass to the pnpm CLI. */
 	readonly args: MaybeArray<string>;
+	/** Workspace package(s) to scope the command to, passed as pnpm `--filter` flags. */
+	readonly filter?: MaybeArray<string>;
 }
 
 /**
  * Task for running pnpm commands.
  *
  * Executes pnpm with the provided arguments in the given working directory.
+ * When `filter` is set, each value is prepended as a `--filter <value>` flag so
+ * the command runs only in the matching workspace package(s).
  */
 export const PnpmTask = defineTask<PnpmTaskOptions>({
 	run: async ({ options, context }) => {
-		const args = MaybeArray.toArray(options.args);
+		const filterArgs = MaybeArray.toArray(options.filter ?? []).flatMap((filter) => ["--filter", filter]);
+		const args = [...filterArgs, ...MaybeArray.toArray(options.args)];
 
 		context.logger.info(`Running pnpm command: pnpm ${args.join(" ")}`);
 

--- a/packages/nadle/test/__fixtures__/pnpm-task/nadle.config.ts
+++ b/packages/nadle/test/__fixtures__/pnpm-task/nadle.config.ts
@@ -3,3 +3,7 @@ import { tasks, PnpmTask } from "nadle";
 tasks.register("pass", PnpmTask, { args: ["exec", "tsc", "./src/pass.ts", "--noEmit", "--pretty"] });
 tasks.register("fail", PnpmTask, { args: ["exec", "tsc", "./src/nonexistent.ts", "--noEmit", "--pretty"] });
 tasks.register("echo", PnpmTask, { args: ["exec", "echo", "hello"] });
+tasks.register("filtered", PnpmTask, {
+	args: ["exec", "echo", "hello"],
+	filter: "@nadle/internal-nadle-test-fixtures-pnpm-task"
+});

--- a/packages/nadle/test/builtin-tasks/pnpm-task.test.ts
+++ b/packages/nadle/test/builtin-tasks/pnpm-task.test.ts
@@ -1,7 +1,7 @@
 import Path from "node:path";
 
-import { it, describe } from "vitest";
-import { createExec, expectFail, expectPass, fixturesDir } from "setup";
+import { it, expect, describe } from "vitest";
+import { getStdout, createExec, expectFail, expectPass, fixturesDir } from "setup";
 
 describe("pnpm Task", () => {
 	const exec = createExec({ cwd: Path.join(fixturesDir, "pnpm-task") });
@@ -16,5 +16,11 @@ describe("pnpm Task", () => {
 
 	it("throw error when running tsc command with error ts file", async () => {
 		await expectFail(exec`fail`);
+	});
+
+	it("prepends --filter flags when filter is set", async () => {
+		const stdout = await getStdout(exec`filtered --log-level info`);
+
+		expect(stdout).toContain("Running pnpm command: pnpm --filter @nadle/internal-nadle-test-fixtures-pnpm-task exec echo hello");
 	});
 });

--- a/spec/10-builtin-tasks.md
+++ b/spec/10-builtin-tasks.md
@@ -28,18 +28,20 @@ Executes a pnpm command. Specialized variant of ExecTask with `pnpm` as the comm
 
 ### Options
 
-| Field  | Type                       | Required | Description                  |
-| ------ | -------------------------- | -------- | ---------------------------- |
-| `args` | string or array of strings | Yes      | Arguments to pass to `pnpm`. |
+| Field    | Type                       | Required | Description                                                          |
+| -------- | -------------------------- | -------- | -------------------------------------------------------------------- |
+| `args`   | string or array of strings | Yes      | Arguments to pass to `pnpm`.                                         |
+| `filter` | string or array of strings | No       | Workspace package(s) to scope the command to, as `--filter` flag(s). |
 
 ### Behavior
 
-1. Normalize arguments to an array.
-2. Spawn `pnpm` with the arguments.
-3. Set working directory to the task's `workingDir`.
-4. Force color output (`FORCE_COLOR=1`).
-5. Stream combined output to the task logger.
-6. Await subprocess completion.
+1. Normalize `filter` to an array and expand each value into a `--filter <value>` pair.
+2. Normalize `args` to an array and append it after the filter flags.
+3. Spawn `pnpm` with the combined arguments.
+4. Set working directory to the task's `workingDir`.
+5. Force color output (`FORCE_COLOR=1`).
+6. Stream combined output to the task logger.
+7. Await subprocess completion.
 
 ## NodeTask
 

--- a/spec/CHANGELOG.md
+++ b/spec/CHANGELOG.md
@@ -8,6 +8,13 @@ Versioning follows [Semantic Versioning](https://semver.org/):
 - **MINOR**: New concept, new section, or materially expanded rules
 - **PATCH**: Clarifications, corrections, wording improvements
 
+## 1.9.0 — 2026-06-07
+
+### Added
+
+- 10-builtin-tasks: PnpmTask `filter` option — scopes the command to specific
+  workspace package(s) by prepending `--filter <value>` flag(s) before `args`.
+
 ## 1.8.0 — 2026-06-07
 
 ### Changed

--- a/spec/README.md
+++ b/spec/README.md
@@ -1,6 +1,6 @@
 # Nadle Specification
 
-**Version**: 1.8.0
+**Version**: 1.9.0
 
 This directory contains the language-agnostic specification for Nadle, a type-safe,
 Gradle-inspired task runner for Node.js.


### PR DESCRIPTION
Closes #102.

## What

`PnpmTaskOptions` gains an optional **`filter`** (`string | string[]`). Each value becomes a `--filter <value>` flag, prepended before `args`, scoping the pnpm command to the matching workspace package(s):

```ts
tasks.register("build-api", PnpmTask, { args: ["run", "build"], filter: "api" });
// → pnpm --filter api run build

tasks.register("test-libs", PnpmTask, { args: "test", filter: ["core", "utils"] });
// → pnpm --filter core --filter utils test
```

Backward compatible — `filter` is optional, existing registrations are unchanged.

## How

`MaybeArray.toArray(options.filter ?? []).flatMap(f => ["--filter", f])`, prepended to the normalized `args`. Mirrors the existing `MaybeArray` pattern used across builtin tasks.

## Spec / API / docs

- `spec/10-builtin-tasks.md`: `filter` option + updated behavior steps; spec bumped to 1.9.0.
- `index.api.md` regenerated.
- Typedoc API page regenerates from the new TSDoc.

## Verification

New integration test runs `filtered --log-level info` against the pnpm-task fixture and asserts the logged command is `pnpm --filter <pkg> exec echo hello` (real pnpm exec, exits 0). All 4 pnpm-task tests pass; typecheck/eslint/prettier/testAPI green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)