### PR TITLE
feat: support CLI argument passthrough to tasks via -- separator

### DIFF
--- a/docs/superpowers/plans/2026-06-10-cli-passthrough-args.md
+++ b/docs/superpowers/plans/2026-06-10-cli-passthrough-args.md
@@ -1,0 +1,929 @@
+# CLI Argument Passthrough (`--`) Implementation Plan
+
+> **For agent workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** `nadle test -- -u` passes `-u` to the `test` task's underlying command (and to custom tasks via `context.passthroughArgs`), per the approved design in `docs/superpowers/specs/2026-06-10-cli-passthrough-args-design.md` (issue #525).
+
+**Architecture:** Capture args after `--` via yargs `populate--`, thread them through `NadleCLIOptions` → `NadleResolvedOptions` (already serialized to workers), expose on `RunnerContext` only for explicitly requested tasks, auto-append in exec-based builtin tasks, and include them in the cache key of requested tasks.
+
+**Tech Stack:** TypeScript ESM, yargs, vitest (integration tests spawn the built CLI via execa; **run `npx nadle build` before integration tests**).
+
+**House rules that apply to every task:**
+
+- Run commands as single atomic invocations (no `&&`, no pipes).
+- Integration tests run against `packages/nadle/lib/`, so after any `src/` change: `npx nadle build` first, then `pnpm -F nadle test <file>`.
+- Pre-commit hook runs prettier/eslint/cspell — if it fails on formatting, run `npx prettier --write <file>` and re-commit.
+- Commit messages: conventional commits, lowercase subject, trailer `Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>` after a blank line.
+
+---
+
+### Task 1: Capture `--` args into options types
+
+**Files:**
+
+- Modify: `packages/nadle/src/cli.ts:68-70`
+- Modify: `packages/nadle/src/core/options/types.ts` (NadleCLIOptions, NadleResolvedOptions)
+- Modify: `packages/nadle/src/core/options/cli-options-resolver.ts:43-51`
+- Modify: `packages/nadle/src/core/options/options-resolver.ts:20-34`
+- Test (create): `packages/nadle/test/unit/cli-options-resolver.test.ts`
+
+- [ ] **Step 1: Write the failing unit test**
+
+Create `packages/nadle/test/unit/cli-options-resolver.test.ts`:
+
+```ts
+import { it, expect, describe } from "vitest";
+import { CLIOptionsResolver } from "src/core/options/cli-options-resolver.js";
+
+describe("CLIOptionsResolver", () => {
+	it("captures args after -- into passthroughArgs", () => {
+		const options = CLIOptionsResolver.resolve({ "--": ["-u", "--reporter", "dot"], tasks: ["test"] });
+
+		expect(options.passthroughArgs).toEqual(["-u", "--reporter", "dot"]);
+	});
+
+	it("omits passthroughArgs when -- is absent", () => {
+		const options = CLIOptionsResolver.resolve({ tasks: ["test"] });
+
+		expect(options.passthroughArgs).toBeUndefined();
+	});
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `pnpm -F nadle test cli-options-resolver`
+Expected: FAIL — `passthroughArgs` is `undefined` in the first test (the `"--"` key is currently dropped by the dash-excluding transformer).
+
+- [ ] **Step 3: Implement option capture**
+
+In `packages/nadle/src/core/options/cli-options-resolver.ts`, the transformer list at line 43 currently starts with alias/dash excludes which would swallow the `"--"` key. Add a rename transform **first**:
+
+```ts
+const transformers = [
+	transform("--", { transformKey: "passthroughArgs" }),
+	exclude((key) => aliases.includes(key)),
+	exclude((key) => key.includes(DASH)),
+	exclude("$0"),
+	exclude(UNDERSCORE),
+	transform("config", { transformKey: "configFile" }),
+	transform("cache", { transformValue: Boolean }),
+	transform("exclude", { transformKey: "excludedTasks" })
+];
+```
+
+(`transform` already returns `null` when the value is `undefined`, so runs without `--` produce no key.)
+
+In `packages/nadle/src/core/options/types.ts` add to `NadleCLIOptions` (after `excludedTasks`, line ~41):
+
+```ts
+	/** Arguments after `--` on the command line, passed through to requested tasks. */
+	readonly passthroughArgs?: string[];
+```
+
+`NadleResolvedOptions` extends `Required<Omit<NadleCLIOptions, ...>>` and `passthroughArgs` is not in the `Omit` list, so it becomes required (`string[]`) on resolved options automatically. No change needed there.
+
+In `packages/nadle/src/core/options/options-resolver.ts` add the default to `defaultOptions` (line ~30, next to `excludedTasks`):
+
+```ts
+		passthroughArgs: [] as string[],
+```
+
+In `packages/nadle/src/cli.ts` add a parser configuration before `.strict()` (line ~68):
+
+```ts
+	.parserConfiguration({ "populate--": true })
+	.wrap(100)
+	.strict()
+	.parseSync();
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `pnpm -F nadle test cli-options-resolver`
+Expected: PASS (2 tests)
+
+- [ ] **Step 5: Type-check**
+
+Run: `npx tsc -p packages/nadle/tsconfig.build.json --noEmit`
+Expected: clean
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add packages/nadle/src/cli.ts packages/nadle/src/core/options/types.ts packages/nadle/src/core/options/cli-options-resolver.ts packages/nadle/src/core/options/options-resolver.ts packages/nadle/test/unit/cli-options-resolver.test.ts
+```
+
+```bash
+git commit -m "feat: capture CLI args after -- into passthroughArgs option (#525)
+
+Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>"
+```
+
+---
+
+### Task 2: Expose `passthroughArgs` on `RunnerContext` (requested tasks only)
+
+**Files:**
+
+- Modify: `packages/nadle/src/core/interfaces/task.ts:20-25`
+- Modify: `packages/nadle/src/core/engine/worker.ts:52-66`
+- Test (create): `packages/nadle/test/features/passthrough-args.test.ts`
+
+- [ ] **Step 1: Write the failing integration tests**
+
+Create `packages/nadle/test/features/passthrough-args.test.ts`:
+
+```ts
+import { it, expect, describe } from "vitest";
+import { settle, fixture, getStdout, withGeneratedFixture } from "setup";
+
+const echoArgs = `({ context }) => console.log("ARGS=[" + context.passthroughArgs.join(" ") + "]")`;
+
+const files = fixture()
+	.packageJson("passthrough-args")
+	.configRaw(
+		[
+			`import { tasks } from "nadle";`,
+			``,
+			`tasks.register("compile", ${echoArgs});`,
+			`tasks.register("build", ${echoArgs}).config({ dependsOn: ["compile"] });`,
+			`tasks.register("verify", ${echoArgs});`
+		].join("\n")
+	)
+	.build();
+
+describe.concurrent("passthrough args", () => {
+	it("passes args after -- to the requested task", () =>
+		withGeneratedFixture({
+			files,
+			testFn: async ({ exec }) => {
+				const stdout = await getStdout(exec`verify -- -u --silent`);
+
+				expect(stdout).toContain("ARGS=[-u --silent]");
+			}
+		}));
+
+	it("does not pass args to dependency tasks", () =>
+		withGeneratedFixture({
+			files,
+			testFn: async ({ exec }) => {
+				const stdout = await getStdout(exec`build -- -u`);
+
+				// compile (dependency) sees no args; build (requested) sees -u
+				expect(stdout).toContain("ARGS=[]");
+				expect(stdout).toContain("ARGS=[-u]");
+			}
+		}));
+
+	it("exposes an empty array when no -- is given", () =>
+		withGeneratedFixture({
+			files,
+			testFn: async ({ exec }) => {
+				const stdout = await getStdout(exec`verify`);
+
+				expect(stdout).toContain("ARGS=[]");
+			}
+		}));
+
+	it("still rejects unknown flags before --", () =>
+		withGeneratedFixture({
+			files,
+			testFn: async ({ exec }) => {
+				const { exitCode, stderr } = await settle(exec`verify --unknown-flag -- -u`);
+
+				expect(exitCode).not.toBe(0);
+				expect(stderr).toContain("unknown-flag");
+			}
+		}));
+});
+```
+
+- [ ] **Step 2: Build, then run tests to verify they fail**
+
+Run: `npx nadle build`
+Run: `pnpm -F nadle test passthrough-args`
+Expected: FAIL — `context.passthroughArgs` is `undefined` (TypeError on `.join`).
+
+- [ ] **Step 3: Add the field to `RunnerContext`**
+
+In `packages/nadle/src/core/interfaces/task.ts` extend the interface:
+
+```ts
+/**
+ * Context object passed to task runners.
+ */
+export interface RunnerContext {
+	/** Logger instance for reporting. */
+	readonly logger: Logger;
+	/** The working directory for the task. */
+	readonly workingDir: string;
+	/** Arguments after `--` on the CLI. Empty unless this task was explicitly requested. */
+	readonly passthroughArgs: readonly string[];
+}
+```
+
+- [ ] **Step 4: Populate it in the worker**
+
+In `packages/nadle/src/core/engine/worker.ts`, `runTask` (line ~57), compute the per-task value and add it to the context literal:
+
+```ts
+const task = nadle.taskRegistry.getTaskById(taskId);
+const taskConfig = task.configResolver();
+const workspace = getWorkspaceById(options.project, task.workspaceId);
+const workingDir = Path.resolve(workspace.absolutePath, taskConfig.workingDir ?? "");
+const requested = options.tasks.some((resolvedTask) => resolvedTask.taskId === taskId);
+const passthroughArgs = requested ? options.passthroughArgs : [];
+
+const context: RunnerContext = {
+	workingDir,
+	passthroughArgs,
+	logger: bindObject(nadle.logger, ["error", "warn", "log", "info", "debug", "getColumns"])
+};
+```
+
+- [ ] **Step 5: Build and run the tests**
+
+Run: `npx nadle build`
+Run: `pnpm -F nadle test passthrough-args`
+Expected: PASS (4 tests)
+
+- [ ] **Step 6: Type-check**
+
+Run: `npx tsc -p packages/nadle/tsconfig.build.json --noEmit`
+Expected: clean
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add packages/nadle/src/core/interfaces/task.ts packages/nadle/src/core/engine/worker.ts packages/nadle/test/features/passthrough-args.test.ts
+```
+
+```bash
+git commit -m "feat: expose passthroughArgs on RunnerContext for requested tasks (#525)
+
+Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>"
+```
+
+---
+
+### Task 3: Append passthrough args in exec-based builtin tasks
+
+**Files:**
+
+- Modify: `packages/nadle/src/builtin-tasks/exec-task.ts:25`
+- Modify: `packages/nadle/src/builtin-tasks/pnpm-task.ts:26`
+- Modify: `packages/nadle/src/builtin-tasks/pnpx-task.ts`
+- Modify: `packages/nadle/src/builtin-tasks/npm-task.ts`
+- Modify: `packages/nadle/src/builtin-tasks/npx-task.ts`
+- Modify: `packages/nadle/src/builtin-tasks/node-task.ts:23`
+- Test (modify): `packages/nadle/test/features/passthrough-args.test.ts`
+
+- [ ] **Step 1: Write the failing integration tests**
+
+Append to the `describe` block in `packages/nadle/test/features/passthrough-args.test.ts` (uses a separate fixture with exec tasks; `node -e` keeps it cross-platform):
+
+```ts
+const execFiles = fixture()
+	.packageJson("passthrough-args-exec")
+	.configRaw(
+		[
+			`import { tasks, ExecTask } from "nadle";`,
+			``,
+			`tasks.register("echo-a", ExecTask, { command: "node", args: ["-e", "console.log('A:' + process.argv.slice(1).join(' '))"] });`,
+			`tasks.register("echo-b", ExecTask, { command: "node", args: ["-e", "console.log('B:' + process.argv.slice(1).join(' '))"] });`
+		].join("\n")
+	)
+	.build();
+
+it("appends args to ExecTask commands", () =>
+	withGeneratedFixture({
+		files: execFiles,
+		testFn: async ({ exec }) => {
+			const stdout = await getStdout(exec`echo-a -- --flag value`);
+
+			expect(stdout).toContain("A:--flag value");
+		}
+	}));
+
+it("appends the same args to every requested task", () =>
+	withGeneratedFixture({
+		files: execFiles,
+		testFn: async ({ exec }) => {
+			const stdout = await getStdout(exec`echo-a echo-b -- --flag`);
+
+			expect(stdout).toContain("A:--flag");
+			expect(stdout).toContain("B:--flag");
+		}
+	}));
+```
+
+- [ ] **Step 2: Build, then run tests to verify they fail**
+
+Run: `npx nadle build`
+Run: `pnpm -F nadle test passthrough-args`
+Expected: the two new tests FAIL (`A:` printed without the flag).
+
+- [ ] **Step 3: Append `context.passthroughArgs` in each builtin**
+
+`exec-task.ts` (line 25):
+
+```ts
+const commandArguments = [...(args == null ? [] : typeof args === "string" ? parseCommandString(args) : args), ...context.passthroughArgs];
+```
+
+`pnpm-task.ts` (line 26):
+
+```ts
+const args = [...filterArgs, ...MaybeArray.toArray(options.args), ...context.passthroughArgs];
+```
+
+`node-task.ts` (line 23):
+
+```ts
+const args = [...(options.args == null ? [] : typeof options.args === "string" ? [options.args] : options.args), ...context.passthroughArgs];
+```
+
+`pnpx-task.ts`, `npm-task.ts`, `npx-task.ts`: same pattern — read each file first; each builds an args array immediately before its `execa(...)` call; spread `...context.passthroughArgs` as the final elements of that array. Do not touch the logged message lines — the args variable is already interpolated into them, so the appended args show up in logs automatically where the log uses the final array; if a file logs from `options.args` directly, leave the log as is.
+
+`copy-task.ts` / `delete-task.ts`: intentionally untouched.
+
+- [ ] **Step 4: Build and run the tests**
+
+Run: `npx nadle build`
+Run: `pnpm -F nadle test passthrough-args`
+Expected: PASS (6 tests)
+
+- [ ] **Step 5: Run the builtin-task test suites to catch regressions**
+
+Run: `pnpm -F nadle test builtin-tasks`
+Expected: PASS
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add packages/nadle/src/builtin-tasks packages/nadle/test/features/passthrough-args.test.ts
+```
+
+```bash
+git commit -m "feat: append passthrough args in exec-based builtin tasks (#525)
+
+Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>"
+```
+
+---
+
+### Task 4: Multi-task notice
+
+**Files:**
+
+- Modify: `packages/nadle/src/core/utilities/messages.ts`
+- Modify: `packages/nadle/src/core/handlers/execute-handler.ts:15-37`
+- Test (modify): `packages/nadle/test/features/passthrough-args.test.ts`
+
+- [ ] **Step 1: Write the failing test**
+
+Add to `passthrough-args.test.ts` (reuses `execFiles` from Task 3):
+
+```ts
+it("logs a notice when multiple requested tasks receive args", () =>
+	withGeneratedFixture({
+		files: execFiles,
+		testFn: async ({ exec }) => {
+			const stdout = await getStdout(exec`echo-a echo-b -- --flag`);
+
+			expect(stdout).toContain("Passing extra arguments [--flag] to 2 tasks");
+		}
+	}));
+
+it("logs no notice for a single requested task", () =>
+	withGeneratedFixture({
+		files: execFiles,
+		testFn: async ({ exec }) => {
+			const stdout = await getStdout(exec`echo-a -- --flag`);
+
+			expect(stdout).not.toContain("Passing extra arguments");
+		}
+	}));
+```
+
+- [ ] **Step 2: Build, run, verify the first new test fails**
+
+Run: `npx nadle build`
+Run: `pnpm -F nadle test passthrough-args`
+Expected: notice test FAILS (no such output).
+
+- [ ] **Step 3: Implement the notice**
+
+In `packages/nadle/src/core/utilities/messages.ts` add to the `Messages` object:
+
+```ts
+	PassthroughArgsNotice: (args: string[], taskLabels: string[]) =>
+		`Passing extra arguments [${args.join(" ")}] to ${taskLabels.length} tasks: ${taskLabels.join(", ")}`,
+```
+
+In `packages/nadle/src/core/handlers/execute-handler.ts`, inside `handle()` after `chosenTasks` is final (right before `taskScheduler.init`, line ~34):
+
+```ts
+const { passthroughArgs } = this.context.options;
+
+if (passthroughArgs.length > 0 && chosenTasks.length > 1) {
+	this.context.logger.log(Messages.PassthroughArgsNotice([...passthroughArgs], chosenTasks));
+}
+```
+
+- [ ] **Step 4: Build and run the tests**
+
+Run: `npx nadle build`
+Run: `pnpm -F nadle test passthrough-args`
+Expected: PASS (8 tests)
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add packages/nadle/src/core/utilities/messages.ts packages/nadle/src/core/handlers/execute-handler.ts packages/nadle/test/features/passthrough-args.test.ts
+```
+
+```bash
+git commit -m "feat: log notice when passthrough args target multiple tasks (#525)
+
+Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>"
+```
+
+---
+
+### Task 5: Include passthrough args in the cache key
+
+**Files:**
+
+- Modify: `packages/nadle/src/core/models/cache/cache-key.ts:8-14`
+- Modify: `packages/nadle/src/core/caching/cache-validator.ts:18-27` (context) and `computeCacheQuery` (line ~81)
+- Modify: `packages/nadle/src/core/engine/worker.ts:69-122` (pass per-task args into the validator)
+- Test (create): `packages/nadle/test/unit/cache-key.test.ts`
+- Test (modify): `packages/nadle/test/features/passthrough-args.test.ts`
+
+- [ ] **Step 1: Write the failing unit test**
+
+Create `packages/nadle/test/unit/cache-key.test.ts`:
+
+```ts
+import { it, expect, describe } from "vitest";
+import { CacheKey } from "src/core/models/cache/cache-key.js";
+
+const base = { taskId: "build", inputsFingerprints: {} };
+
+describe("CacheKey", () => {
+	it("changes when passthrough args change", async () => {
+		const without = await CacheKey.compute(base);
+		const withArgs = await CacheKey.compute({ ...base, passthroughArgs: ["-u"] });
+
+		expect(withArgs).not.toBe(without);
+	});
+
+	it("treats absent and undefined passthrough args identically", async () => {
+		const absent = await CacheKey.compute(base);
+		const explicit = await CacheKey.compute({ ...base, passthroughArgs: undefined });
+
+		expect(explicit).toBe(absent);
+	});
+});
+```
+
+- [ ] **Step 2: Run to verify the first test fails**
+
+Run: `pnpm -F nadle test cache-key`
+Expected: first test FAILS (unknown property is accepted by `hashObject` only if typed; if TypeScript rejects the property, that is the failure — proceed).
+
+- [ ] **Step 3: Implement key + validator changes**
+
+`packages/nadle/src/core/models/cache/cache-key.ts` — extend `Input`:
+
+```ts
+interface Input {
+	readonly env?: TaskEnv;
+	readonly options?: object;
+	readonly taskId: TaskIdentifier;
+	readonly inputsFingerprints: FileFingerprints;
+	readonly passthroughArgs?: readonly string[];
+	readonly dependencyFingerprints?: Record<string, string>;
+}
+```
+
+(`hashObject` hashes the whole input; `undefined` must hash the same as absent — verify by reading `src/core/utilities/hash.ts`; if it does not, normalize with a spread that omits the key when undefined.)
+
+`packages/nadle/src/core/caching/cache-validator.ts` — add to `CacheValidatorContext`:
+
+```ts
+	readonly passthroughArgs: readonly string[];
+```
+
+and in `computeCacheQuery` (line ~87) include it only when non-empty so existing cache entries stay valid:
+
+```ts
+const cacheKey = await CacheKey.compute({
+	inputsFingerprints,
+	taskId: this.taskId,
+	env: this.taskConfiguration.env,
+	options: this.context.taskOptions,
+	passthroughArgs: this.context.passthroughArgs.length > 0 ? this.context.passthroughArgs : undefined,
+	dependencyFingerprints: Object.keys(this.context.dependencyFingerprints).length > 0 ? this.context.dependencyFingerprints : undefined
+});
+```
+
+`packages/nadle/src/core/engine/worker.ts` — **critical:** `createCacheValidator` spreads `...nadle.options` into the context, which would leak the _global_ `passthroughArgs` into every task's cache context, including dependencies. Pass the per-task value explicitly after the spread. Add `passthroughArgs` to `CacheValidatorParams` and thread it from `runTask`:
+
+```ts
+const cacheValidator = createCacheValidator(nadle, {
+	taskId,
+	taskConfig,
+	workingDir,
+	taskOptions,
+	passthroughArgs,
+	dependencyFingerprints,
+	workspaceId: task.workspaceId
+});
+```
+
+```ts
+interface CacheValidatorParams {
+	taskId: string;
+	workingDir: string;
+	workspaceId: string;
+	taskOptions: unknown;
+	taskConfig: TaskConfiguration;
+	passthroughArgs: readonly string[];
+	dependencyFingerprints: Record<string, string>;
+}
+```
+
+and in `createCacheValidator`, after the `...nadle.options` spread:
+
+```ts
+return new CacheValidator(params.taskId, params.taskConfig, {
+	...nadle.options,
+	configFiles,
+	workingDir: params.workingDir,
+	passthroughArgs: params.passthroughArgs,
+	taskOptions: params.taskOptions as object | undefined,
+	dependencyFingerprints: params.dependencyFingerprints,
+	projectDir: nadle.options.project.rootWorkspace.absolutePath,
+	maxCacheEntries: params.taskConfig.maxCacheEntries ?? nadle.options.maxCacheEntries
+});
+```
+
+- [ ] **Step 4: Run the unit test**
+
+Run: `pnpm -F nadle test cache-key`
+Expected: PASS
+
+- [ ] **Step 5: Write the failing cache integration test**
+
+Add to `passthrough-args.test.ts`:
+
+```ts
+const cachedFiles = fixture()
+	.packageJson("passthrough-args-cache")
+	.file("input.txt", "content")
+	.configRaw(
+		[
+			`import { tasks } from "nadle";`,
+			``,
+			`tasks.register("emit", async () => {`,
+			`\tconst Fs = await import("node:fs");`,
+			`\tFs.writeFileSync("out.txt", "done");`,
+			`}).config({ inputs: ["input.txt"], outputs: ["out.txt"] });`
+		].join("\n")
+	)
+	.build();
+
+it("does not reuse the no-args cache entry when args are passed", () =>
+	withGeneratedFixture({
+		files: cachedFiles,
+		testFn: async ({ exec }) => {
+			await getStdout(exec`emit`);
+			const second = await getStdout(exec`emit`);
+
+			expect(second).toContain("UP-TO-DATE");
+
+			const withArgs = await getStdout(exec`emit -- -u`);
+
+			expect(withArgs).not.toContain("UP-TO-DATE");
+			expect(withArgs).not.toContain("FROM-CACHE");
+		}
+	}));
+```
+
+Check `packages/nadle/test/caching/` first for the exact inputs/outputs declaration shape and assertion strings used there (`UP-TO-DATE` / `FROM-CACHE` appear in task status lines); mirror that style if it differs from the above.
+
+- [ ] **Step 6: Build and run; verify it failed before the validator change, passes after**
+
+Run: `npx nadle build`
+Run: `pnpm -F nadle test passthrough-args`
+Expected: PASS (all tests, including the new cache test)
+
+- [ ] **Step 7: Run the caching suite for regressions**
+
+Run: `pnpm -F nadle test caching`
+Expected: PASS (existing cache keys unaffected because empty args map to `undefined`)
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add packages/nadle/src/core/models/cache/cache-key.ts packages/nadle/src/core/caching/cache-validator.ts packages/nadle/src/core/engine/worker.ts packages/nadle/test/unit/cache-key.test.ts packages/nadle/test/features/passthrough-args.test.ts
+```
+
+```bash
+git commit -m "feat: include passthrough args in cache key for requested tasks (#525)
+
+Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>"
+```
+
+---
+
+### Task 6: Dry-run annotation
+
+**Files:**
+
+- Modify: `packages/nadle/src/core/handlers/dry-run-handler.ts:26-34`
+- Test (modify): `packages/nadle/test/features/passthrough-args.test.ts`
+
+- [ ] **Step 1: Write the failing test**
+
+```ts
+it("shows args on requested tasks in dry run", () =>
+	withGeneratedFixture({
+		files,
+		testFn: async ({ exec }) => {
+			const stdout = await getStdout(exec`build --dry-run -- -u`);
+
+			expect(stdout).toContain("build (args: -u)");
+			expect(stdout).not.toContain("compile (args:");
+		}
+	}));
+```
+
+- [ ] **Step 2: Build, run, verify it fails**
+
+Run: `npx nadle build`
+Run: `pnpm -F nadle test passthrough-args`
+Expected: new test FAILS.
+
+- [ ] **Step 3: Implement**
+
+In `packages/nadle/src/core/handlers/dry-run-handler.ts`, inside the `for` loop add a requested-task suffix (`ResolvedTask` import from `../interfaces/resolved-task.js`):
+
+```ts
+const { passthroughArgs } = this.context.options;
+const requestedTaskIds = new Set(this.context.options.tasks.map(ResolvedTask.getId));
+
+for (const taskId of taskIds) {
+	const label = this.context.taskRegistry.getTaskById(taskId).label;
+	const implicitDeps = scheduler.getImplicitDeps(taskId);
+	const argsSuffix = passthroughArgs.length > 0 && requestedTaskIds.has(taskId) ? c.dim(` (args: ${passthroughArgs.join(" ")})`) : "";
+	const suffix =
+		implicitDeps.length > 0 ? c.dim(` (after ${implicitDeps.map((d) => this.context.taskRegistry.getTaskById(d).label).join(", ")} — implicit)`) : "";
+	this.context.logger.log(`${c.yellow(">")} Task ${c.bold(label)}${argsSuffix}${suffix}`);
+}
+```
+
+Mind the 200-line/50-line-function eslint limits; if the function grows past limits, extract a `formatArgsSuffix` helper in the same file.
+
+- [ ] **Step 4: Build and run**
+
+Run: `npx nadle build`
+Run: `pnpm -F nadle test passthrough-args`
+Expected: PASS
+
+- [ ] **Step 5: Run existing dry-run-related tests**
+
+Run: `pnpm -F nadle test dry`
+Expected: PASS (or no matching files — then skip)
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add packages/nadle/src/core/handlers/dry-run-handler.ts packages/nadle/test/features/passthrough-args.test.ts
+```
+
+```bash
+git commit -m "feat: show passthrough args in dry-run execution plan (#525)
+
+Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>"
+```
+
+---
+
+### Task 7: Help text example
+
+**Files:**
+
+- Modify: `packages/nadle/src/cli.ts:67-70`
+
+- [ ] **Step 1: Add an example to the yargs builder**
+
+Before `.wrap(100)`:
+
+```ts
+	.example("nadle test -- -u", "Run the test task, passing -u through to its underlying command")
+```
+
+- [ ] **Step 2: Verify manually**
+
+Run: `npx nadle build`
+Run: `node packages/nadle/lib/cli.js --help`
+Expected: Examples section shows the line.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add packages/nadle/src/cli.ts
+```
+
+```bash
+git commit -m "docs: add passthrough args example to CLI help (#525)
+
+Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>"
+```
+
+---
+
+### Task 8: Regenerate the public API report
+
+`RunnerContext` is exported from `src/index.ts`; the new field changes the API surface tracked by api-extractor. Pre-commit does NOT run api-extractor — do it manually.
+
+**Files:**
+
+- Modify: `packages/nadle/index.api.md` (generated)
+
+- [ ] **Step 1: Build (runs api-extractor)**
+
+Run: `npx nadle build`
+Expected: build succeeds; may warn about API report mismatch.
+
+- [ ] **Step 2: Copy the regenerated report**
+
+Run: `node -e "require('node:fs').copyFileSync('packages/nadle/build/api/index.api.md', 'packages/nadle/index.api.md')"`
+
+- [ ] **Step 3: Verify the diff only adds `passthroughArgs`**
+
+Run: `git diff packages/nadle/index.api.md`
+Expected: only the `RunnerContext` member addition.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add packages/nadle/index.api.md
+```
+
+```bash
+git commit -m "chore: update api report for RunnerContext.passthroughArgs (#525)
+
+Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>"
+```
+
+---
+
+### Task 9: Spec updates
+
+**Files:**
+
+- Modify: `spec/09-cli.md` (new section after "Glob Task Selection", before "## Flags")
+- Modify: `spec/10-builtin-tasks.md`
+- Modify: `spec/CHANGELOG.md`
+- Modify: `spec/README.md` (minor version bump)
+
+- [ ] **Step 1: Add "Argument Passthrough" to `spec/09-cli.md`**
+
+Read the file first to match its voice. Insert:
+
+```markdown
+### Argument Passthrough
+
+Arguments after the first bare `--` are not parsed as Nadle options; they are captured
+verbatim and passed through to tasks.
+
+    nadle <tasks...> [options] -- <args...>
+
+Rules:
+
+- Passthrough arguments are delivered only to tasks explicitly requested on the command
+  line (including tasks matched by a glob pattern). Dependency tasks never receive them.
+- Every requested task receives the same arguments. When more than one requested task
+  will receive arguments, an informational notice is logged.
+- Task runners access the arguments via the runner context (`passthroughArgs`).
+  Exec-based builtin tasks append them to their underlying command.
+- Passthrough arguments participate in the cache key of requested tasks; an invocation
+  with arguments is never served from a cache entry produced without them. Dependency
+  task cache keys are unaffected.
+- Strict option parsing still applies before `--`: unknown Nadle flags remain an error.
+- Dry run annotates requested tasks with the arguments they would receive.
+```
+
+- [ ] **Step 2: Update `spec/10-builtin-tasks.md`**
+
+Read the file; add a short subsection or per-task notes stating: `ExecTask`, `PnpmTask`, `PnpxTask`, `NpmTask`, `NpxTask`, and `NodeTask` append passthrough arguments after their configured arguments; `CopyTask` and `DeleteTask` ignore them.
+
+- [ ] **Step 3: CHANGELOG + version**
+
+Add an entry to `spec/CHANGELOG.md` under a new minor version (check current version in `spec/README.md` first, bump minor) describing the new Argument Passthrough concept; update the version in `spec/README.md`.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add spec/09-cli.md spec/10-builtin-tasks.md spec/CHANGELOG.md spec/README.md
+```
+
+```bash
+git commit -m "docs: specify CLI argument passthrough behavior (#525)
+
+Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>"
+```
+
+---
+
+### Task 10: User-facing docs
+
+**Files:**
+
+- Modify: `packages/docs/docs/guides/executing-task.md`
+- Possibly modify: `packages/docs/docs/config-reference.md` or API docs page documenting the runner context (locate with `rtk grep -rln "workingDir" packages/docs/docs`)
+
+- [ ] **Step 1: Add a "Passing extra arguments" section to the executing-task guide**
+
+Read the guide first; match its tone and example style. Cover: `nadle test -- -u`, multi-task behavior with the notice, dependency exclusion, `context.passthroughArgs` for custom tasks, builtin behavior, cache interaction (one sentence).
+
+- [ ] **Step 2: Document `passthroughArgs` wherever `RunnerContext`/task context is documented**
+
+Search: `rtk grep -rln "workingDir" packages/docs/docs` — add the field with the same JSDoc sentence used in the interface.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add packages/docs
+```
+
+```bash
+git commit -m "docs: document CLI argument passthrough (#525)
+
+Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>"
+```
+
+---
+
+### Task 11: Full verification
+
+- [ ] **Step 1: Full pipeline**
+
+Run: `npx nadle check build test --summary`
+Expected: RUN SUCCESSFUL — lint, build, all test projects green. (Long-running; notify via `terminal-notifier -title "Claude Code - nadle" -message "Full pipeline finished"` when done.)
+
+- [ ] **Step 2: Glob interaction smoke test (already covered by unit/integration, verify nothing missed)**
+
+Confirm `passthrough-args.test.ts` covers: requested task, multi-task, dependency exclusion, no-args default, strict mode, exec append, notice, cache, dry run. Add the glob case if absent:
+
+```ts
+it("passes args to every glob-matched task", () =>
+	withGeneratedFixture({
+		files: execFiles,
+		testFn: async ({ exec }) => {
+			const stdout = await getStdout(exec`echo-* -- --flag`);
+
+			expect(stdout).toContain("A:--flag");
+			expect(stdout).toContain("B:--flag");
+		}
+	}));
+```
+
+- [ ] **Step 3: Push and open PR**
+
+```bash
+git push -u origin feat/cli-passthrough-args
+```
+
+```bash
+gh pr create --title "feat: support CLI argument passthrough to tasks via -- separator" --body "Implements #525 per docs/superpowers/specs/2026-06-10-cli-passthrough-args-design.md.
+
+## Summary
+- Capture args after \`--\` (yargs \`populate--\`), thread through options to workers
+- \`RunnerContext.passthroughArgs\` — populated only for explicitly requested tasks (incl. glob matches); dependencies receive \`[]\`
+- Exec-based builtins (Exec/Pnpm/Pnpx/Npm/Npx/Node) append the args; Copy/Delete ignore them
+- Args participate in the cache key of requested tasks only; empty args keep existing cache entries valid
+- Multi-task notice, dry-run annotation, help example, spec + docs updates
+
+Closes #525
+
+🤖 Generated with [Claude Code](https://claude.com/claude-code)"
+```
+
+```bash
+gh pr merge --auto --squash
+```
+
+---
+
+## Self-review notes
+
+- Spec coverage: design §1 → Task 1+7; §2 → Tasks 2, 4, 11; §3 → Tasks 1–2; §4 → Tasks 2–3, 8; §5 → Task 5; §6 → Tasks 4, 6, 7; §7 → Tasks 9–10; §8 → tests embedded per task.
+- The `"--"` key would be dropped by the existing dash-excluding transformer in `cli-options-resolver.ts` — the rename transform MUST run first (Task 1 Step 3).
+- `createCacheValidator` spreads `nadle.options`, which would leak global args into dependency cache contexts — explicit per-task override required (Task 5 Step 3).
+- `getOrCreateNadle` constructs the worker Nadle with `tasks: []`; always read the requested set from the `runTask` `options` parameter, never `nadle.options`.

