### PR TITLE
feat: redesign CopyTask around file selections and a directory destination

### DIFF
--- a/packages/docs/docs/guides/registering-task.md
+++ b/packages/docs/docs/guides/registering-task.md
@@ -74,8 +74,8 @@ This makes it easy to reuse logic across multiple tasks without duplicating code
 import { tasks, CopyTask } from "nadle";
 
 tasks.register("copy", CopyTask, {
-	from: "assets/",
-	to: "dist/"
+	from: "assets",
+	into: "dist"
 });
 ```
 

--- a/packages/nadle/index.api.md
+++ b/packages/nadle/index.api.md
@@ -30,9 +30,13 @@ export const CopyTask: Task<CopyTaskOptions>;
 // @public
 export interface CopyTaskOptions {
     readonly exclude?: MaybeArray<string>;
-    readonly from: string;
+    readonly flatten?: boolean;
+    readonly from: MaybeArray<FileSelection>;
     readonly include?: MaybeArray<string>;
-    readonly to: string;
+    readonly into: string;
+    readonly overwrite?: "error" | "replace" | "skip";
+    readonly rename?: Record<string, string>;
+    readonly strict?: boolean;
 }
 
 // @public
@@ -77,6 +81,16 @@ export interface ExecTaskOptions {
 export interface FileDeclaration {
     readonly patterns: string[];
     readonly type: "file";
+}
+
+// @public
+export type FileSelection = string | FileSelector;
+
+// @public
+export interface FileSelector {
+    readonly dir: string;
+    readonly exclude?: MaybeArray<string>;
+    readonly include?: MaybeArray<string>;
 }
 
 // @public

--- a/packages/nadle/package.json
+++ b/packages/nadle/package.json
@@ -105,7 +105,7 @@
 	"size-limit": [
 		{
 			"path": "lib/**",
-			"limit": "145 KB",
+			"limit": "150 KB",
 			"name": "bundled",
 			"brotli": false
 		}

--- a/packages/nadle/src/builtin-tasks/copy-task.ts
+++ b/packages/nadle/src/builtin-tasks/copy-task.ts
@@ -1,139 +1,101 @@
 import Path from "node:path";
 import Fs from "node:fs/promises";
 
-import fg from "fast-glob";
-import micromatch from "micromatch";
-
-import { MaybeArray } from "../core/index.js";
+import { type MaybeArray } from "../core/index.js";
 import { isPathExists } from "../core/utilities/fs.js";
-import { type Logger } from "../core/interfaces/logger.js";
+import { type RunnerContext } from "../core/interfaces/task.js";
 import { defineTask } from "../core/registration/define-task.js";
+import { TaskExecutionError } from "../core/utilities/nadle-error.js";
+import { type SelectedFile, type FileSelection, resolveFileSelections } from "./file-selection.js";
 
 /**
  * Options for the CopyTask.
  */
 export interface CopyTaskOptions {
-	/** Destination path to copy to. */
-	readonly to: string;
-	/** Source path to copy from. */
-	readonly from: string;
-	/** Glob patterns to exclude from copying. */
-	readonly exclude?: MaybeArray<string>;
-	/** Glob patterns to include in copying. */
+	/** Destination directory. Created if missing. */
+	readonly into: string;
+	/** Fail when a source path is missing or no files match. Defaults to false. */
+	readonly strict?: boolean;
+	/** Copy all files directly into `into`, dropping source directory structure. */
+	readonly flatten?: boolean;
+	/** Default include patterns for directory selections without their own. */
 	readonly include?: MaybeArray<string>;
-}
-
-interface CopyContext {
-	readonly logger: Logger;
-	readonly srcPath: string;
-	readonly destPath: string;
-	readonly workingDir: string;
-	readonly includePatterns: string[];
-	readonly excludePatterns: string[];
+	/** Default exclude patterns for directory selections without their own. */
+	readonly exclude?: MaybeArray<string>;
+	/** Source file(s), directory(ies), or selector(s) with glob patterns. */
+	readonly from: MaybeArray<FileSelection>;
+	/** Renames by exact base name, e.g. `{ "config.dev.json": "config.json" }`. */
+	readonly rename?: Record<string, string>;
+	/** Behavior when a destination file already exists. Defaults to `replace`. */
+	readonly overwrite?: "error" | "replace" | "skip";
 }
 
 /**
  * Task for copying files and directories.
  *
- * Supports include/exclude glob patterns and handles both files and directories.
+ * Sources are files, directories, or glob selectors; the destination (`into`) is
+ * always a directory. Supports flattening, renaming, and overwrite policies.
  */
 export const CopyTask = defineTask<CopyTaskOptions>({
 	run: async ({ options, context }) => {
-		const { to, from, exclude = [], include = "**/*" } = options;
-		const { logger, workingDir } = context;
-
-		const srcPath = Path.resolve(workingDir, from);
-		const destPath = Path.resolve(workingDir, to);
-
-		logger.info(`Copying from ${from} to ${to} within working directory ${workingDir}`);
-		const includePatterns = MaybeArray.toArray(include);
-		const excludePatterns = MaybeArray.toArray(exclude);
-
-		logger.debug(`Include patterns: ${includePatterns.join(", ")}`);
-
-		if (excludePatterns.length > 0) {
-			logger.debug(`Exclude patterns: ${excludePatterns.join(", ")}`);
+		if (options.into === undefined) {
+			throw new TaskExecutionError(`CopyTask requires the 'into' option.`);
 		}
 
-		const srcPathExists = await isPathExists(srcPath);
+		const files = await resolveFileSelections({
+			logger: context.logger,
+			selections: options.from,
+			workingDir: context.workingDir,
+			strict: options.strict ?? false,
+			defaultInclude: options.include,
+			defaultExclude: options.exclude
+		});
 
-		if (!srcPathExists) {
-			logger.warn(`File '${srcPath}' does not exist.`);
+		const intoPath = Path.resolve(context.workingDir, options.into);
+		const targets = computeTargets(files, intoPath, options);
 
-			return;
-		}
-
-		const copyCtx: CopyContext = {
-			logger,
-			srcPath,
-			destPath,
-			workingDir,
-			includePatterns,
-			excludePatterns
-		};
-		const srcStat = await Fs.stat(srcPath);
-
-		if (srcStat.isDirectory()) {
-			await copyDirectory(copyCtx);
-			logger.info(`Copied directory ${from} to ${to}`);
-
-			return;
-		}
-
-		await copySingleFile(copyCtx);
-		logger.info(`Copied file ${from} to ${to}`);
+		await copyFiles(targets, options.overwrite ?? "replace", context);
+		context.logger.info(`Copied ${targets.size} file(s) into ${options.into}`);
 	}
 });
 
-async function copyDirectory(ctx: CopyContext): Promise<void> {
-	const { logger, srcPath, destPath, workingDir, includePatterns, excludePatterns } = ctx;
-
-	await Fs.mkdir(destPath, { recursive: true });
-
-	const files = await fg(includePatterns, {
-		dot: true,
-		cwd: srcPath,
-		onlyFiles: true,
-		ignore: excludePatterns
-	});
-
-	logger.info(`Found ${files.length} file(s) to copy`);
+function computeTargets(files: SelectedFile[], intoPath: string, options: Pick<CopyTaskOptions, "rename" | "flatten">): Map<string, string> {
+	const targets = new Map<string, string>();
 
 	for (const file of files) {
-		const source = Path.join(srcPath, file);
-		const target = Path.join(destPath, file);
+		let relativePath = options.flatten ? Path.basename(file.relativePath) : file.relativePath;
+		const renamed = options.rename?.[Path.basename(relativePath)];
 
-		await Fs.mkdir(Path.dirname(target), { recursive: true });
-		logger.log(`Copy ${Path.relative(workingDir, source)} -> ${Path.relative(workingDir, target)}`);
-		await Fs.cp(source, target);
+		if (renamed !== undefined) {
+			relativePath = Path.join(Path.dirname(relativePath), renamed);
+		}
+
+		const target = Path.join(intoPath, relativePath);
+		const existingSource = targets.get(target);
+
+		if (existingSource !== undefined) {
+			throw new TaskExecutionError(`Both '${existingSource}' and '${file.source}' map to the same destination '${target}'.`);
+		}
+
+		targets.set(target, file.source);
 	}
+
+	return targets;
 }
 
-async function copySingleFile(ctx: CopyContext): Promise<void> {
-	const { logger, srcPath, destPath, workingDir, includePatterns, excludePatterns } = ctx;
+async function copyFiles(targets: Map<string, string>, overwrite: "error" | "replace" | "skip", context: RunnerContext): Promise<void> {
+	for (const [target, source] of targets) {
+		if (overwrite !== "replace" && (await isPathExists(target))) {
+			if (overwrite === "error") {
+				throw new TaskExecutionError(`Destination '${target}' already exists.`);
+			}
 
-	let targetFile = destPath;
-
-	try {
-		const destStat = await Fs.stat(destPath);
-
-		if (destStat.isDirectory()) {
-			targetFile = Path.join(destPath, Path.basename(srcPath));
+			context.logger.info(`Skip existing ${Path.relative(context.workingDir, target)}`);
+			continue;
 		}
-	} catch {
-		if (destPath.endsWith(Path.sep)) {
-			targetFile = Path.join(destPath, Path.basename(srcPath));
-		}
-	}
 
-	if (
-		!micromatch.isMatch(Path.basename(srcPath), includePatterns) ||
-		(excludePatterns.length > 0 && micromatch.isMatch(Path.basename(srcPath), excludePatterns))
-	) {
-		return;
+		await Fs.mkdir(Path.dirname(target), { recursive: true });
+		context.logger.log(`Copy ${Path.relative(context.workingDir, source)} -> ${Path.relative(context.workingDir, target)}`);
+		await Fs.cp(source, target);
 	}
-
-	await Fs.mkdir(Path.dirname(targetFile), { recursive: true });
-	logger.log(`Copy ${Path.relative(workingDir, srcPath)} -> ${Path.relative(workingDir, targetFile)}`);
-	await Fs.cp(srcPath, targetFile);
 }

--- a/packages/nadle/src/builtin-tasks/file-selection.ts
+++ b/packages/nadle/src/builtin-tasks/file-selection.ts
@@ -1,0 +1,98 @@
+import Path from "node:path";
+import Fs from "node:fs/promises";
+
+import fg from "fast-glob";
+
+import { MaybeArray } from "../core/index.js";
+import { isPathExists } from "../core/utilities/fs.js";
+import { type Logger } from "../core/interfaces/logger.js";
+import { TaskExecutionError } from "../core/utilities/nadle-error.js";
+
+/**
+ * Selects files relative to a base directory using glob patterns.
+ *
+ * @public
+ */
+export interface FileSelector {
+	/** Base directory the patterns are matched against. */
+	readonly dir: string;
+	/** Glob patterns to include. Defaults to all files. */
+	readonly include?: MaybeArray<string>;
+	/** Glob patterns to exclude. */
+	readonly exclude?: MaybeArray<string>;
+}
+
+/**
+ * A source of files for file-operation tasks: a path to a file or directory,
+ * or a {@link FileSelector} with glob patterns.
+ *
+ * @public
+ */
+export type FileSelection = string | FileSelector;
+
+/** A file resolved from a selection: absolute source path plus destination-relative path. */
+export interface SelectedFile {
+	readonly source: string;
+	readonly relativePath: string;
+}
+
+interface ResolveParams {
+	readonly logger: Logger;
+	readonly strict: boolean;
+	readonly workingDir: string;
+	/** Fallback include patterns for selections that do not declare their own. */
+	readonly defaultInclude?: MaybeArray<string>;
+	/** Fallback exclude patterns for selections that do not declare their own. */
+	readonly defaultExclude?: MaybeArray<string>;
+	readonly selections: MaybeArray<FileSelection>;
+}
+
+/**
+ * Resolves file selections to concrete files. A string selection pointing to a file
+ * yields that file; one pointing to a directory selects files inside it by pattern.
+ * Missing sources fail in strict mode and log a warning otherwise.
+ */
+export async function resolveFileSelections(params: ResolveParams): Promise<SelectedFile[]> {
+	const selected: SelectedFile[] = [];
+
+	for (const selection of MaybeArray.toArray(params.selections)) {
+		selected.push(...(await resolveSelection(selection, params)));
+	}
+
+	if (params.strict && selected.length === 0) {
+		throw new TaskExecutionError(`No files matched the configured sources.`);
+	}
+
+	return selected;
+}
+
+async function resolveSelection(selection: FileSelection, params: ResolveParams): Promise<SelectedFile[]> {
+	const selector = typeof selection === "string" ? undefined : selection;
+	const sourcePath = Path.resolve(params.workingDir, selector?.dir ?? (selection as string));
+
+	if (!(await isPathExists(sourcePath))) {
+		if (params.strict) {
+			throw new TaskExecutionError(`Source path '${sourcePath}' does not exist.`);
+		}
+
+		params.logger.warn(`Source path '${sourcePath}' does not exist. Skipping.`);
+
+		return [];
+	}
+
+	if (selector === undefined && !(await Fs.stat(sourcePath)).isDirectory()) {
+		return [{ source: sourcePath, relativePath: Path.basename(sourcePath) }];
+	}
+
+	const { include, exclude } = resolvePatterns(selector, params);
+	const files = await fg(include, { dot: true, cwd: sourcePath, ignore: exclude, onlyFiles: true });
+
+	return files.map((file) => ({ relativePath: file, source: Path.join(sourcePath, file) }));
+}
+
+function resolvePatterns(selector: FileSelector | undefined, params: ResolveParams): { include: string[]; exclude: string[] } {
+	return {
+		exclude: MaybeArray.toArray(selector?.exclude ?? params.defaultExclude ?? []),
+		include: MaybeArray.toArray(selector?.include ?? params.defaultInclude ?? "**/*")
+	};
+}

--- a/packages/nadle/src/builtin-tasks/index.ts
+++ b/packages/nadle/src/builtin-tasks/index.ts
@@ -6,3 +6,4 @@ export * from "./pnpx-task.js";
 export * from "./exec-task.js";
 export * from "./copy-task.js";
 export * from "./delete-task.js";
+export { type FileSelector, type FileSelection } from "./file-selection.js";

--- a/packages/nadle/test/__fixtures__/copy-task/nadle.config.ts
+++ b/packages/nadle/test/__fixtures__/copy-task/nadle.config.ts
@@ -1,6 +1,6 @@
 import { tasks, CopyTask } from "nadle";
 
-tasks.register("copyAssets", CopyTask, { to: "dist", from: "assets" });
-tasks.register("copyFoo", CopyTask, { to: "dist", from: "foo.txt" });
-tasks.register("copyToNested", CopyTask, { from: "foo.txt", to: "dist/sub/nested" });
-tasks.register("copyWithFilter", CopyTask, { to: "dist", from: "assets", exclude: ["bar.txt"], include: ["**/*.txt"] });
+tasks.register("copyAssets", CopyTask, { into: "dist", from: "assets" });
+tasks.register("copyFoo", CopyTask, { into: "dist", from: "foo.txt" });
+tasks.register("copyToNested", CopyTask, { from: "foo.txt", into: "dist/sub/nested" });
+tasks.register("copyWithFilter", CopyTask, { into: "dist", from: "assets", exclude: ["bar.txt"], include: ["**/*.txt"] });

--- a/packages/nadle/test/__snapshots__/builtin-tasks/copy-task.test.ts.snap
+++ b/packages/nadle/test/__snapshots__/builtin-tasks/copy-task.test.ts.snap
@@ -1,6 +1,6 @@
 // Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
 
-exports[`copyTask > given a file path > can copy it 1`] = `
+exports[`copyTask > given a file path > copies it into the destination directory 1`] = `
 ---------- Context -----------
 Working Directory: /ROOT/test/__fixtures__/copy-task/__temp__/__{hash}__
 Command: /ROOT/nadle.mjs --max-workers 1 --no-footer copyFoo
@@ -11,7 +11,7 @@ Command: /ROOT/nadle.mjs --max-workers 1 --no-footer copyFoo
 
 [log] <Yellow>></Yellow> Task <Bold>copyFoo</BoldDim> <Yellow>STARTED</Yellow>
 
-[log] Copy foo.txt -> dist
+[log] Copy foo.txt -> dist/foo.txt
 [log]
 <Green>✓</Green> Task <Bold>copyFoo</BoldDim> <Green>DONE</Green> <Dim>{duration}</BoldDim>
 [log]
@@ -50,7 +50,7 @@ Command: /ROOT/nadle.mjs --max-workers 1 --no-footer copyToNested
 
 [log] <Yellow>></Yellow> Task <Bold>copyToNested</BoldDim> <Yellow>STARTED</Yellow>
 
-[log] Copy foo.txt -> dist/sub/nested
+[log] Copy foo.txt -> dist/sub/nested/foo.txt
 [log]
 <Green>✓</Green> Task <Bold>copyToNested</BoldDim> <Green>DONE</Green> <Dim>{duration}</BoldDim>
 [log]

--- a/packages/nadle/test/builtin-tasks/copy-task.test.ts
+++ b/packages/nadle/test/builtin-tasks/copy-task.test.ts
@@ -1,7 +1,7 @@
+import fixturify from "fixturify";
 import { isWindows } from "std-env";
-import type fixturify from "fixturify";
 import { it, expect, describe } from "vitest";
-import { expectPass, withFixture } from "setup";
+import { settle, fixture, getStdout, expectPass, withFixture, withGeneratedFixture } from "setup";
 
 describe.skipIf(isWindows)("copyTask", () => {
 	const files: fixturify.DirJSON = {
@@ -43,7 +43,7 @@ describe.skipIf(isWindows)("copyTask", () => {
 	});
 
 	describe("given a file path", () => {
-		it("can copy it", async () => {
+		it("copies it into the destination directory", async () => {
 			await withFixture({
 				files,
 				fixtureDir: "copy-task",
@@ -58,7 +58,9 @@ describe.skipIf(isWindows)("copyTask", () => {
 						      baz.txt: baz contents,
 						    },
 						  },
-						  dist: foo contents,
+						  dist: {
+						    foo.txt: foo contents,
+						  },
 						  foo.txt: foo contents,
 						}
 					`);
