### PR TITLE
feat: support selecting tasks by glob pattern

### DIFF
--- a/packages/docs/docs/guides/executing-task.md
+++ b/packages/docs/docs/guides/executing-task.md
@@ -42,6 +42,28 @@ With `--parallel`, Nadle will run the `eslint`, `prettier`, and `spell-check` ta
 as long as there are no dependencies between them. If any of these tasks declare dependencies,
 Nadle will still ensure the dependencies are completed before running the dependent task, even in parallel mode.
 
+## Running Tasks by Glob Pattern
+
+Instead of listing task names individually, you can select them with a glob pattern. Any task
+argument that contains a glob character (`*`, `?`, `[`, `]`, `{`, `}`, `!`) is matched against the
+registered task names:
+
+```sh
+nadle "build*"
+```
+
+This runs every task whose name starts with `build` (e.g. `build`, `build-css`, `build-js`). Quote
+the pattern so your shell does not expand it first.
+
+Patterns also work with a workspace qualifier and with [`--exclude`](../config-reference.md#exclude):
+
+```sh
+nadle "api:build*"          # only matching tasks in the api workspace
+nadle "build*" --exclude "build-*-dev"
+```
+
+If a pattern matches no task, Nadle exits with an error rather than running nothing.
+
 ## Running Task with Dependencies
 
 If a task declares dependencies using the [`dependsOn`](./configuring-task.md#dependson) option,

--- a/packages/nadle/src/core/options/task-input-resolver.ts
+++ b/packages/nadle/src/core/options/task-input-resolver.ts
@@ -1,4 +1,5 @@
 import { uniq } from "lodash-es";
+import micromatch from "micromatch";
 import { type Project, getAllWorkspaces, getWorkspaceByLabelOrId } from "@nadle/project-resolver";
 
 import { highlight } from "../utilities/utils.js";
@@ -24,8 +25,16 @@ export class TaskInputResolver {
 				.filter(Boolean)
 		);
 
-		return taskInputs.map((taskInput) => {
+		return taskInputs.flatMap((taskInput) => {
 			const { taskNameInput, workspaceInput } = TaskIdentifier.parser(taskInput);
+
+			if (isGlob(taskNameInput)) {
+				const targetWorkspaceId =
+					workspaceInput === undefined ? targetWorkspace : getWorkspaceByLabelOrId(project, this.resolveWorkspace(workspaceInput, workspaces)).id;
+				const fallbackWorkspaceId = workspaceInput === undefined ? fallbackWorkspace : undefined;
+
+				return this.resolveGlob({ project, taskInput, taskNameInput, targetWorkspaceId, fallbackWorkspaceId });
+			}
 
 			let resolvedTask: string;
 
@@ -53,8 +62,43 @@ export class TaskInputResolver {
 				(workspaceInput !== undefined && TaskIdentifier.parser(resolvedTask).workspaceInput !== workspaceInput) ||
 				(workspaceInput === undefined && TaskIdentifier.parser(resolvedTask).workspaceInput !== targetWorkspace);
 
-			return { corrected, rawInput: taskInput, taskId: resolvedTask };
+			return [{ corrected, rawInput: taskInput, taskId: resolvedTask }];
 		});
+	}
+
+	private resolveGlob(options: {
+		project: Project;
+		taskInput: string;
+		taskNameInput: string;
+		targetWorkspaceId: string;
+		fallbackWorkspaceId: string | undefined;
+	}): ResolvedTask[] {
+		const { project, taskInput, taskNameInput, targetWorkspaceId, fallbackWorkspaceId } = options;
+
+		const matchIn = (workspaceId: string): ResolvedTask[] =>
+			micromatch(this.taskNamesGetter(workspaceId), taskNameInput).map((taskName) => ({
+				corrected: false,
+				rawInput: taskInput,
+				taskId: TaskIdentifier.create(workspaceId, taskName)
+			}));
+
+		const matches = matchIn(targetWorkspaceId);
+
+		if (matches.length > 0) {
+			return matches;
+		}
+
+		if (fallbackWorkspaceId !== undefined) {
+			const fallbackMatches = matchIn(getWorkspaceByLabelOrId(project, fallbackWorkspaceId).id);
+
+			if (fallbackMatches.length > 0) {
+				return fallbackMatches;
+			}
+		}
+
+		const message = Messages.UnresolvedTaskPattern({ targetWorkspaceId, fallbackWorkspaceId, pattern: taskNameInput });
+		this.logger.error(message);
+		throw new TaskNotFoundError(message);
 	}
 
 	private resolveTask(options: {
@@ -101,6 +145,10 @@ export class TaskInputResolver {
 
 		return suggestedWorkspace.result;
 	}
+}
+
+function isGlob(taskNameInput: string): boolean {
+	return /[*?[\]{}!]/.test(taskNameInput);
 }
 
 function formatSuggestions(suggestions: string[]): string {

--- a/packages/nadle/src/core/utilities/messages.ts
+++ b/packages/nadle/src/core/utilities/messages.ts
@@ -27,6 +27,9 @@ export const Messages = {
 	}) =>
 		`Task ${highlight(options.taskNameInput)} not found in ${highlight(options.targetWorkspaceId)}${options.fallbackWorkspaceId ? ` nor ${highlight(options.fallbackWorkspaceId)}` : ""} workspace. ${options.suggestions}`,
 
+	UnresolvedTaskPattern: (options: { pattern: string; targetWorkspaceId: string; fallbackWorkspaceId: string | undefined }) =>
+		`No task matching pattern ${highlight(options.pattern)} found in ${highlight(options.targetWorkspaceId)}${options.fallbackWorkspaceId ? ` nor ${highlight(options.fallbackWorkspaceId)}` : ""} workspace.`,
+
 	EmptyWorkspaceLabel: (workspaceId: string) => `Workspace ${highlight(workspaceId)} alias can not be empty.`,
 	UnresolvedWorkspace: (workspaceInput: string, suggestions: string) => `Workspace ${highlight(workspaceInput)} not found. ${suggestions}`,
 	WorkspaceNotFound: (workspaceInput: string, availableWorkspaces: string) =>

--- a/packages/nadle/test/features/glob-task-pattern.test.ts
+++ b/packages/nadle/test/features/glob-task-pattern.test.ts
@@ -1,0 +1,42 @@
+import { it, expect, describe } from "vitest";
+import { config, settle, fixture, getStdout, withGeneratedFixture } from "setup";
+
+const files = fixture().packageJson("glob-pattern").config(config().task("build").task("build-css").task("build-js").task("test")).build();
+
+describe.concurrent("glob task patterns", () => {
+	it("runs every task matching a glob pattern", () =>
+		withGeneratedFixture({
+			files,
+			testFn: async ({ exec }) => {
+				const stdout = await getStdout(exec`build*`);
+
+				expect(stdout).toRun("build");
+				expect(stdout).toRun("build-css");
+				expect(stdout).toRun("build-js");
+				expect(stdout).not.toRun("test");
+			}
+		}));
+
+	it("excludes tasks matching a glob pattern", () =>
+		withGeneratedFixture({
+			files,
+			testFn: async ({ exec }) => {
+				const stdout = await getStdout(exec`build* --exclude build-*`);
+
+				expect(stdout).toRun("build");
+				expect(stdout).not.toRun("build-css");
+				expect(stdout).not.toRun("build-js");
+			}
+		}));
+
+	it("fails when a glob pattern matches no task", () =>
+		withGeneratedFixture({
+			files,
+			testFn: async ({ exec }) => {
+				const { stderr, exitCode } = await settle(exec`nope*`);
+
+				expect(exitCode).not.toBe(0);
+				expect(stderr).toContain("No task matching pattern");
+			}
+		}));
+});

--- a/packages/nadle/test/unit/task-input-resolver.test.ts
+++ b/packages/nadle/test/unit/task-input-resolver.test.ts
@@ -95,4 +95,26 @@ describe.concurrent("TaskInputResolver", () => {
 	it("suggests correct task and workspace name for typos", () => {
 		expect(resolver.resolve(["backe:biuld"], project).map(ResolvedTask.getId)).toEqual(["backend:build"]);
 	});
+
+	it("expands a glob pattern to all matching tasks in the target workspace", () => {
+		expect(resolver.resolve(["pre*"], project).map(ResolvedTask.getId)).toEqual(["frontend:prepare"]);
+		expect(resolver.resolve(["*e*"], project).map(ResolvedTask.getId)).toEqual([
+			"frontend:clean",
+			"frontend:prepare",
+			"frontend:dev",
+			"frontend:test"
+		]);
+	});
+
+	it("expands a workspace-qualified glob within that workspace", () => {
+		expect(resolver.resolve(["backend:*"], project).map(ResolvedTask.getId)).toEqual(["backend:build", "backend:test"]);
+	});
+
+	it("falls back to the root workspace when a glob matches nothing in the target workspace", () => {
+		expect(resolver.resolve(["dep*"], project).map(ResolvedTask.getId)).toEqual(["root:deploy"]);
+	});
+
+	it("throws when a glob pattern matches no task", () => {
+		expect(() => resolver.resolve(["nope*"], project)).toThrowPlainMessage("No task matching pattern nope* found in frontend nor root workspace.");
+	});
 });

--- a/spec/09-cli.md
+++ b/spec/09-cli.md
@@ -11,6 +11,21 @@ nadle [tasks...] [options]
 - `tasks` — zero or more task names or task identifiers to execute.
 - If no tasks are specified and stdin is a TTY, Nadle enters interactive task selection.
 
+### Glob Task Selection
+
+A task name (the name segment, after any workspace qualifier) may be a glob pattern — any input
+containing `*`, `?`, `[`, `]`, `{`, `}`, or `!`. Patterns are matched against the registered task
+names of the resolved workspace:
+
+- An unqualified pattern (e.g. `build*`) matches task names in the target workspace; if none match
+  there, the root workspace is tried as a fallback.
+- A workspace-qualified pattern (e.g. `backend:build*`) matches only within that workspace.
+- A pattern that matches no task is an error (exit code 3) — patterns never silently expand to
+  nothing.
+
+Glob patterns apply equally to the `--exclude` option. Because task names never contain glob
+characters, an input is treated as a glob if and only if it contains one.
+
 ## Flags
 
 ### Execution Options

--- a/spec/CHANGELOG.md
+++ b/spec/CHANGELOG.md
@@ -8,6 +8,16 @@ Versioning follows [Semantic Versioning](https://semver.org/):
 - **MINOR**: New concept, new section, or materially expanded rules
 - **PATCH**: Clarifications, corrections, wording improvements
 
+## 1.10.0 — 2026-06-07
+
+### Added
+
+- 09-cli: Glob task selection — a task-name input containing glob characters
+  (`*`, `?`, `[`, `]`, `{`, `}`, `!`) expands to all registered task names that
+  match, in the target workspace (falling back to root) or within a
+  workspace-qualified pattern. Applies to `--exclude` too. A pattern matching no
+  task is an error (exit code 3).
+
 ## 1.9.0 — 2026-06-07
 
 ### Added

--- a/spec/README.md
+++ b/spec/README.md
@@ -1,6 +1,6 @@
 # Nadle Specification
 
-**Version**: 1.9.0
+**Version**: 1.10.0
 
 This directory contains the language-agnostic specification for Nadle, a type-safe,
 Gradle-inspired task runner for Node.js.


### PR DESCRIPTION
Closes #145.

## What

Task arguments can now be glob patterns:

```sh
nadle "build*"                 # runs build, build-css, build-js, ...
nadle "api:build*"             # matching tasks in the api workspace
nadle "build*" --exclude "build-*-dev"
```

Any input containing a glob character (`* ? [ ] { } !`) is expanded against the registered task names via `micromatch`.

## Semantics

- **Unqualified** pattern → matches the target workspace; if nothing matches there, falls back to the root workspace (same fallback as exact-name resolution).
- **Workspace-qualified** pattern (`backend:build*`) → matches only within that workspace.
- Applies to **`--exclude`** as well.
- A pattern matching **no task** throws `TaskNotFoundError` (exit code 3) — patterns never silently expand to nothing.
- Task names are restricted to `[a-z0-9-]`, so they never contain glob characters: an input is a glob **iff** it contains one. No ambiguity, fully backward compatible.

## How

`TaskInputResolver.resolve` now `flatMap`s inputs; a glob input routes to `resolveGlob`, which runs `micromatch(taskNames, pattern)` in the resolved workspace(s) and maps each match to a `ResolvedTask`. `micromatch` is already a dependency (used by CopyTask).

## Spec / docs

- `spec/09-cli.md`: Glob Task Selection section; spec bumped to 1.9.0.
- `docs/guides/executing-task.md`: Running Tasks by Glob Pattern.

## Verification

- Unit tests (`task-input-resolver.test.ts`): expansion, `*e*` multi-match ordering, workspace-qualified, root fallback, zero-match throw.
- Integration tests (`glob-task-pattern.test.ts`): runs all matches, `--exclude` glob, zero-match failure (exit ≠ 0).
- 15 tests pass; typecheck/eslint/prettier/cspell green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)