### PR TITLE
refactor: extract shared command runner for exec-based builtin tasks

### DIFF
--- a/packages/nadle/src/builtin-tasks/exec-task.ts
+++ b/packages/nadle/src/builtin-tasks/exec-task.ts
@@ -1,5 +1,6 @@
-import { execa, parseCommandString } from "execa";
+import { parseCommandString } from "execa";
 
+import { runCommand } from "./run-command.js";
 import type { MaybeArray } from "../core/index.js";
 import { defineTask } from "../core/registration/define-task.js";
 
@@ -22,17 +23,11 @@ export const ExecTask = defineTask<ExecTaskOptions>({
 	run: async ({ options, context }) => {
 		const { args, command } = options;
 
-		const commandArguments = [...(args == null ? [] : typeof args === "string" ? parseCommandString(args) : args), ...context.passthroughArgs];
-
-		context.logger.info(`Running command: ${command} ${commandArguments.join(" ")}`);
-
-		const subprocess = execa(command, commandArguments, { all: true, cwd: context.workingDir, env: { FORCE_COLOR: "1" } });
-
-		subprocess.all?.on("data", (chunk) => {
-			context.logger.log(chunk.toString());
+		await runCommand(context, {
+			command,
+			doneMessage: `Run completed successfully.`,
+			startMessage: (finalArgs) => `Running command: ${command} ${finalArgs.join(" ")}`,
+			args: args == null ? [] : typeof args === "string" ? parseCommandString(args) : args
 		});
-
-		await subprocess;
-		context.logger.info(`Run completed successfully.`);
 	}
 });

--- a/packages/nadle/src/builtin-tasks/node-task.ts
+++ b/packages/nadle/src/builtin-tasks/node-task.ts
@@ -1,5 +1,4 @@
-import { execa } from "execa";
-
+import { runCommand } from "./run-command.js";
 import type { MaybeArray } from "../core/index.js";
 import { defineTask } from "../core/registration/define-task.js";
 
@@ -20,18 +19,13 @@ export interface NodeTaskOptions {
  */
 export const NodeTask = defineTask<NodeTaskOptions>({
 	run: async ({ options, context }) => {
-		const args = [...(options.args == null ? [] : typeof options.args === "string" ? [options.args] : options.args), ...context.passthroughArgs];
+		const args = options.args == null ? [] : typeof options.args === "string" ? [options.args] : options.args;
 
-		context.logger.info(`Running node script: node ${options.script} ${args.join(" ")}`);
-
-		const subprocess = execa("node", [options.script, ...args], { all: true, cwd: context.workingDir, env: { FORCE_COLOR: "1" } });
-
-		subprocess.all?.on("data", (chunk) => {
-			context.logger.log(chunk.toString());
+		await runCommand(context, {
+			command: "node",
+			args: [options.script, ...args],
+			doneMessage: `Node script completed successfully.`,
+			startMessage: (finalArgs) => `Running node script: node ${finalArgs.join(" ")}`
 		});
-
-		await subprocess;
-
-		context.logger.info(`Node script completed successfully.`);
 	}
 });

--- a/packages/nadle/src/builtin-tasks/npm-task.ts
+++ b/packages/nadle/src/builtin-tasks/npm-task.ts
@@ -1,5 +1,4 @@
-import { execa } from "execa";
-
+import { runCommand } from "./run-command.js";
 import { MaybeArray } from "../core/index.js";
 import { defineTask } from "../core/registration/define-task.js";
 
@@ -18,18 +17,11 @@ export interface NpmTaskOptions {
  */
 export const NpmTask = defineTask<NpmTaskOptions>({
 	run: async ({ options, context }) => {
-		const args = [...MaybeArray.toArray(options.args), ...context.passthroughArgs];
-
-		context.logger.info(`Running npm command: npm ${args.join(" ")}`);
-
-		const subprocess = execa("npm", args, { all: true, cwd: context.workingDir, env: { FORCE_COLOR: "1" } });
-
-		subprocess.all?.on("data", (chunk) => {
-			context.logger.log(chunk.toString());
+		await runCommand(context, {
+			command: "npm",
+			args: MaybeArray.toArray(options.args),
+			doneMessage: `npm command completed successfully.`,
+			startMessage: (finalArgs) => `Running npm command: npm ${finalArgs.join(" ")}`
 		});
-
-		await subprocess;
-
-		context.logger.info(`npm command completed successfully.`);
 	}
 });

--- a/packages/nadle/src/builtin-tasks/npx-task.ts
+++ b/packages/nadle/src/builtin-tasks/npx-task.ts
@@ -1,5 +1,4 @@
-import { execa } from "execa";
-
+import { runCommand } from "./run-command.js";
 import { MaybeArray } from "../core/index.js";
 import { defineTask } from "../core/registration/define-task.js";
 
@@ -20,18 +19,13 @@ export interface NpxTaskOptions {
  */
 export const NpxTask = defineTask<NpxTaskOptions>({
 	run: async ({ options, context }) => {
-		const args = [...(options.args == null ? [] : MaybeArray.toArray(options.args)), ...context.passthroughArgs];
+		const args = options.args == null ? [] : MaybeArray.toArray(options.args);
 
-		context.logger.info(`Running npx command: npx ${options.command} ${args.join(" ")}`);
-
-		const subprocess = execa("npx", [options.command, ...args], { all: true, cwd: context.workingDir, env: { FORCE_COLOR: "1" } });
-
-		subprocess.all?.on("data", (chunk) => {
-			context.logger.log(chunk.toString());
+		await runCommand(context, {
+			command: "npx",
+			args: [options.command, ...args],
+			doneMessage: `npx command completed successfully.`,
+			startMessage: (finalArgs) => `Running npx command: npx ${finalArgs.join(" ")}`
 		});
-
-		await subprocess;
-
-		context.logger.info(`npx command completed successfully.`);
 	}
 });

--- a/packages/nadle/src/builtin-tasks/pnpm-task.ts
+++ b/packages/nadle/src/builtin-tasks/pnpm-task.ts
@@ -1,5 +1,4 @@
-import { execa } from "execa";
-
+import { runCommand } from "./run-command.js";
 import { MaybeArray } from "../core/index.js";
 import { defineTask } from "../core/registration/define-task.js";
 
@@ -23,18 +22,12 @@ export interface PnpmTaskOptions {
 export const PnpmTask = defineTask<PnpmTaskOptions>({
 	run: async ({ options, context }) => {
 		const filterArgs = MaybeArray.toArray(options.filter ?? []).flatMap((filter) => ["--filter", filter]);
-		const args = [...filterArgs, ...MaybeArray.toArray(options.args), ...context.passthroughArgs];
 
-		context.logger.info(`Running pnpm command: pnpm ${args.join(" ")}`);
-
-		const subprocess = execa("pnpm", args, { all: true, cwd: context.workingDir, env: { FORCE_COLOR: "1" } });
-
-		subprocess.all?.on("data", (chunk) => {
-			context.logger.log(chunk.toString());
+		await runCommand(context, {
+			command: "pnpm",
+			doneMessage: `pnpm command completed successfully.`,
+			args: [...filterArgs, ...MaybeArray.toArray(options.args)],
+			startMessage: (finalArgs) => `Running pnpm command: pnpm ${finalArgs.join(" ")}`
 		});
-
-		await subprocess;
-
-		context.logger.info(`pnpm command completed successfully.`);
 	}
 });

--- a/packages/nadle/src/builtin-tasks/pnpx-task.ts
+++ b/packages/nadle/src/builtin-tasks/pnpx-task.ts
@@ -1,5 +1,4 @@
-import { execa } from "execa";
-
+import { runCommand } from "./run-command.js";
 import { MaybeArray } from "../core/index.js";
 import { defineTask } from "../core/registration/define-task.js";
 
@@ -20,18 +19,13 @@ export interface PnpxTaskOptions {
  */
 export const PnpxTask = defineTask<PnpxTaskOptions>({
 	run: async ({ options, context }) => {
-		const args = [...(options.args == null ? [] : MaybeArray.toArray(options.args)), ...context.passthroughArgs];
+		const args = options.args == null ? [] : MaybeArray.toArray(options.args);
 
-		context.logger.info(`Running pnpm exec command: pnpm exec ${options.command} ${args.join(" ")}`);
-
-		const subprocess = execa("pnpm", ["exec", options.command, ...args], { all: true, cwd: context.workingDir, env: { FORCE_COLOR: "1" } });
-
-		subprocess.all?.on("data", (chunk) => {
-			context.logger.log(chunk.toString());
+		await runCommand(context, {
+			command: "pnpm",
+			args: ["exec", options.command, ...args],
+			doneMessage: `pnpm exec command completed successfully.`,
+			startMessage: (finalArgs) => `Running pnpm exec command: pnpm ${finalArgs.join(" ")}`
 		});
-
-		await subprocess;
-
-		context.logger.info(`pnpm exec command completed successfully.`);
 	}
 });

--- a/packages/nadle/src/builtin-tasks/run-command.ts
+++ b/packages/nadle/src/builtin-tasks/run-command.ts
@@ -1,0 +1,44 @@
+import { execa } from "execa";
+
+import { type RunnerContext } from "../core/interfaces/task.js";
+import { TaskExecutionError } from "../core/utilities/nadle-error.js";
+
+interface RunCommandParams {
+	/** The binary to spawn. */
+	readonly command: string;
+	/** Info log line emitted after the command completes successfully. */
+	readonly doneMessage: string;
+	/** Configured arguments; the runner context's passthrough args are appended after them. */
+	readonly args: readonly string[];
+	/** Builds the info log line emitted before spawning, from the final argument list. */
+	readonly startMessage: (finalArgs: readonly string[]) => string;
+}
+
+/**
+ * Shared runner for exec-based builtin tasks: appends passthrough args, spawns the
+ * command in the task's working directory with forced color, streams combined
+ * output to the task logger, and wraps failures in a TaskExecutionError.
+ */
+export async function runCommand(context: RunnerContext, { args, command, doneMessage, startMessage }: RunCommandParams): Promise<void> {
+	const finalArgs = [...args, ...context.passthroughArgs];
+
+	context.logger.info(startMessage(finalArgs));
+
+	const subprocess = execa(command, finalArgs, { all: true, cwd: context.workingDir, env: { FORCE_COLOR: "1" } });
+
+	subprocess.all?.on("data", (chunk) => {
+		context.logger.log(chunk.toString());
+	});
+
+	try {
+		await subprocess;
+	} catch (error) {
+		const exitCode = (error as { exitCode?: number }).exitCode;
+
+		throw new TaskExecutionError(`Command failed${exitCode !== undefined ? ` with exit code ${exitCode}` : ""}: ${command} ${finalArgs.join(" ")}`, {
+			cause: error
+		});
+	}
+
+	context.logger.info(doneMessage);
+}


### PR DESCRIPTION
Fixes #600.

Extracts `runCommand()` (`packages/nadle/src/builtin-tasks/run-command.ts`) shared by all six exec-based builtins (`ExecTask`, `PnpmTask`, `PnpxTask`, `NpmTask`, `NpxTask`, `NodeTask`). It owns:

- the `execa` invocation (`FORCE_COLOR=1`, `all: true`, task `workingDir`)
- combined-output streaming to the task logger
- appending `context.passthroughArgs` (previously duplicated in each task)
- wrapping subprocess failures in `TaskExecutionError` with the full command and exit code (exit code stays 1)

Each task is now option normalization + a `runCommand` call. Log messages preserved byte-for-byte — all builtin-task snapshot tests pass unchanged, as do the passthrough-args integration tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)