@@ -85,7 +87,9 @@ describe.skipIf(isWindows)("copyTask", () => {
 						  },
 						  dist: {
 						    sub: {
-						      nested: foo contents,
+						      nested: {
+						        foo.txt: foo contents,
+						      },
 						    },
 						  },
 						  foo.txt: foo contents,
@@ -124,4 +128,127 @@ describe.skipIf(isWindows)("copyTask", () => {
 			});
 		});
 	});
+});
+
+describe.skipIf(isWindows).concurrent("copyTask with into", () => {
+	const makeFixture = (config: string) =>
+		fixture()
+			.packageJson("copy-task-into")
+			.file("foo.txt", "foo contents")
+			.file("assets/bar.txt", "bar contents")
+			.file("assets/sub/baz.txt", "baz contents")
+			.file("other/qux.txt", "qux contents")
+			.configRaw([`import { tasks, CopyTask } from "nadle";`, ``, config].join("\n"))
+			.build();
+
+	const readDist = (cwd: string) =>
+		(fixturify.readSync(cwd, { ignore: ["nadle.config.ts", "package.json", "node_modules"] }) as Record<string, unknown>)["dist"];
+
+	it("copies a directory into the destination preserving structure", () =>
+		withGeneratedFixture({
+			files: makeFixture(`tasks.register("copy", CopyTask, { from: "assets", into: "dist" });`),
+			testFn: async ({ cwd, exec }) => {
+				await getStdout(exec`copy`);
+
+				expect(readDist(cwd)).toEqual({ "bar.txt": "bar contents", sub: { "baz.txt": "baz contents" } });
+			}
+		}));
+
+	it("copies multiple sources, files and selectors mixed", () =>
+		withGeneratedFixture({
+			files: makeFixture(
+				`tasks.register("copy", CopyTask, { from: ["foo.txt", { dir: "assets", include: "**/*.txt", exclude: "bar.txt" }], into: "dist" });`
+			),
+			testFn: async ({ cwd, exec }) => {
+				await getStdout(exec`copy`);
+
+				expect(readDist(cwd)).toEqual({ "foo.txt": "foo contents", sub: { "baz.txt": "baz contents" } });
+			}
+		}));
+
+	it("flattens source structure when flatten is set", () =>
+		withGeneratedFixture({
+			files: makeFixture(`tasks.register("copy", CopyTask, { flatten: true, from: ["assets", "other"], into: "dist" });`),
+			testFn: async ({ cwd, exec }) => {
+				await getStdout(exec`copy`);
+
+				expect(readDist(cwd)).toEqual({ "bar.txt": "bar contents", "baz.txt": "baz contents", "qux.txt": "qux contents" });
+			}
+		}));
+
+	it("renames files by base name", () =>
+		withGeneratedFixture({
+			files: makeFixture(`tasks.register("copy", CopyTask, { from: "assets", into: "dist", rename: { "bar.txt": "renamed.txt" } });`),
+			testFn: async ({ cwd, exec }) => {
+				await getStdout(exec`copy`);
+
+				expect(readDist(cwd)).toEqual({ "renamed.txt": "bar contents", sub: { "baz.txt": "baz contents" } });
+			}
+		}));
+
+	it("fails when flattening collides", () =>
+		withGeneratedFixture({
+			files: makeFixture(`tasks.register("copy", CopyTask, { flatten: true, into: "dist", from: [{ dir: "assets" }, { dir: "assets" }] });`),
+			testFn: async ({ exec }) => {
+				const { stdout, stderr, exitCode } = await settle(exec`copy --stacktrace`);
+
+				expect(exitCode).not.toBe(0);
+				expect(stdout + stderr).toContain("map to the same destination");
+			}
+		}));
+
+	it("respects overwrite skip", () =>
+		withGeneratedFixture({
+			testFn: async ({ cwd, exec }) => {
+				await getStdout(exec`seed`);
+				await getStdout(exec`copy`);
+
+				expect((readDist(cwd) as { sub: Record<string, string> }).sub).toEqual({ "baz.txt": "baz contents" });
+			},
+			files: makeFixture(
+				[
+					`tasks.register("seed", CopyTask, { from: "assets", into: "dist" });`,
+					`tasks.register("copy", CopyTask, { from: "other", into: "dist/sub", overwrite: "skip", rename: { "qux.txt": "baz.txt" } });`
+				].join("\n")
+			)
+		}));
+
+	it("fails on existing destination with overwrite error", () =>
+		withGeneratedFixture({
+			files: makeFixture(
+				[
+					`tasks.register("seed", CopyTask, { from: "assets", into: "dist" });`,
+					`tasks.register("copy", CopyTask, { from: "assets", into: "dist", overwrite: "error" });`
+				].join("\n")
+			),
+			testFn: async ({ exec }) => {
+				await getStdout(exec`seed`);
+				const { stdout, stderr, exitCode } = await settle(exec`copy --stacktrace`);
+
+				expect(exitCode).not.toBe(0);
+				expect(stdout + stderr).toContain("already exists");
+			}
+		}));
+
+	it("warns and succeeds on missing source by default", () =>
+		withGeneratedFixture({
+			files: makeFixture(`tasks.register("copy", CopyTask, { from: "missing", into: "dist" });`),
+			testFn: async ({ exec }) => {
+				const { stdout, stderr, exitCode } = await settle(exec`copy`);
+
+				expect(exitCode).toBe(0);
+				expect(stdout + stderr).toContain("does not exist");
+			}
+		}));
+
+	it("fails on missing source when strict", () =>
+		withGeneratedFixture({
+			files: makeFixture(`tasks.register("copy", CopyTask, { strict: true, from: "missing", into: "dist" });`),
+			testFn: async ({ exec }) => {
+				const { stdout, stderr, exitCode } = await settle(exec`copy --stacktrace`);
+
+				expect(exitCode).not.toBe(0);
+				expect(stdout + stderr).toContain("does not exist");
+			}
+		}));
 });

