### PR TITLE
fix: glob once in DeleteTask so logged paths match deleted paths

### DIFF
--- a/packages/nadle/src/builtin-tasks/delete-task.ts
+++ b/packages/nadle/src/builtin-tasks/delete-task.ts
@@ -1,3 +1,5 @@
+import Path from "node:path";
+
 import { glob } from "glob";
 import { rimraf, type RimrafAsyncOptions } from "rimraf";
 
@@ -24,10 +26,15 @@ export const DeleteTask = defineTask<DeleteTaskOptions>({
 		const { paths, ...restOptions } = options;
 		const { workingDir } = context;
 
+		// Glob once and delete the resolved paths literally, so the logged list is
+		// exactly what gets deleted (no second, independent glob inside rimraf).
 		const matchPaths = await glob(paths, { cwd: workingDir });
 		context.logger.info(`Current working dir: ${workingDir}`);
 		context.logger.info("Deleting paths:", matchPaths.map(normalizeGlobPath).join(", "));
 
-		await rimraf(paths, { ...restOptions, glob: { cwd: workingDir, ...restOptions } });
+		await rimraf(
+			matchPaths.map((matchPath) => Path.resolve(workingDir, matchPath)),
+			restOptions
+		);
 	}
 });


### PR DESCRIPTION
Fixes #602.

`DeleteTask` previously globbed twice: once to build the log line, then again inside `rimraf` to delete — the two expansions could diverge if the filesystem changed in between. `restOptions` was also spread into both the top-level rimraf options and the nested `glob` options, mixing two different option sets.

Now: glob once, log the matches, and pass the resolved absolute paths to rimraf literally (no second glob). `restOptions` applies only at the top level.

All 6 existing DeleteTask integration tests pass unchanged (the race itself is not deterministically testable; they serve as the regression net).

🤖 Generated with [Claude Code](https://claude.com/claude-code)