--- a/docs/superpowers/specs/2026-06-10-cli-passthrough-args-design.md
+++ b/docs/superpowers/specs/2026-06-10-cli-passthrough-args-design.md
@@ -1,0 +1,167 @@
+# Design: CLI Argument Passthrough via `--` Separator
+
+**Issue:** [#525](https://github.com/nadlejs/nadle/issues/525)
+**Date:** 2026-06-10
+**Status:** Approved
+
+## Problem
+
+There is no way to pass extra arguments from the CLI through to a task's underlying
+command. `nadle test -- -u` and `nadle test -u` are both rejected by yargs strict mode.
+Task arguments are fully baked into `nadle.config.ts` at definition time. Other tools
+(pnpm, npm, turborepo) support this as a standard workflow.
+
+## Prior art
+
+| Tool       | Mechanism                                             | Multi-task behavior          | Dependencies receive args? |
+| ---------- | ----------------------------------------------------- | ---------------------------- | -------------------------- |
+| pnpm / npm | `run script -- args`                                  | N/A (single script)          | N/A                        |
+| Turborepo  | `turbo run a b -- args`                               | All _named_ tasks get args   | No                         |
+| Nx         | unknown args + `--args`, `forwardAllArgs` opt-out     | Forwarded to invoked targets | No                         |
+| Gradle     | Per-task declared `@Option` (e.g. `run --args="..."`) | Each task parses own flags   | No                         |
+
+Convergent rules: dependency tasks never receive passthrough args; args participate in
+cache keys; per-task partitioning does not exist anywhere (turborepo
+[#5743](https://github.com/vercel/turborepo/issues/5743) is an open request).
+
+## Decision summary
+
+Turborepo-style blanket append, scoped to explicitly requested tasks, exposed uniformly
+on `RunnerContext`, auto-consumed by exec-based builtin tasks, included in the cache
+fingerprint of requested tasks. Multiple requested tasks are allowed and all receive the
+same args; a notice is logged when more than one task receives them (Option 1 — see
+Alternatives).
+
+## 1. CLI grammar
+
+```
+nadle [tasks...] [nadle-options] -- [passthrough-args...]
+```
+
+Everything after the first bare `--` is captured verbatim and never parsed by yargs.
+
+- Implementation: `.parserConfiguration({ "populate--": true })` in `src/cli.ts`;
+  captured args appear in `argv["--"]`.
+- `.strict()` remains. Unknown flags _before_ `--` still error. No existing CLI
+  behavior changes.
+- Args are kept as an array of strings and passed to `execa` as array elements — no
+  shell re-interpretation; spaces and quoting preserved.
+
+## 2. Scope semantics
+
+**Passthrough args go to tasks explicitly requested on the CLI — never to dependency
+tasks.**
+
+- Multiple requested tasks all receive the same args.
+- Glob-selected tasks (#591) count as requested: `nadle "test:*" -- -u` passes `-u` to
+  every matched task.
+- Workspace-qualified ids likewise: `nadle app:test lib:test -- -u` → both.
+- Tasks removed via `--exclude` are not executed, hence receive nothing.
+- `--` combined with `--list`, `--dry-run`, or zero tasks: args are carried but unused
+  by execution; dry run displays them (§6).
+- When more than one requested task will receive args, log an info-level notice:
+  `Passing extra arguments [--reporter dot] to 2 tasks: check, test`.
+
+## 3. Data flow
+
+```
+argv["--"]
+  → NadleCLIOptions.passthroughArgs?: string[]          (src/core/options/types.ts)
+  → CLIOptionsResolver                                   (copy through)
+  → NadleResolvedOptions.passthroughArgs: string[]       (default [])
+  → WorkerParams.options                                 (already serialized to workers)
+  → worker.ts: requested-task check → RunnerContext
+```
+
+The worker decides whether the current task was requested by comparing its `taskId`
+against `options.tasks` (`ResolvedTask[]`), which is already present in the resolved
+options. No new worker protocol fields.
+
+## 4. API surface
+
+`RunnerContext` (`src/core/interfaces/task.ts`) gains one field:
+
+```ts
+export interface RunnerContext {
+	readonly logger: Logger;
+	readonly workingDir: string;
+	/** Args after `--` on the CLI. Empty unless this task was explicitly requested. */
+	readonly passthroughArgs: readonly string[];
+}
+```
+
+- **Custom tasks** read `context.passthroughArgs` directly. Raw strings; parsing is the
+  task's responsibility.
+- **Exec-based builtins** (`ExecTask`, `PnpmTask`, `NpxTask`, `NodeTask`, `NpmTask`,
+  `PnpxTask`) append `context.passthroughArgs` after their configured args:
+  `[...commandArguments, ...context.passthroughArgs]`.
+- **Non-exec builtins** (`CopyTask`, `DeleteTask`) ignore them. Documented.
+- No per-task opt-in/opt-out in v1 (YAGNI; dependency exclusion already prevents the
+  dangerous case). If demanded later: a `TaskConfiguration` flag, with Gradle/Nx
+  precedent.
+
+Public API change → regenerate `packages/nadle/index.api.md` via `npx nadle build`.
+
+## 5. Caching
+
+Passthrough args change task behavior, so they must affect the cache key — otherwise
+`nadle test -- -u` followed by `nadle test` would return a stale FROM-CACHE result.
+
+- `CacheKey.compute` (used by `CacheValidator.computeCacheQuery`) gains
+  `passthroughArgs` as a key input, **only for requested tasks**.
+- Dependency tasks' keys are unchanged — they never see the args, and their keys must
+  stay stable for cache reuse.
+- An empty array must produce the same key as today so existing cache entries remain
+  valid for plain runs.
+
+## 6. UX details
+
+- **Dry run** annotates requested tasks with the args: `test (args: -u)`.
+- **Exec log line**: the existing `Running command: ...` output naturally includes the
+  appended args.
+- **Help text**: add an epilogue example showing `nadle test -- -u`.
+- **Multi-task notice**: see §2.
+
+## 7. Spec and docs updates
+
+- `spec/09-cli.md`: new "Argument Passthrough" section — grammar, requested-task scope
+  rule, dependency exclusion, cache interaction, multi-task notice.
+- `spec/10-builtin-tasks.md`: which builtins consume passthrough args.
+- `spec/CHANGELOG.md` entry + minor version bump in `spec/README.md` (new concept).
+- `packages/docs/`: update `guides/executing-task.md`; document `RunnerContext` field in
+  API reference.
+
+## 8. Testing
+
+Integration (execa-spawned CLI, custom matchers, per house style):
+
+1. `nadle test -- -u` → exec task command receives `-u`.
+2. Two requested tasks → both receive args; notice logged.
+3. Dependency task does **not** receive args.
+4. Glob pattern → all matched tasks receive args.
+5. Cache: run with args is not a cache hit of run without args; dependencies stay
+   cached across both runs.
+6. Unknown flag before `--` still errors (strict mode preserved).
+7. Custom task reads `context.passthroughArgs`.
+8. Dry run displays args on requested tasks.
+
+Unit:
+
+- `cli-options-resolver` captures `argv["--"]` into `passthroughArgs`.
+- Cache key includes/excludes `passthroughArgs` per requested/dependency status.
+
+## Alternatives considered
+
+- **Option 2 — restrict `--` to a single requested task** (pnpm semantics; error
+  otherwise). Safest, and relaxing later is non-breaking. Rejected: blocks the
+  legitimate homogeneous cases (`nadle "test:*" -- -u`, `nadle app:test lib:test -- -u`)
+  to prevent a recoverable mistake whose failure is visible in the logged command.
+- **All executed tasks receive args** (including dependencies). Rejected: args meant
+  for `test` would break `build`; no other tool does this.
+- **Gradle-style declared per-task options**. Precise but heavyweight; deferred.
+
+## Out of scope
+
+- Per-task arg partitioning (`task1 -- a --- task2 -- b`).
+- Gradle-style declared `@Option` flags per task.
+- Per-task opt-in/opt-out configuration.

--- a/packages/docs/docs/guides/executing-task.md
+++ b/packages/docs/docs/guides/executing-task.md
@@ -124,6 +124,40 @@ You can exclude multiple tasks by repeating the flag or providing a comma-separa
 nadle build --exclude lint,spell-check
 ```
 
+## Passing Extra Arguments to Tasks
+
+Arguments after a bare `--` are passed through to the tasks you request, instead of being parsed
+as Nadle options:
+
+```sh
+nadle test -- -u
+```
+
+Here the `test` task's underlying command receives `-u` appended after its configured arguments.
+This works for all exec-based built-in tasks (`ExecTask`, `PnpmTask`, `PnpxTask`, `NpmTask`,
+`NpxTask`, `NodeTask`). `CopyTask` and `DeleteTask` ignore passthrough arguments.
+
+Only tasks named on the command line (including glob matches) receive the arguments — their
+dependencies do not:
+
+```sh
+nadle build -- --sourcemap     # build gets --sourcemap; its dependencies do not
+nadle "test:*" -- --reporter dot
+```
+
+When several requested tasks receive the same arguments, Nadle logs a notice listing them.
+
+Custom tasks can read the arguments from the runner context:
+
+```ts
+tasks.register("greet", ({ context }) => {
+	console.log(context.passthroughArgs);
+});
+```
+
+Passthrough arguments are part of the cache key: a run with arguments is never served from a
+cache entry produced without them (dependencies stay cached as usual).
+
 ## Task and Workspace Name Autocorrect
 
 Nadle automatically suggests and corrects task and workspace names if you mistype or use a partial name.

--- a/packages/nadle/index.api.md
+++ b/packages/nadle/index.api.md
@@ -184,6 +184,7 @@ export type Resolver<T = unknown> = T | Callback<T>;
 // @public
 export interface RunnerContext {
     readonly logger: Logger;
+    readonly passthroughArgs: readonly string[];
     readonly workingDir: string;
 }
 

--- a/packages/nadle/src/builtin-tasks/exec-task.ts
+++ b/packages/nadle/src/builtin-tasks/exec-task.ts
@@ -22,7 +22,7 @@ export const ExecTask = defineTask<ExecTaskOptions>({
 	run: async ({ options, context }) => {
 		const { args, command } = options;
 
-		const commandArguments = args == null ? [] : typeof args === "string" ? parseCommandString(args) : args;
+		const commandArguments = [...(args == null ? [] : typeof args === "string" ? parseCommandString(args) : args), ...context.passthroughArgs];
 
 		context.logger.info(`Running command: ${command} ${commandArguments.join(" ")}`);
 

--- a/packages/nadle/src/builtin-tasks/node-task.ts
+++ b/packages/nadle/src/builtin-tasks/node-task.ts
@@ -20,7 +20,7 @@ export interface NodeTaskOptions {
  */
 export const NodeTask = defineTask<NodeTaskOptions>({
 	run: async ({ options, context }) => {
-		const args = options.args == null ? [] : typeof options.args === "string" ? [options.args] : options.args;
+		const args = [...(options.args == null ? [] : typeof options.args === "string" ? [options.args] : options.args), ...context.passthroughArgs];
 
 		context.logger.info(`Running node script: node ${options.script} ${args.join(" ")}`);
 

--- a/packages/nadle/src/builtin-tasks/npm-task.ts
+++ b/packages/nadle/src/builtin-tasks/npm-task.ts
@@ -18,7 +18,7 @@ export interface NpmTaskOptions {
  */
 export const NpmTask = defineTask<NpmTaskOptions>({
 	run: async ({ options, context }) => {
-		const args = MaybeArray.toArray(options.args);
+		const args = [...MaybeArray.toArray(options.args), ...context.passthroughArgs];
 
 		context.logger.info(`Running npm command: npm ${args.join(" ")}`);
 

--- a/packages/nadle/src/builtin-tasks/npx-task.ts
+++ b/packages/nadle/src/builtin-tasks/npx-task.ts
@@ -20,7 +20,7 @@ export interface NpxTaskOptions {
  */
 export const NpxTask = defineTask<NpxTaskOptions>({
 	run: async ({ options, context }) => {
-		const args = options.args == null ? [] : MaybeArray.toArray(options.args);
+		const args = [...(options.args == null ? [] : MaybeArray.toArray(options.args)), ...context.passthroughArgs];
 
 		context.logger.info(`Running npx command: npx ${options.command} ${args.join(" ")}`);
 

--- a/packages/nadle/src/builtin-tasks/pnpm-task.ts
+++ b/packages/nadle/src/builtin-tasks/pnpm-task.ts
@@ -23,7 +23,7 @@ export interface PnpmTaskOptions {
 export const PnpmTask = defineTask<PnpmTaskOptions>({
 	run: async ({ options, context }) => {
 		const filterArgs = MaybeArray.toArray(options.filter ?? []).flatMap((filter) => ["--filter", filter]);
-		const args = [...filterArgs, ...MaybeArray.toArray(options.args)];
+		const args = [...filterArgs, ...MaybeArray.toArray(options.args), ...context.passthroughArgs];
 
 		context.logger.info(`Running pnpm command: pnpm ${args.join(" ")}`);
 

--- a/packages/nadle/src/builtin-tasks/pnpx-task.ts
+++ b/packages/nadle/src/builtin-tasks/pnpx-task.ts
@@ -20,7 +20,7 @@ export interface PnpxTaskOptions {
  */
 export const PnpxTask = defineTask<PnpxTaskOptions>({
 	run: async ({ options, context }) => {
-		const args = options.args == null ? [] : MaybeArray.toArray(options.args);
+		const args = [...(options.args == null ? [] : MaybeArray.toArray(options.args)), ...context.passthroughArgs];
 
 		context.logger.info(`Running pnpm exec command: pnpm exec ${options.command} ${args.join(" ")}`);
 

--- a/packages/nadle/src/cli.ts
+++ b/packages/nadle/src/cli.ts
@@ -65,6 +65,7 @@ const argv = yargs(hideBin(Process.argv))
 		"General options:"
 	)
 	.group(["help", "version"], "Miscellaneous options:")
+	.example("nadle test -- -u", "Run the test task, passing -u through to its underlying command")
 	.parserConfiguration({ "populate--": true })
 	.wrap(100)
 	.strict()

--- a/packages/nadle/src/cli.ts
+++ b/packages/nadle/src/cli.ts
@@ -65,6 +65,7 @@ const argv = yargs(hideBin(Process.argv))
 		"General options:"
 	)
 	.group(["help", "version"], "Miscellaneous options:")
+	.parserConfiguration({ "populate--": true })
 	.wrap(100)
 	.strict()
 	.parseSync();

--- a/packages/nadle/src/core/caching/cache-validator.ts
+++ b/packages/nadle/src/core/caching/cache-validator.ts
@@ -23,6 +23,7 @@ interface CacheValidatorContext {
 	readonly taskOptions?: object;
 	readonly configFiles: string[];
 	readonly maxCacheEntries: number;
+	readonly passthroughArgs: readonly string[];
 	readonly dependencyFingerprints: Record<string, string>;
 }
 
@@ -89,6 +90,9 @@ export class CacheValidator {
 			taskId: this.taskId,
 			env: this.taskConfiguration.env,
 			options: this.context.taskOptions,
+			// Spread conditionally: an explicit undefined key would still change the hash,
+			// invalidating cache entries created before passthrough args existed.
+			...(this.context.passthroughArgs.length > 0 ? { passthroughArgs: this.context.passthroughArgs } : {}),
 			dependencyFingerprints: Object.keys(this.context.dependencyFingerprints).length > 0 ? this.context.dependencyFingerprints : undefined
 		});
 

--- a/packages/nadle/src/core/engine/worker.ts
+++ b/packages/nadle/src/core/engine/worker.ts
@@ -74,6 +74,7 @@ export async function runTask(
 		taskConfig,
 		workingDir,
 		taskOptions,
+		passthroughArgs,
 		dependencyFingerprints,
 		workspaceId: task.workspaceId
 	});
@@ -105,6 +106,7 @@ interface CacheValidatorParams {
 	workspaceId: string;
 	taskOptions: unknown;
 	taskConfig: TaskConfiguration;
+	passthroughArgs: readonly string[];
 	dependencyFingerprints: Record<string, string>;
 }
 
@@ -113,10 +115,13 @@ function createCacheValidator(nadle: Nadle, params: CacheValidatorParams) {
 	const workspace = getWorkspaceById(nadle.options.project, params.workspaceId);
 	const configFiles = workspace.configFilePath ? [rootConfigFile, workspace.configFilePath] : [rootConfigFile];
 
+	// Override the global options value with the per-task one: dependency tasks must
+	// keep a stable cache key regardless of what was passed on the CLI.
 	return new CacheValidator(params.taskId, params.taskConfig, {
 		...nadle.options,
 		configFiles,
 		workingDir: params.workingDir,
+		passthroughArgs: params.passthroughArgs,
 		taskOptions: params.taskOptions as object | undefined,
 		dependencyFingerprints: params.dependencyFingerprints,
 		projectDir: nadle.options.project.rootWorkspace.absolutePath,

--- a/packages/nadle/src/core/engine/worker.ts
+++ b/packages/nadle/src/core/engine/worker.ts
@@ -58,9 +58,12 @@ export async function runTask(
 	const taskConfig = task.configResolver();
 	const workspace = getWorkspaceById(options.project, task.workspaceId);
 	const workingDir = Path.resolve(workspace.absolutePath, taskConfig.workingDir ?? "");
+	const requested = options.tasks.some((resolvedTask) => resolvedTask.taskId === taskId);
+	const passthroughArgs = requested ? options.passthroughArgs : [];
 
 	const context: RunnerContext = {
 		workingDir,
+		passthroughArgs,
 		logger: bindObject(nadle.logger, ["error", "warn", "log", "info", "debug", "getColumns"])
 	};
 	const taskOptions = typeof task.optionsResolver === "function" ? task.optionsResolver(context) : task.optionsResolver;

--- a/packages/nadle/src/core/handlers/dry-run-handler.ts
+++ b/packages/nadle/src/core/handlers/dry-run-handler.ts
@@ -2,6 +2,7 @@ import c from "tinyrainbow";
 
 import { BaseHandler } from "./base-handler.js";
 import { Messages } from "../utilities/messages.js";
+import { ResolvedTask } from "../interfaces/resolved-task.js";
 
 export class DryRunHandler extends BaseHandler {
 	public readonly name = "dry-run";
@@ -23,14 +24,18 @@ export class DryRunHandler extends BaseHandler {
 
 		this.context.logger.log(c.bold("Execution plan:"));
 
+		const { passthroughArgs } = this.context.options;
+		const requestedTaskIds = new Set(this.context.options.tasks.map(ResolvedTask.getId));
+
 		for (const taskId of taskIds) {
 			const label = this.context.taskRegistry.getTaskById(taskId).label;
 			const implicitDeps = scheduler.getImplicitDeps(taskId);
+			const argsSuffix = passthroughArgs.length > 0 && requestedTaskIds.has(taskId) ? c.dim(` (args: ${passthroughArgs.join(" ")})`) : "";
 			const suffix =
 				implicitDeps.length > 0
 					? c.dim(` (after ${implicitDeps.map((d) => this.context.taskRegistry.getTaskById(d).label).join(", ")} — implicit)`)
 					: "";
-			this.context.logger.log(`${c.yellow(">")} Task ${c.bold(label)}${suffix}`);
+			this.context.logger.log(`${c.yellow(">")} Task ${c.bold(label)}${argsSuffix}${suffix}`);
 		}
 	}
 }

--- a/packages/nadle/src/core/handlers/execute-handler.ts
+++ b/packages/nadle/src/core/handlers/execute-handler.ts
@@ -31,6 +31,12 @@ export class ExecuteHandler extends BaseHandler {
 			}
 		}
 
+		const { passthroughArgs } = this.context.options;
+
+		if (passthroughArgs.length > 0 && chosenTasks.length > 1) {
+			this.context.logger.log(Messages.PassthroughArgsNotice([...passthroughArgs], chosenTasks));
+		}
+
 		const scheduler = this.context.taskScheduler.init(chosenTasks);
 		await this.context.eventEmitter.onTasksScheduled(scheduler.scheduledTask.map((taskId) => this.context.taskRegistry.getTaskById(taskId)));
 

--- a/packages/nadle/src/core/interfaces/task.ts
+++ b/packages/nadle/src/core/interfaces/task.ts
@@ -22,4 +22,6 @@ export interface RunnerContext {
 	readonly logger: Logger;
 	/** The working directory for the task. */
 	readonly workingDir: string;
+	/** Arguments after `--` on the CLI. Empty unless this task was explicitly requested. */
+	readonly passthroughArgs: readonly string[];
 }

--- a/packages/nadle/src/core/models/cache/cache-key.ts
+++ b/packages/nadle/src/core/models/cache/cache-key.ts
@@ -9,6 +9,7 @@ export namespace CacheKey {
 		readonly env?: TaskEnv;
 		readonly options?: object;
 		readonly taskId: TaskIdentifier;
+		readonly passthroughArgs?: readonly string[];
 		readonly inputsFingerprints: FileFingerprints;
 		readonly dependencyFingerprints?: Record<string, string>;
 	}

--- a/packages/nadle/src/core/options/cli-options-resolver.ts
+++ b/packages/nadle/src/core/options/cli-options-resolver.ts
@@ -41,6 +41,7 @@ const transform =
 	};
 
 const transformers = [
+	transform("--", { transformKey: "passthroughArgs" }),
 	exclude((key) => aliases.includes(key)),
 	exclude((key) => key.includes(DASH)),
 	exclude("$0"),

--- a/packages/nadle/src/core/options/options-resolver.ts
+++ b/packages/nadle/src/core/options/options-resolver.ts
@@ -28,6 +28,7 @@ export class OptionsResolver {
 		reporter: "default",
 		implicitDependencies: true,
 		excludedTasks: [] as string[],
+		passthroughArgs: [] as string[],
 		footer: !isCI && !!process.stdout.isTTY,
 
 		isWorkerThread: false

--- a/packages/nadle/src/core/options/types.ts
+++ b/packages/nadle/src/core/options/types.ts
@@ -39,6 +39,8 @@ export interface NadleCLIOptions extends NadleBaseOptions {
 	readonly tasks: string[];
 	/** List of tasks to exclude from execution. */
 	readonly excludedTasks?: string[];
+	/** Arguments after `--` on the command line, passed through to requested tasks. */
+	readonly passthroughArgs?: string[];
 
 	/** List all available tasks. */
 	readonly list: boolean;

--- a/packages/nadle/src/core/utilities/messages.ts
+++ b/packages/nadle/src/core/utilities/messages.ts
@@ -15,6 +15,8 @@ export const Messages = {
 		`Task ${highlight(taskName)} already registered in workspace ${highlight(workspaceId)}`,
 	NoTasksFound: () =>
 		`No tasks were specified. Please specify one or more tasks to execute, or use the ${highlight("--list")} option to view available tasks.`,
+	PassthroughArgsNotice: (args: string[], taskLabels: string[]) =>
+		`Passing extra arguments [${args.join(" ")}] to ${taskLabels.length} tasks: ${taskLabels.join(", ")}`,
 	UnresolvedTaskWithoutSuggestions: (taskNameInput: string, targetWorkspaceId: string) =>
 		`Task ${highlight(taskNameInput)} not found in ${highlight(targetWorkspaceId)} workspace.`,
 	InvalidTaskName: (taskName: string) =>

--- a/packages/nadle/test/__snapshots__/builtin-tasks/delete-task.test.ts.snap
+++ b/packages/nadle/test/__snapshots__/builtin-tasks/delete-task.test.ts.snap
@@ -94,6 +94,7 @@ Command: /ROOT/nadle.mjs --max-workers 1 --no-footer deleteJsonFiles --log-level
   "reporter": "default",
   "implicitDependencies": true,
   "excludedTasks": [],
+  "passthroughArgs": [],
   "footer": false,
   "isWorkerThread": false,
   "tasks": [

--- a/packages/nadle/test/__snapshots__/builtin-tasks/node-task.test.ts.snap
+++ b/packages/nadle/test/__snapshots__/builtin-tasks/node-task.test.ts.snap
@@ -22,6 +22,7 @@ Command: /ROOT/nadle.mjs --max-workers 1 --no-footer pass --log-level info
   "reporter": "default",
   "implicitDependencies": true,
   "excludedTasks": [],
+  "passthroughArgs": [],
   "footer": false,
   "isWorkerThread": false,
   "tasks": [

--- a/packages/nadle/test/__snapshots__/builtin-tasks/npm-task.test.ts.snap
+++ b/packages/nadle/test/__snapshots__/builtin-tasks/npm-task.test.ts.snap
@@ -22,6 +22,7 @@ Command: /ROOT/nadle.mjs --max-workers 1 --no-footer pass --log-level info
   "reporter": "default",
   "implicitDependencies": true,
   "excludedTasks": [],
+  "passthroughArgs": [],
   "footer": false,
   "isWorkerThread": false,
   "tasks": [

--- a/packages/nadle/test/__snapshots__/builtin-tasks/npx-task.test.ts.snap
+++ b/packages/nadle/test/__snapshots__/builtin-tasks/npx-task.test.ts.snap
@@ -22,6 +22,7 @@ Command: /ROOT/nadle.mjs --max-workers 1 --no-footer pass --log-level info
   "reporter": "default",
   "implicitDependencies": true,
   "excludedTasks": [],
+  "passthroughArgs": [],
   "footer": false,
   "isWorkerThread": false,
   "tasks": [

--- a/packages/nadle/test/__snapshots__/builtin-tasks/pnpm-task.test.ts.snap
+++ b/packages/nadle/test/__snapshots__/builtin-tasks/pnpm-task.test.ts.snap
@@ -22,6 +22,7 @@ Command: /ROOT/nadle.mjs --max-workers 1 --no-footer pass --log-level info
   "reporter": "default",
   "implicitDependencies": true,
   "excludedTasks": [],
+  "passthroughArgs": [],
   "footer": false,
   "isWorkerThread": false,
   "tasks": [

--- a/packages/nadle/test/__snapshots__/builtin-tasks/pnpx-task.test.ts.snap
+++ b/packages/nadle/test/__snapshots__/builtin-tasks/pnpx-task.test.ts.snap
@@ -22,6 +22,7 @@ Command: /ROOT/nadle.mjs --max-workers 1 --no-footer pass --log-level info
   "reporter": "default",
   "implicitDependencies": true,
   "excludedTasks": [],
+  "passthroughArgs": [],
   "footer": false,
   "isWorkerThread": false,
   "tasks": [

--- a/packages/nadle/test/__snapshots__/options/config-key.test.ts.snap
+++ b/packages/nadle/test/__snapshots__/options/config-key.test.ts.snap
@@ -16,6 +16,7 @@ Command: /ROOT/nadle.mjs --max-workers 1 --no-footer --show-config --config-key
   "reporter": "default",
   "implicitDependencies": true,
   "excludedTasks": [],
+  "passthroughArgs": [],
   "footer": false,
   "isWorkerThread": false,
   "tasks": [],

--- a/packages/nadle/test/__snapshots__/options/help.test.ts.snap
+++ b/packages/nadle/test/__snapshots__/options/help.test.ts.snap
@@ -47,4 +47,7 @@ Miscellaneous options:
 Options:
       --reporter  Output reporter: 'default' (human) or 'agent' (compact, plain, for agents/scripts)
                                            [string] [choices: "default", "agent"] [default: default]
+
+Examples:
+  nadle test -- -u  Run the test task, passing -u through to its underlying command
 `;

--- a/packages/nadle/test/__snapshots__/options/show-config.test.ts.snap
+++ b/packages/nadle/test/__snapshots__/options/show-config.test.ts.snap
@@ -16,6 +16,7 @@ Command: /ROOT/nadle.mjs --max-workers 1 --no-footer hello --show-config
   "reporter": "default",
   "implicitDependencies": true,
   "excludedTasks": [],
+  "passthroughArgs": [],
   "footer": false,
   "isWorkerThread": false,
   "tasks": [
@@ -75,6 +76,7 @@ Command: /ROOT/nadle.mjs --no-footer hello --show-config --min-workers 2 --max-w
   "reporter": "default",
   "implicitDependencies": true,
   "excludedTasks": [],
+  "passthroughArgs": [],
   "footer": false,
   "isWorkerThread": false,
   "tasks": [

--- a/packages/nadle/test/features/passthrough-args.test.ts
+++ b/packages/nadle/test/features/passthrough-args.test.ts
@@ -83,6 +83,17 @@ describe.concurrent("passthrough args", () => {
 			}
 		}));
 
+	it("passes args to every glob-matched task", () =>
+		withGeneratedFixture({
+			files: execFiles,
+			testFn: async ({ exec }) => {
+				const stdout = await getStdout(exec`echo-* -- --flag`);
+
+				expect(stdout).toContain("A:--flag");
+				expect(stdout).toContain("B:--flag");
+			}
+		}));
+
 	it("logs a notice when multiple requested tasks receive args", () =>
 		withGeneratedFixture({
 			files: execFiles,

--- a/packages/nadle/test/features/passthrough-args.test.ts
+++ b/packages/nadle/test/features/passthrough-args.test.ts
@@ -82,6 +82,26 @@ describe.concurrent("passthrough args", () => {
 			}
 		}));
 
+	it("logs a notice when multiple requested tasks receive args", () =>
+		withGeneratedFixture({
+			files: execFiles,
+			testFn: async ({ exec }) => {
+				const stdout = await getStdout(exec`echo-a echo-b -- --flag`);
+
+				expect(stdout).toContain("Passing extra arguments [--flag] to 2 tasks");
+			}
+		}));
+
+	it("logs no notice for a single requested task", () =>
+		withGeneratedFixture({
+			files: execFiles,
+			testFn: async ({ exec }) => {
+				const stdout = await getStdout(exec`echo-a -- --flag`);
+
+				expect(stdout).not.toContain("Passing extra arguments");
+			}
+		}));
+
 	it("still rejects unknown flags before --", () =>
 		withGeneratedFixture({
 			files,

--- a/packages/nadle/test/features/passthrough-args.test.ts
+++ b/packages/nadle/test/features/passthrough-args.test.ts
@@ -1,3 +1,4 @@
+import { isWindows } from "std-env";
 import { it, expect, describe } from "vitest";
 import { settle, fixture, getStdout, withGeneratedFixture } from "setup";
 
@@ -111,5 +112,65 @@ describe.concurrent("passthrough args", () => {
 				expect(exitCode).not.toBe(0);
 				expect(stderr).toContain("unknown-flag");
 			}
+		}));
+});
+
+const cachedFiles = fixture()
+	.packageJson("passthrough-args-cache")
+	.file("input.txt", "content")
+	.configRaw(
+		[
+			`import Path from "node:path";`,
+			`import Fs from "node:fs/promises";`,
+			``,
+			`import { tasks, Inputs, Outputs } from "nadle";`,
+			``,
+			`tasks`,
+			`\t.register("emit", async ({ context }) => {`,
+			`\t\tawait Fs.writeFile(Path.join(context.workingDir, "out.txt"), "done");`,
+			`\t})`,
+			`\t.config({ inputs: [Inputs.files("input.txt")], outputs: [Outputs.files("out.txt")] });`
+		].join("\n")
+	)
+	.build();
+
+describe.skipIf(isWindows).concurrent("passthrough args in cache key", () => {
+	it("does not reuse the no-args cache entry when args are passed", () =>
+		withGeneratedFixture({
+			files: cachedFiles,
+			testFn: async ({ exec }) => {
+				await exec`emit`;
+
+				await expect(getStdout(exec`emit`)).resolves.toSettle("emit", "up-to-date");
+				await expect(getStdout(exec`emit -- -u`)).resolves.toSettle("emit", "done");
+			}
+		}));
+
+	it("keeps dependency tasks cached when args are passed to the requested task", () =>
+		withGeneratedFixture({
+			testFn: async ({ exec }) => {
+				await exec`verify`;
+
+				await expect(getStdout(exec`verify -- -u`)).resolves.toSettle("prepare", "up-to-date");
+			},
+			files: fixture()
+				.packageJson("passthrough-args-cache-dep")
+				.file("input.txt", "content")
+				.configRaw(
+					[
+						`import Path from "node:path";`,
+						`import Fs from "node:fs/promises";`,
+						``,
+						`import { tasks, Inputs, Outputs } from "nadle";`,
+						``,
+						`tasks`,
+						`\t.register("prepare", async ({ context }) => {`,
+						`\t\tawait Fs.writeFile(Path.join(context.workingDir, "out.txt"), "done");`,
+						`\t})`,
+						`\t.config({ inputs: [Inputs.files("input.txt")], outputs: [Outputs.files("out.txt")] });`,
+						`tasks.register("verify", () => {}).config({ dependsOn: ["prepare"] });`
+					].join("\n")
+				)
+				.build()
 		}));
 });

--- a/packages/nadle/test/features/passthrough-args.test.ts
+++ b/packages/nadle/test/features/passthrough-args.test.ts
@@ -103,6 +103,17 @@ describe.concurrent("passthrough args", () => {
 			}
 		}));
 
+	it("shows args on requested tasks in dry run", () =>
+		withGeneratedFixture({
+			files,
+			testFn: async ({ exec }) => {
+				const stdout = await getStdout(exec`build --dry-run -- -u`);
+
+				expect(stdout).toContain("build (args: -u)");
+				expect(stdout).not.toContain("compile (args:");
+			}
+		}));
+
 	it("still rejects unknown flags before --", () =>
 		withGeneratedFixture({
 			files,

--- a/packages/nadle/test/features/passthrough-args.test.ts
+++ b/packages/nadle/test/features/passthrough-args.test.ts
@@ -1,0 +1,62 @@
+import { it, expect, describe } from "vitest";
+import { settle, fixture, getStdout, withGeneratedFixture } from "setup";
+
+const echoArgs = `({ context }) => console.log("ARGS=[" + context.passthroughArgs.join(" ") + "]")`;
+
+const files = fixture()
+	.packageJson("passthrough-args")
+	.configRaw(
+		[
+			`import { tasks } from "nadle";`,
+			``,
+			`tasks.register("compile", ${echoArgs});`,
+			`tasks.register("build", ${echoArgs}).config({ dependsOn: ["compile"] });`,
+			`tasks.register("verify", ${echoArgs});`
+		].join("\n")
+	)
+	.build();
+
+describe.concurrent("passthrough args", () => {
+	it("passes args after -- to the requested task", () =>
+		withGeneratedFixture({
+			files,
+			testFn: async ({ exec }) => {
+				const stdout = await getStdout(exec`verify -- -u --silent`);
+
+				expect(stdout).toContain("ARGS=[-u --silent]");
+			}
+		}));
+
+	it("does not pass args to dependency tasks", () =>
+		withGeneratedFixture({
+			files,
+			testFn: async ({ exec }) => {
+				const stdout = await getStdout(exec`build -- -u`);
+
+				// compile (dependency) sees no args; build (requested) sees -u
+				expect(stdout).toContain("ARGS=[]");
+				expect(stdout).toContain("ARGS=[-u]");
+			}
+		}));
+
+	it("exposes an empty array when no -- is given", () =>
+		withGeneratedFixture({
+			files,
+			testFn: async ({ exec }) => {
+				const stdout = await getStdout(exec`verify`);
+
+				expect(stdout).toContain("ARGS=[]");
+			}
+		}));
+
+	it("still rejects unknown flags before --", () =>
+		withGeneratedFixture({
+			files,
+			testFn: async ({ exec }) => {
+				const { stderr, exitCode } = await settle(exec`verify --unknown-flag -- -u`);
+
+				expect(exitCode).not.toBe(0);
+				expect(stderr).toContain("unknown-flag");
+			}
+		}));
+});

--- a/packages/nadle/test/features/passthrough-args.test.ts
+++ b/packages/nadle/test/features/passthrough-args.test.ts
@@ -16,6 +16,18 @@ const files = fixture()
 	)
 	.build();
 
+const execFiles = fixture()
+	.packageJson("passthrough-args-exec")
+	.configRaw(
+		[
+			`import { tasks, ExecTask } from "nadle";`,
+			``,
+			`tasks.register("echo-a", ExecTask, { command: "node", args: ["-e", "console.log('A:' + process.argv.slice(1).join(' '))", "--"] });`,
+			`tasks.register("echo-b", ExecTask, { command: "node", args: ["-e", "console.log('B:' + process.argv.slice(1).join(' '))", "--"] });`
+		].join("\n")
+	)
+	.build();
+
 describe.concurrent("passthrough args", () => {
 	it("passes args after -- to the requested task", () =>
 		withGeneratedFixture({
@@ -46,6 +58,27 @@ describe.concurrent("passthrough args", () => {
 				const stdout = await getStdout(exec`verify`);
 
 				expect(stdout).toContain("ARGS=[]");
+			}
+		}));
+
+	it("appends args to ExecTask commands", () =>
+		withGeneratedFixture({
+			files: execFiles,
+			testFn: async ({ exec }) => {
+				const stdout = await getStdout(exec`echo-a -- --flag value`);
+
+				expect(stdout).toContain("A:--flag value");
+			}
+		}));
+
+	it("appends the same args to every requested task", () =>
+		withGeneratedFixture({
+			files: execFiles,
+			testFn: async ({ exec }) => {
+				const stdout = await getStdout(exec`echo-a echo-b -- --flag`);
+
+				expect(stdout).toContain("A:--flag");
+				expect(stdout).toContain("B:--flag");
 			}
 		}));
 

--- a/packages/nadle/test/unit/cache-key.test.ts
+++ b/packages/nadle/test/unit/cache-key.test.ts
@@ -1,0 +1,20 @@
+import { it, expect, describe } from "vitest";
+import { CacheKey } from "src/core/models/cache/cache-key.js";
+
+const base = { taskId: "build", inputsFingerprints: {} };
+
+describe.concurrent("CacheKey", () => {
+	it("changes when passthrough args change", async () => {
+		const without = await CacheKey.compute(base);
+		const withArgs = await CacheKey.compute({ ...base, passthroughArgs: ["-u"] });
+
+		expect(withArgs).not.toBe(without);
+	});
+
+	it("changes when passthrough args values differ", async () => {
+		const first = await CacheKey.compute({ ...base, passthroughArgs: ["-u"] });
+		const second = await CacheKey.compute({ ...base, passthroughArgs: ["--reporter", "dot"] });
+
+		expect(first).not.toBe(second);
+	});
+});

--- a/packages/nadle/test/unit/cli-options-resolver.test.ts
+++ b/packages/nadle/test/unit/cli-options-resolver.test.ts
@@ -71,6 +71,19 @@ describe.concurrent("CLIOptionsResolver.resolve", () => {
 		expect(result).not.toHaveProperty("config");
 	});
 
+	it("captures args after -- into passthroughArgs", () => {
+		const result = CLIOptionsResolver.resolve({ tasks: ["test"], "--": ["-u", "--reporter", "dot"] });
+
+		expect(result.passthroughArgs).toEqual(["-u", "--reporter", "dot"]);
+		expect(result).not.toHaveProperty("--");
+	});
+
+	it("omits passthroughArgs when -- is absent", () => {
+		const result = CLIOptionsResolver.resolve({ tasks: ["test"] });
+
+		expect(result.passthroughArgs).toBeUndefined();
+	});
+
 	it("preserves other valid options", () => {
 		const result = CLIOptionsResolver.resolve({
 			footer: false,

--- a/spec/09-cli.md
+++ b/spec/09-cli.md
@@ -26,6 +26,29 @@ names of the resolved workspace:
 Glob patterns apply equally to the `--exclude` option. Because task names never contain glob
 characters, an input is treated as a glob if and only if it contains one.
 
+### Argument Passthrough
+
+Arguments after the first bare `--` are not parsed as Nadle options; they are captured
+verbatim and passed through to tasks.
+
+```
+nadle <tasks...> [options] -- <args...>
+```
+
+Rules:
+
+- Passthrough arguments are delivered only to tasks explicitly requested on the command
+  line (including tasks matched by a glob pattern). Dependency tasks never receive them.
+- Every requested task receives the same arguments. When more than one requested task
+  will receive arguments, an informational notice is logged.
+- Task runners access the arguments via the runner context (`passthroughArgs`).
+  Exec-based builtin tasks append them to their underlying command.
+- Passthrough arguments participate in the cache key of requested tasks; an invocation
+  with arguments is never served from a cache entry produced without them. Dependency
+  task cache keys are unaffected.
+- Strict option parsing still applies before `--`: unknown Nadle flags remain an error.
+- Dry run annotates requested tasks with the arguments they would receive.
+
 ## Flags
 
 ### Execution Options

--- a/spec/10-builtin-tasks.md
+++ b/spec/10-builtin-tasks.md
@@ -177,6 +177,9 @@ All built-in tasks share these characteristics:
 
 - They all respect the `workingDir` from the runner context.
 - ExecTask, NodeTask, NpmTask, NpxTask, PnpmTask, and PnpxTask force color output via `FORCE_COLOR=1` environment variable.
+- ExecTask, NodeTask, NpmTask, NpxTask, PnpmTask, and PnpxTask append the runner context's
+  passthrough arguments (CLI args after `--`, see spec 09) after their configured arguments.
+  CopyTask and DeleteTask ignore passthrough arguments.
 - All tasks stream output through the task logger.
 
 ## Custom Task Types

--- a/spec/CHANGELOG.md
+++ b/spec/CHANGELOG.md
@@ -8,6 +8,19 @@ Versioning follows [Semantic Versioning](https://semver.org/):
 - **MINOR**: New concept, new section, or materially expanded rules
 - **PATCH**: Clarifications, corrections, wording improvements
 
+## 1.13.0 — 2026-06-10
+
+### Added
+
+- 09-cli: Argument passthrough — CLI args after the first bare `--` are captured
+  verbatim and delivered only to explicitly requested tasks (glob matches included);
+  dependency tasks never receive them. Args are exposed on the runner context
+  (`passthroughArgs`), appended by exec-based builtin tasks, included in the cache
+  key of requested tasks, surfaced in dry run, and a notice is logged when more than
+  one requested task receives them.
+- 10-builtin-tasks: Documented which builtin tasks consume passthrough arguments
+  (exec-based ones append; CopyTask and DeleteTask ignore).
+
 ## 1.12.0 — 2026-06-07
 
 ### Added

--- a/spec/README.md
+++ b/spec/README.md
@@ -1,6 +1,6 @@
 # Nadle Specification
 
-**Version**: 1.12.0
+**Version**: 1.13.0
 
 This directory contains the language-agnostic specification for Nadle, a type-safe,
 Gradle-inspired task runner for Node.js.


### PR DESCRIPTION
Implements #525 per `docs/superpowers/specs/2026-06-10-cli-passthrough-args-design.md`.

## Summary
- Capture args after `--` (yargs `populate--`), thread through options to workers
- `RunnerContext.passthroughArgs` — populated only for explicitly requested tasks (incl. glob matches); dependency tasks receive `[]`
- Exec-based builtins (Exec/Pnpm/Pnpx/Npm/Npx/Node) append the args; Copy/Delete ignore them
- Args participate in the cache key of requested tasks only; empty args keep existing cache entries valid (key omitted, not `undefined` — object-hash treats them differently)
- Notice logged when multiple requested tasks receive args; dry run annotates requested tasks; CLI help example
- Spec 1.13.0 (09-cli Argument Passthrough section, 10-builtin-tasks) + docs guide update
- 12 integration tests + unit tests for resolver capture and cache key

Closes #525

🤖 Generated with [Claude Code](https://claude.com/claude-code)