### PR TITLE
feat: add MoveTask and SyncTask builtin tasks

### DIFF
--- a/packages/nadle/index.api.md
+++ b/packages/nadle/index.api.md
@@ -28,15 +28,8 @@ export function configure(options: NadleFileOptions): void;
 export const CopyTask: Task<CopyTaskOptions>;
 
 // @public
-export interface CopyTaskOptions {
-    readonly exclude?: MaybeArray<string>;
-    readonly flatten?: boolean;
-    readonly from: MaybeArray<FileSelection>;
-    readonly include?: MaybeArray<string>;
-    readonly into: string;
-    readonly overwrite?: "error" | "replace" | "skip";
-    readonly rename?: Record<string, string>;
-    readonly strict?: boolean;
+export interface CopyTaskOptions extends FileOperationOptions {
+    readonly overwrite?: OverwritePolicy;
 }
 
 // @public
@@ -84,6 +77,17 @@ export interface FileDeclaration {
 }
 
 // @public
+export interface FileOperationOptions {
+    readonly exclude?: MaybeArray<string>;
+    readonly flatten?: boolean;
+    readonly from: MaybeArray<FileSelection>;
+    readonly include?: MaybeArray<string>;
+    readonly into: string;
+    readonly rename?: Record<string, string>;
+    readonly strict?: boolean;
+}
+
+// @public
 export type FileSelection = string | FileSelector;
 
 // @public
@@ -115,6 +119,14 @@ export type MaybeArray<T> = T | T[];
 // @public
 export namespace MaybeArray {
     export function toArray<T>(value: MaybeArray<T>): T[];
+}
+
+// @public
+export const MoveTask: Task<MoveTaskOptions>;
+
+// @public
+export interface MoveTaskOptions extends FileOperationOptions {
+    readonly overwrite?: OverwritePolicy;
 }
 
 // @public
@@ -175,6 +187,9 @@ export namespace Outputs {
 }
 
 // @public
+export type OverwritePolicy = "error" | "replace" | "skip";
+
+// @public
 export const PnpmTask: Task<PnpmTaskOptions>;
 
 // @public
@@ -213,6 +228,14 @@ export type SupportReporter = (typeof SupportReporters)[number];
 
 // @public
 export const SupportReporters: readonly ["default", "agent"];
+
+// @public
+export const SyncTask: Task<SyncTaskOptions>;
+
+// @public
+export interface SyncTaskOptions extends FileOperationOptions {
+    readonly preserve?: MaybeArray<string>;
+}
 
 // @public
 export interface Task<Options = unknown> {

--- a/packages/nadle/src/builtin-tasks/copy-task.ts
+++ b/packages/nadle/src/builtin-tasks/copy-task.ts
@@ -1,33 +1,15 @@
 import Path from "node:path";
 import Fs from "node:fs/promises";
 
-import { type MaybeArray } from "../core/index.js";
-import { isPathExists } from "../core/utilities/fs.js";
-import { type RunnerContext } from "../core/interfaces/task.js";
 import { defineTask } from "../core/registration/define-task.js";
-import { TaskExecutionError } from "../core/utilities/nadle-error.js";
-import { type SelectedFile, type FileSelection, resolveFileSelections } from "./file-selection.js";
+import { shouldWrite, resolveTargets, type OverwritePolicy, type FileOperationOptions } from "./file-operations.js";
 
 /**
  * Options for the CopyTask.
  */
-export interface CopyTaskOptions {
-	/** Destination directory. Created if missing. */
-	readonly into: string;
-	/** Fail when a source path is missing or no files match. Defaults to false. */
-	readonly strict?: boolean;
-	/** Copy all files directly into `into`, dropping source directory structure. */
-	readonly flatten?: boolean;
-	/** Default include patterns for directory selections without their own. */
-	readonly include?: MaybeArray<string>;
-	/** Default exclude patterns for directory selections without their own. */
-	readonly exclude?: MaybeArray<string>;
-	/** Source file(s), directory(ies), or selector(s) with glob patterns. */
-	readonly from: MaybeArray<FileSelection>;
-	/** Renames by exact base name, e.g. `{ "config.dev.json": "config.json" }`. */
-	readonly rename?: Record<string, string>;
+export interface CopyTaskOptions extends FileOperationOptions {
 	/** Behavior when a destination file already exists. Defaults to `replace`. */
-	readonly overwrite?: "error" | "replace" | "skip";
+	readonly overwrite?: OverwritePolicy;
 }
 
 /**
@@ -38,64 +20,19 @@ export interface CopyTaskOptions {
  */
 export const CopyTask = defineTask<CopyTaskOptions>({
 	run: async ({ options, context }) => {
-		if (options.into === undefined) {
-			throw new TaskExecutionError(`CopyTask requires the 'into' option.`);
+		const targets = await resolveTargets(options, context);
+		const overwrite = options.overwrite ?? "replace";
+
+		for (const [target, source] of targets) {
+			if (!(await shouldWrite(target, overwrite, context))) {
+				continue;
+			}
+
+			await Fs.mkdir(Path.dirname(target), { recursive: true });
+			context.logger.log(`Copy ${Path.relative(context.workingDir, source)} -> ${Path.relative(context.workingDir, target)}`);
+			await Fs.cp(source, target);
 		}
 
-		const files = await resolveFileSelections({
-			logger: context.logger,
-			selections: options.from,
-			workingDir: context.workingDir,
-			strict: options.strict ?? false,
-			defaultInclude: options.include,
-			defaultExclude: options.exclude
-		});
-
-		const intoPath = Path.resolve(context.workingDir, options.into);
-		const targets = computeTargets(files, intoPath, options);
-
-		await copyFiles(targets, options.overwrite ?? "replace", context);
 		context.logger.info(`Copied ${targets.size} file(s) into ${options.into}`);
 	}
 });
-
-function computeTargets(files: SelectedFile[], intoPath: string, options: Pick<CopyTaskOptions, "rename" | "flatten">): Map<string, string> {
-	const targets = new Map<string, string>();
-
-	for (const file of files) {
-		let relativePath = options.flatten ? Path.basename(file.relativePath) : file.relativePath;
-		const renamed = options.rename?.[Path.basename(relativePath)];
-
-		if (renamed !== undefined) {
-			relativePath = Path.join(Path.dirname(relativePath), renamed);
-		}
-
-		const target = Path.join(intoPath, relativePath);
-		const existingSource = targets.get(target);
-
-		if (existingSource !== undefined) {
-			throw new TaskExecutionError(`Both '${existingSource}' and '${file.source}' map to the same destination '${target}'.`);
-		}
-
-		targets.set(target, file.source);
-	}
-
-	return targets;
-}
-
-async function copyFiles(targets: Map<string, string>, overwrite: "error" | "replace" | "skip", context: RunnerContext): Promise<void> {
-	for (const [target, source] of targets) {
-		if (overwrite !== "replace" && (await isPathExists(target))) {
-			if (overwrite === "error") {
-				throw new TaskExecutionError(`Destination '${target}' already exists.`);
-			}
-
-			context.logger.info(`Skip existing ${Path.relative(context.workingDir, target)}`);
-			continue;
-		}
-
-		await Fs.mkdir(Path.dirname(target), { recursive: true });
-		context.logger.log(`Copy ${Path.relative(context.workingDir, source)} -> ${Path.relative(context.workingDir, target)}`);
-		await Fs.cp(source, target);
-	}
-}

--- a/packages/nadle/src/builtin-tasks/file-operations.ts
+++ b/packages/nadle/src/builtin-tasks/file-operations.ts
@@ -1,0 +1,93 @@
+import Path from "node:path";
+
+import { type MaybeArray } from "../core/index.js";
+import { isPathExists } from "../core/utilities/fs.js";
+import { type RunnerContext } from "../core/interfaces/task.js";
+import { TaskExecutionError } from "../core/utilities/nadle-error.js";
+import { type FileSelection, resolveFileSelections } from "./file-selection.js";
+
+/**
+ * Options shared by the file-operation tasks (Copy, Move, Sync).
+ *
+ * @public
+ */
+export interface FileOperationOptions {
+	/** Destination directory. Created if missing. */
+	readonly into: string;
+	/** Fail when a source path is missing or no files match. Defaults to false. */
+	readonly strict?: boolean;
+	/** Place all files directly into `into`, dropping source directory structure. */
+	readonly flatten?: boolean;
+	/** Default include patterns for directory selections without their own. */
+	readonly include?: MaybeArray<string>;
+	/** Default exclude patterns for directory selections without their own. */
+	readonly exclude?: MaybeArray<string>;
+	/** Source file(s), directory(ies), or selector(s) with glob patterns. */
+	readonly from: MaybeArray<FileSelection>;
+	/** Renames by exact base name, e.g. `{ "config.dev.json": "config.json" }`. */
+	readonly rename?: Record<string, string>;
+}
+
+/** Overwrite policy applied per existing destination file. */
+export type OverwritePolicy = "error" | "replace" | "skip";
+
+/**
+ * Resolves the task's selections and maps every selected file to its absolute
+ * destination path under `into`, applying `flatten` and `rename`. Fails when two
+ * sources map to the same destination.
+ */
+export async function resolveTargets(options: FileOperationOptions, context: RunnerContext): Promise<Map<string, string>> {
+	if (options.into === undefined) {
+		throw new TaskExecutionError(`The 'into' option is required.`);
+	}
+
+	const files = await resolveFileSelections({
+		logger: context.logger,
+		selections: options.from,
+		workingDir: context.workingDir,
+		strict: options.strict ?? false,
+		defaultInclude: options.include,
+		defaultExclude: options.exclude
+	});
+
+	const intoPath = Path.resolve(context.workingDir, options.into);
+	const targets = new Map<string, string>();
+
+	for (const file of files) {
+		const target = Path.join(intoPath, computeRelativePath(file.relativePath, options));
+		const existingSource = targets.get(target);
+
+		if (existingSource !== undefined) {
+			throw new TaskExecutionError(`Both '${existingSource}' and '${file.source}' map to the same destination '${target}'.`);
+		}
+
+		targets.set(target, file.source);
+	}
+
+	return targets;
+}
+
+function computeRelativePath(relativePath: string, options: Pick<FileOperationOptions, "rename" | "flatten">): string {
+	const flattened = options.flatten ? Path.basename(relativePath) : relativePath;
+	const renamed = options.rename?.[Path.basename(flattened)];
+
+	return renamed === undefined ? flattened : Path.join(Path.dirname(flattened), renamed);
+}
+
+/**
+ * Applies the overwrite policy for one destination file: returns true when the
+ * write should proceed, false when it should be skipped, and throws on `error`.
+ */
+export async function shouldWrite(target: string, overwrite: OverwritePolicy, context: RunnerContext): Promise<boolean> {
+	if (overwrite === "replace" || !(await isPathExists(target))) {
+		return true;
+	}
+
+	if (overwrite === "error") {
+		throw new TaskExecutionError(`Destination '${target}' already exists.`);
+	}
+
+	context.logger.info(`Skip existing ${Path.relative(context.workingDir, target)}`);
+
+	return false;
+}

--- a/packages/nadle/src/builtin-tasks/file-selection.ts
+++ b/packages/nadle/src/builtin-tasks/file-selection.ts
@@ -31,7 +31,7 @@ export interface FileSelector {
 export type FileSelection = string | FileSelector;
 
 /** A file resolved from a selection: absolute source path plus destination-relative path. */
-export interface SelectedFile {
+interface SelectedFile {
 	readonly source: string;
 	readonly relativePath: string;
 }

--- a/packages/nadle/src/builtin-tasks/index.ts
+++ b/packages/nadle/src/builtin-tasks/index.ts
@@ -5,5 +5,8 @@ export * from "./pnpm-task.js";
 export * from "./pnpx-task.js";
 export * from "./exec-task.js";
 export * from "./copy-task.js";
+export * from "./move-task.js";
+export * from "./sync-task.js";
 export * from "./delete-task.js";
 export { type FileSelector, type FileSelection } from "./file-selection.js";
+export { type OverwritePolicy, type FileOperationOptions } from "./file-operations.js";

--- a/packages/nadle/src/builtin-tasks/move-task.ts
+++ b/packages/nadle/src/builtin-tasks/move-task.ts
@@ -1,0 +1,46 @@
+import Path from "node:path";
+import Fs from "node:fs/promises";
+
+import { defineTask } from "../core/registration/define-task.js";
+import { shouldWrite, resolveTargets, type OverwritePolicy, type FileOperationOptions } from "./file-operations.js";
+
+/**
+ * Options for the MoveTask.
+ */
+export interface MoveTaskOptions extends FileOperationOptions {
+	/** Behavior when a destination file already exists. Defaults to `replace`. */
+	readonly overwrite?: OverwritePolicy;
+}
+
+/**
+ * Task for moving files and directories.
+ *
+ * Same selection semantics as CopyTask, but sources are removed after the move.
+ * Uses a rename syscall when possible and falls back to copy-then-delete (e.g.
+ * across devices). Skipped files (overwrite policy) keep their source.
+ */
+export const MoveTask = defineTask<MoveTaskOptions>({
+	run: async ({ options, context }) => {
+		const targets = await resolveTargets(options, context);
+		const overwrite = options.overwrite ?? "replace";
+
+		for (const [target, source] of targets) {
+			if (!(await shouldWrite(target, overwrite, context))) {
+				continue;
+			}
+
+			await Fs.mkdir(Path.dirname(target), { recursive: true });
+			context.logger.log(`Move ${Path.relative(context.workingDir, source)} -> ${Path.relative(context.workingDir, target)}`);
+
+			try {
+				await Fs.rename(source, target);
+			} catch {
+				// Cross-device moves cannot rename; copy and delete instead.
+				await Fs.cp(source, target);
+				await Fs.rm(source);
+			}
+		}
+
+		context.logger.info(`Moved ${targets.size} file(s) into ${options.into}`);
+	}
+});

--- a/packages/nadle/src/builtin-tasks/sync-task.ts
+++ b/packages/nadle/src/builtin-tasks/sync-task.ts
@@ -1,0 +1,89 @@
+import Path from "node:path";
+import Fs from "node:fs/promises";
+
+import fg from "fast-glob";
+import micromatch from "micromatch";
+
+import { MaybeArray } from "../core/index.js";
+import { isPathExists } from "../core/utilities/fs.js";
+import { type RunnerContext } from "../core/interfaces/task.js";
+import { defineTask } from "../core/registration/define-task.js";
+import { resolveTargets, type FileOperationOptions } from "./file-operations.js";
+
+/**
+ * Options for the SyncTask.
+ */
+export interface SyncTaskOptions extends FileOperationOptions {
+	/** Glob patterns (relative to `into`) for files that are never deleted. */
+	readonly preserve?: MaybeArray<string>;
+}
+
+/**
+ * Task for mirroring sources into a destination directory.
+ *
+ * Same selection semantics as CopyTask, but after copying, files in `into` that do
+ * not correspond to a source (and do not match `preserve`) are deleted, and empty
+ * directories are pruned. The destination ends up as an exact mirror.
+ */
+export const SyncTask = defineTask<SyncTaskOptions>({
+	run: async ({ options, context }) => {
+		const targets = await resolveTargets(options, context);
+		const intoPath = Path.resolve(context.workingDir, options.into);
+
+		for (const [target, source] of targets) {
+			await Fs.mkdir(Path.dirname(target), { recursive: true });
+			context.logger.log(`Sync ${Path.relative(context.workingDir, source)} -> ${Path.relative(context.workingDir, target)}`);
+			await Fs.cp(source, target);
+		}
+
+		const deleted = await deleteExtraneous({ context, targets, intoPath, preserve: MaybeArray.toArray(options.preserve ?? []) });
+
+		await pruneEmptyDirectories(intoPath);
+		context.logger.info(`Synced ${targets.size} file(s) into ${options.into}${deleted > 0 ? `, deleted ${deleted} extraneous file(s)` : ""}`);
+	}
+});
+
+interface DeleteExtraneousParams {
+	readonly intoPath: string;
+	readonly preserve: string[];
+	readonly context: RunnerContext;
+	readonly targets: Map<string, string>;
+}
+
+async function deleteExtraneous({ context, targets, intoPath, preserve }: DeleteExtraneousParams): Promise<number> {
+	if (!(await isPathExists(intoPath))) {
+		return 0;
+	}
+
+	const existingFiles = await fg("**/*", { dot: true, cwd: intoPath, onlyFiles: true });
+	let deleted = 0;
+
+	for (const relativePath of existingFiles) {
+		const absolutePath = Path.join(intoPath, relativePath);
+
+		if (targets.has(absolutePath) || (preserve.length > 0 && micromatch.isMatch(relativePath, preserve))) {
+			continue;
+		}
+
+		context.logger.log(`Delete extraneous ${Path.relative(context.workingDir, absolutePath)}`);
+		await Fs.rm(absolutePath);
+		deleted += 1;
+	}
+
+	return deleted;
+}
+
+async function pruneEmptyDirectories(intoPath: string): Promise<void> {
+	const directories = await fg("**/*", { dot: true, cwd: intoPath, onlyDirectories: true });
+
+	// Deepest first, so emptied parents become removable in the same pass.
+	directories.sort((left, right) => right.split("/").length - left.split("/").length);
+
+	for (const directory of directories) {
+		try {
+			await Fs.rmdir(Path.join(intoPath, directory));
+		} catch {
+			// Not empty (or already gone) — keep it.
+		}
+	}
+}

--- a/packages/nadle/test/builtin-tasks/move-sync-task.test.ts
+++ b/packages/nadle/test/builtin-tasks/move-sync-task.test.ts
@@ -1,0 +1,112 @@
+import fixturify from "fixturify";
+import { isWindows } from "std-env";
+import { it, expect, describe } from "vitest";
+import { settle, fixture, getStdout, withGeneratedFixture } from "setup";
+
+const makeFixture = (config: string) =>
+	fixture()
+		.packageJson("move-sync-task")
+		.file("assets/bar.txt", "bar contents")
+		.file("assets/sub/baz.txt", "baz contents")
+		.file("other/qux.txt", "qux contents")
+		.configRaw([`import { tasks, MoveTask, SyncTask, CopyTask } from "nadle";`, ``, config].join("\n"))
+		.build();
+
+const readFiles = (cwd: string) =>
+	fixturify.readSync(cwd, { ignore: ["nadle.config.ts", "package.json", "node_modules"] }) as Record<string, unknown>;
+
+describe.skipIf(isWindows).concurrent("moveTask", () => {
+	it("moves a directory into the destination and removes the sources", () =>
+		withGeneratedFixture({
+			files: makeFixture(`tasks.register("move", MoveTask, { from: "assets", into: "dist" });`),
+			testFn: async ({ cwd, exec }) => {
+				await getStdout(exec`move`);
+
+				const files = readFiles(cwd);
+
+				expect(files["dist"]).toEqual({ "bar.txt": "bar contents", sub: { "baz.txt": "baz contents" } });
+				expect(files["assets"]).toEqual({ sub: {} });
+			}
+		}));
+
+	it("keeps the source for files skipped by the overwrite policy", () =>
+		withGeneratedFixture({
+			files: makeFixture(
+				[
+					`tasks.register("seed", CopyTask, { from: "other", into: "dist", rename: { "qux.txt": "bar.txt" } });`,
+					`tasks.register("move", MoveTask, { from: "assets", into: "dist", overwrite: "skip" });`
+				].join("\n")
+			),
+			testFn: async ({ cwd, exec }) => {
+				await getStdout(exec`seed`);
+				await getStdout(exec`move`);
+
+				const files = readFiles(cwd);
+
+				// dist/bar.txt existed (from seed) — move skipped it, source kept.
+				expect(files["dist"]).toEqual({ "bar.txt": "qux contents", sub: { "baz.txt": "baz contents" } });
+				expect(files["assets"]).toEqual({ sub: {}, "bar.txt": "bar contents" });
+			}
+		}));
+
+	it("fails on missing source when strict", () =>
+		withGeneratedFixture({
+			files: makeFixture(`tasks.register("move", MoveTask, { strict: true, from: "missing", into: "dist" });`),
+			testFn: async ({ exec }) => {
+				const { stdout, stderr, exitCode } = await settle(exec`move --stacktrace`);
+
+				expect(exitCode).not.toBe(0);
+				expect(stdout + stderr).toContain("does not exist");
+			}
+		}));
+});
+
+describe.skipIf(isWindows).concurrent("syncTask", () => {
+	it("mirrors the source, deleting extraneous files and empty directories", () =>
+		withGeneratedFixture({
+			files: makeFixture(
+				[
+					`tasks.register("seed", CopyTask, { from: "other", into: "dist/stale" });`,
+					`tasks.register("sync", SyncTask, { from: "assets", into: "dist" });`
+				].join("\n")
+			),
+			testFn: async ({ cwd, exec }) => {
+				await getStdout(exec`seed`);
+				await getStdout(exec`sync`);
+
+				expect(readFiles(cwd)["dist"]).toEqual({ "bar.txt": "bar contents", sub: { "baz.txt": "baz contents" } });
+			}
+		}));
+
+	it("keeps files matching preserve patterns", () =>
+		withGeneratedFixture({
+			files: makeFixture(
+				[
+					`tasks.register("seed", CopyTask, { from: "other", into: "dist" });`,
+					`tasks.register("sync", SyncTask, { from: "assets", into: "dist", preserve: ["qux.*"] });`
+				].join("\n")
+			),
+			testFn: async ({ cwd, exec }) => {
+				await getStdout(exec`seed`);
+				await getStdout(exec`sync`);
+
+				expect(readFiles(cwd)["dist"]).toEqual({ "bar.txt": "bar contents", "qux.txt": "qux contents", sub: { "baz.txt": "baz contents" } });
+			}
+		}));
+
+	it("overwrites stale content at the destination", () =>
+		withGeneratedFixture({
+			testFn: async ({ cwd, exec }) => {
+				await getStdout(exec`seed`);
+				await getStdout(exec`sync`);
+
+				expect(readFiles(cwd)["dist"]).toEqual({ "bar.txt": "bar contents", sub: { "baz.txt": "baz contents" } });
+			},
+			files: makeFixture(
+				[
+					`tasks.register("seed", CopyTask, { from: "other", into: "dist", rename: { "qux.txt": "bar.txt" } });`,
+					`tasks.register("sync", SyncTask, { from: "assets", into: "dist" });`
+				].join("\n")
+			)
+		}));
+});

--- a/spec/10-builtin-tasks.md
+++ b/spec/10-builtin-tasks.md
@@ -1,6 +1,6 @@
 # 10 — Built-in Task Types
 
-Nadle provides eight built-in reusable task types, all created via `defineTask()`.
+Nadle provides ten built-in reusable task types, all created via `defineTask()`.
 
 ## ExecTask
 
@@ -163,6 +163,38 @@ Copies files into a destination directory.
 4. Apply the `overwrite` policy per existing destination file: `replace` overwrites,
    `skip` logs and skips, `error` fails the task.
 5. Create parent directories as needed and copy.
+
+## MoveTask
+
+Moves files into a destination directory. Identical options and destination-mapping
+behavior to CopyTask (including `flatten`, `rename`, `overwrite`, `strict`), with one
+difference: each source file is removed after it reaches its destination.
+
+- A filesystem rename is used when possible; cross-device moves fall back to
+  copy-then-delete.
+- Files skipped by the `overwrite` policy keep their source.
+- Emptied source directories are not removed.
+
+## SyncTask
+
+Mirrors sources into a destination directory. Identical selection and
+destination-mapping behavior to CopyTask (including `flatten`, `rename`, `strict`),
+without an `overwrite` option — existing destination files are always replaced.
+
+### Additional option
+
+| Field      | Type                       | Required | Description                                                 |
+| ---------- | -------------------------- | -------- | ----------------------------------------------------------- |
+| `preserve` | string or array of strings | No       | Glob patterns (relative to `into`) for files never deleted. |
+
+### Behavior
+
+1. Resolve and copy as CopyTask (always replacing).
+2. Delete every file under `into` that does not correspond to a source and does not
+   match a `preserve` pattern.
+3. Prune directories left empty.
+
+The destination ends up containing exactly the selected files (plus preserved ones).
 
 ## DeleteTask
 

--- a/spec/CHANGELOG.md
+++ b/spec/CHANGELOG.md
@@ -8,6 +8,15 @@ Versioning follows [Semantic Versioning](https://semver.org/):
 - **MINOR**: New concept, new section, or materially expanded rules
 - **PATCH**: Clarifications, corrections, wording improvements
 
+## 2.1.0 — 2026-06-11
+
+### Added
+
+- 10-builtin-tasks: MoveTask — CopyTask semantics plus source removal (rename
+  syscall with copy-then-delete fallback; skipped files keep their source).
+- 10-builtin-tasks: SyncTask — mirrors sources into the destination, deleting
+  extraneous files (except `preserve` matches) and pruning empty directories.
+
 ## 2.0.0 — 2026-06-11
 
 ### Changed (BREAKING)

--- a/spec/README.md
+++ b/spec/README.md
@@ -1,6 +1,6 @@
 # Nadle Specification
 
-**Version**: 2.0.0
+**Version**: 2.1.0
 
 This directory contains the language-agnostic specification for Nadle, a type-safe,
 Gradle-inspired task runner for Node.js.


### PR DESCRIPTION
Phase 2 of #605.

## MoveTask

CopyTask semantics (same `FileSelection` sources, `into`, `flatten`, `rename`, `overwrite`, `strict`) plus source removal: filesystem rename when possible, copy-then-delete fallback for cross-device moves. Files skipped by the overwrite policy keep their source.

```ts
tasks.register("archiveLogs", MoveTask, { from: { dir: "logs", include: "*.log" }, into: "logs/archive", overwrite: "skip" });
```

## SyncTask

Mirrors sources into `into` (gradle `Sync` / `rsync --delete` analog): copies everything (always replacing), then deletes files under `into` with no corresponding source — except `preserve` glob matches — and prunes empty directories.

```ts
tasks.register("syncPublic", SyncTask, { from: "static", into: "dist/public", preserve: ["*.generated.*"] });
```

## Internals

- New `file-operations.ts`: shared resolve-targets pipeline (selection resolution + flatten/rename mapping + collision detection) and overwrite policy — CopyTask slimmed to use it; Move/Sync reuse it
- `FileOperationOptions` / `OverwritePolicy` exported; `CopyTaskOptions` now extends `FileOperationOptions` (shape unchanged)
- Spec 2.1.0: MoveTask + SyncTask sections; api report regenerated
- 6 new integration tests (move dir + sources gone, skip-keeps-source, strict; sync mirror + extraneous deletion, preserve, stale overwrite)

🤖 Generated with [Claude Code](https://claude.com/claude-code)