--- a/packages/nadle/test/types/builtin-tasks.test-d.ts
+++ b/packages/nadle/test/types/builtin-tasks.test-d.ts
@@ -11,6 +11,7 @@ import {
 	type Task,
 	DeleteTask,
 	type MaybeArray,
+	type FileSelection,
 	type NpmTaskOptions,
 	type NpxTaskOptions,
 	type NodeTaskOptions,
@@ -90,11 +91,18 @@ describe.concurrent("CopyTask", () => {
 		expectTypeOf(CopyTask).toEqualTypeOf<Task<CopyTaskOptions>>();
 	});
 
-	it("CopyTaskOptions has from, to, include, exclude", () => {
-		expectTypeOf<CopyTaskOptions["from"]>().toEqualTypeOf<string>();
-		expectTypeOf<CopyTaskOptions["to"]>().toEqualTypeOf<string>();
+	it("CopyTaskOptions has from, into, include, exclude", () => {
+		expectTypeOf<CopyTaskOptions["from"]>().toEqualTypeOf<MaybeArray<FileSelection>>();
+		expectTypeOf<CopyTaskOptions["into"]>().toEqualTypeOf<string>();
 		expectTypeOf<CopyTaskOptions["include"]>().toEqualTypeOf<MaybeArray<string> | undefined>();
 		expectTypeOf<CopyTaskOptions["exclude"]>().toEqualTypeOf<MaybeArray<string> | undefined>();
+	});
+
+	it("CopyTaskOptions has flatten, rename, overwrite, strict", () => {
+		expectTypeOf<CopyTaskOptions["flatten"]>().toEqualTypeOf<boolean | undefined>();
+		expectTypeOf<CopyTaskOptions["rename"]>().toEqualTypeOf<Record<string, string> | undefined>();
+		expectTypeOf<CopyTaskOptions["overwrite"]>().toEqualTypeOf<"error" | "replace" | "skip" | undefined>();
+		expectTypeOf<CopyTaskOptions["strict"]>().toEqualTypeOf<boolean | undefined>();
 	});
 });
 

--- a/spec/10-builtin-tasks.md
+++ b/spec/10-builtin-tasks.md
@@ -124,35 +124,45 @@ for running binaries from `node_modules/.bin` through npx.
 5. Stream combined output to the task logger.
 6. Await subprocess completion.
 
+## File Selections
+
+File-operation tasks share one source vocabulary. A **file selection** is either:
+
+- a **string** — a path (relative to the working directory) to a file or a directory, or
+- a **selector object** — `{ dir, include?, exclude? }`, where `include`/`exclude` are glob
+  patterns matched against files inside `dir` (include defaults to all files).
+
+A string selection pointing to a file yields that file. One pointing to a directory selects
+the files inside it (applying the task-level default `include`/`exclude` patterns, if any).
+A missing source logs a warning and yields nothing — unless the task's `strict` option is
+set, in which case it is an error.
+
 ## CopyTask
 
-Copies files and directories using glob patterns.
+Copies files into a destination directory.
 
 ### Options
 
-| Field     | Type                       | Required | Description                                       |
-| --------- | -------------------------- | -------- | ------------------------------------------------- |
-| `from`    | string                     | Yes      | Source path (relative to working directory).      |
-| `to`      | string                     | Yes      | Destination path (relative to working directory). |
-| `include` | string or array of strings | No       | Glob patterns to include. Default: `**/*`.        |
-| `exclude` | string or array of strings | No       | Glob patterns to exclude. Default: none.          |
+| Field       | Type                            | Required | Description                                                                |
+| ----------- | ------------------------------- | -------- | -------------------------------------------------------------------------- |
+| `from`      | file selection or array thereof | Yes      | Source files, directories, or selectors.                                   |
+| `into`      | string                          | Yes      | Destination directory (relative to working directory). Created if missing. |
+| `include`   | string or array of strings      | No       | Default include patterns for directory selections without their own.       |
+| `exclude`   | string or array of strings      | No       | Default exclude patterns for directory selections without their own.       |
+| `flatten`   | boolean                         | No       | Copy all files directly into `into`, dropping source directory structure.  |
+| `rename`    | record of string to string      | No       | Renames by exact base name, e.g. `{ "config.dev.json": "config.json" }`.   |
+| `overwrite` | `replace` \| `skip` \| `error`  | No       | Behavior when a destination file exists. Default: `replace`.               |
+| `strict`    | boolean                         | No       | Fail when a source is missing or nothing matches. Default: `false`.        |
 
 ### Behavior
 
-**When `from` is a directory:**
-
-1. Create the destination directory.
-2. Glob all files matching `include` patterns, ignoring `exclude` patterns.
-3. Copy each matched file, preserving relative directory structure.
-
-**When `from` is a file:**
-
-1. Check if the file matches include/exclude patterns.
-2. If the destination is a directory (or ends with a path separator), copy into it.
-3. Otherwise, copy to the exact destination path.
-4. Create parent directories as needed.
-
-If the source path does not exist, a warning is logged and no error is raised.
+1. Resolve all `from` selections to files (see File Selections).
+2. Compute each file's destination: its selection-relative path under `into`, flattened to
+   the base name when `flatten` is set, then renamed when its base name appears in `rename`.
+3. If two source files map to the same destination, the task fails.
+4. Apply the `overwrite` policy per existing destination file: `replace` overwrites,
+   `skip` logs and skips, `error` fails the task.
+5. Create parent directories as needed and copy.
 
 ## DeleteTask
 

--- a/spec/CHANGELOG.md
+++ b/spec/CHANGELOG.md
@@ -8,6 +8,21 @@ Versioning follows [Semantic Versioning](https://semver.org/):
 - **MINOR**: New concept, new section, or materially expanded rules
 - **PATCH**: Clarifications, corrections, wording improvements
 
+## 2.0.0 — 2026-06-11
+
+### Changed (BREAKING)
+
+- 10-builtin-tasks: CopyTask redesign — the `to` option is removed; `into` is the
+  required destination and is always a directory (the previous file-or-directory
+  destination guessing is gone). `from` accepts multiple sources (paths or selectors).
+
+### Added
+
+- 10-builtin-tasks: File Selections — a shared source vocabulary for file-operation
+  tasks (path string or `{ dir, include?, exclude? }` selector).
+- 10-builtin-tasks: CopyTask options — `flatten`, `rename` (by base name), `overwrite`
+  (`replace`/`skip`/`error`), and `strict`; destination-collision detection.
+
 ## 1.13.0 — 2026-06-10
 
 ### Added

--- a/spec/README.md
+++ b/spec/README.md
@@ -1,6 +1,6 @@
 # Nadle Specification
 
-**Version**: 1.13.0
+**Version**: 2.0.0
 
 This directory contains the language-agnostic specification for Nadle, a type-safe,
 Gradle-inspired task runner for Node.js.


### PR DESCRIPTION
Phase 1 of #605, per the design in the [issue comment](https://github.com/nadlejs/nadle/issues/605#issuecomment-4671650170). Also closes #603 (subsumed by `strict`).

## BREAKING CHANGE

The `to` option is removed (hard migration, no deprecation alias). `into` is the required destination and is **always a directory** — the old file-or-directory destination guessing (stat + trailing separator) is gone. `from: "foo.txt", to: "dist"` used to produce a *file* named `dist`; `from: "foo.txt", into: "dist"` now produces `dist/foo.txt`.

## New API

```ts
tasks.register("copy", CopyTask, {
	from: ["foo.txt", { dir: "assets", include: "**/*.txt", exclude: "bar.txt" }],
	into: "dist",
	flatten: true,
	rename: { "config.dev.json": "config.json" },
	overwrite: "skip",        // replace (default) | skip | error
	strict: true              // fail on missing source / zero matches
});
```

- New shared `FileSelection`/`FileSelector` vocabulary (`src/builtin-tasks/file-selection.ts`) — reused by the upcoming Move/Sync/Zip tasks (#605)
- Destination-collision detection (two sources mapping to one target fail the task)
- Task-level `include`/`exclude` act as defaults for directory selections without their own

## Updates

- Spec 2.0.0: new File Selections section, rewritten CopyTask section (major bump — breaking contract change)
- Type-level tests, 13 integration tests (multi-source, flatten, rename, overwrite skip/error, strict, collision)
- `index.api.md` regenerated; docs example migrated to `into`

Full `nadle test --summary` pipeline green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)