### PR TITLE
feat: add ZipTask, UnzipTask, and DownloadTask builtin tasks

### DIFF
--- a/packages/nadle/index.api.md
+++ b/packages/nadle/index.api.md
@@ -62,6 +62,17 @@ export interface DirDeclaration {
 }
 
 // @public
+export const DownloadTask: Task<DownloadTaskOptions>;
+
+// @public
+export interface DownloadTaskOptions {
+    readonly filename?: string;
+    readonly into: string;
+    readonly sha256?: string;
+    readonly url: string;
+}
+
+// @public
 export const ExecTask: Task<ExecTaskOptions>;
 
 // @public

--- a/packages/nadle/index.api.md
+++ b/packages/nadle/index.api.md
@@ -290,6 +290,29 @@ export interface TasksAPI {
     register(name: string, fnTask: TaskFn): TaskConfigurationBuilder;
 }
 
+// @public
+export const UnzipTask: Task<UnzipTaskOptions>;
+
+// @public
+export interface UnzipTaskOptions {
+    readonly archive: string;
+    readonly include?: MaybeArray<string>;
+    readonly into: string;
+}
+
+// @public
+export const ZipTask: Task<ZipTaskOptions>;
+
+// @public
+export interface ZipTaskOptions {
+    readonly archive: string;
+    readonly exclude?: MaybeArray<string>;
+    readonly from: MaybeArray<FileSelection>;
+    readonly include?: MaybeArray<string>;
+    readonly prefix?: string;
+    readonly strict?: boolean;
+}
+
 // (No @packageDocumentation comment for this package)
 
 ```

--- a/packages/nadle/package.json
+++ b/packages/nadle/package.json
@@ -30,6 +30,7 @@
 		"execa": "^9.6.1",
 		"fast-glob": "^3.3.3",
 		"fastest-levenshtein": "^1.0.16",
+		"fflate": "^0.8.3",
 		"fuzzysort": "^3.1.0",
 		"glob": "^11.1.0",
 		"ink": "^6.5.1",
@@ -106,7 +107,7 @@
 	"size-limit": [
 		{
 			"path": "lib/**",
-			"limit": "150 KB",
+			"limit": "160 KB",
 			"name": "bundled",
 			"brotli": false
 		}

--- a/packages/nadle/src/builtin-tasks/download-task.ts
+++ b/packages/nadle/src/builtin-tasks/download-task.ts
@@ -1,0 +1,73 @@
+import Path from "node:path";
+import Crypto from "node:crypto";
+import Fs from "node:fs/promises";
+
+import { isPathExists } from "../core/utilities/fs.js";
+import { defineTask } from "../core/registration/define-task.js";
+import { TaskExecutionError } from "../core/utilities/nadle-error.js";
+
+/**
+ * Options for the DownloadTask.
+ */
+export interface DownloadTaskOptions {
+	/** The URL to download. */
+	readonly url: string;
+	/** Destination directory. Created if missing. */
+	readonly into: string;
+	/** Expected SHA-256 hex digest; the task fails on mismatch. */
+	readonly sha256?: string;
+	/** Destination file name. Defaults to the last segment of the URL path. */
+	readonly filename?: string;
+}
+
+/**
+ * Task for downloading a file over HTTP(S).
+ *
+ * When `sha256` is given and the destination file already exists with a matching
+ * digest, the download is skipped. A digest mismatch after download fails the task
+ * and removes the file.
+ */
+export const DownloadTask = defineTask<DownloadTaskOptions>({
+	run: async ({ options, context }) => {
+		const filename = options.filename ?? Path.posix.basename(new URL(options.url).pathname);
+
+		if (filename === "") {
+			throw new TaskExecutionError(`Cannot derive a file name from '${options.url}'. Set the 'filename' option.`);
+		}
+
+		const target = Path.resolve(context.workingDir, options.into, filename);
+
+		if (options.sha256 !== undefined && (await isPathExists(target)) && (await sha256Of(target)) === options.sha256.toLowerCase()) {
+			context.logger.info(`Skip download: ${filename} already matches the expected digest.`);
+
+			return;
+		}
+
+		context.logger.info(`Downloading ${options.url}`);
+		const response = await fetch(options.url);
+
+		if (!response.ok) {
+			throw new TaskExecutionError(`Download of '${options.url}' failed with status ${response.status}.`);
+		}
+
+		await Fs.mkdir(Path.dirname(target), { recursive: true });
+		await Fs.writeFile(target, new Uint8Array(await response.arrayBuffer()));
+
+		if (options.sha256 !== undefined) {
+			const actual = await sha256Of(target);
+
+			if (actual !== options.sha256.toLowerCase()) {
+				await Fs.rm(target);
+				throw new TaskExecutionError(`Digest mismatch for '${options.url}': expected ${options.sha256.toLowerCase()}, got ${actual}.`);
+			}
+		}
+
+		context.logger.info(`Downloaded ${options.url} to ${Path.relative(context.workingDir, target)}`);
+	}
+});
+
+async function sha256Of(filePath: string): Promise<string> {
+	return Crypto.createHash("sha256")
+		.update(await Fs.readFile(filePath))
+		.digest("hex");
+}

--- a/packages/nadle/src/builtin-tasks/index.ts
+++ b/packages/nadle/src/builtin-tasks/index.ts
@@ -10,5 +10,6 @@ export * from "./move-task.js";
 export * from "./sync-task.js";
 export * from "./unzip-task.js";
 export * from "./delete-task.js";
+export * from "./download-task.js";
 export { type FileSelector, type FileSelection } from "./file-selection.js";
 export { type OverwritePolicy, type FileOperationOptions } from "./file-operations.js";

--- a/packages/nadle/src/builtin-tasks/index.ts
+++ b/packages/nadle/src/builtin-tasks/index.ts
@@ -1,5 +1,6 @@
 export * from "./npm-task.js";
 export * from "./npx-task.js";
+export * from "./zip-task.js";
 export * from "./node-task.js";
 export * from "./pnpm-task.js";
 export * from "./pnpx-task.js";
@@ -7,6 +8,7 @@ export * from "./exec-task.js";
 export * from "./copy-task.js";
 export * from "./move-task.js";
 export * from "./sync-task.js";
+export * from "./unzip-task.js";
 export * from "./delete-task.js";
 export { type FileSelector, type FileSelection } from "./file-selection.js";
 export { type OverwritePolicy, type FileOperationOptions } from "./file-operations.js";

--- a/packages/nadle/src/builtin-tasks/unzip-task.ts
+++ b/packages/nadle/src/builtin-tasks/unzip-task.ts
@@ -1,0 +1,59 @@
+import Path from "node:path";
+import Fs from "node:fs/promises";
+
+import { unzipSync } from "fflate";
+import micromatch from "micromatch";
+
+import { MaybeArray } from "../core/index.js";
+import { isPathExists } from "../core/utilities/fs.js";
+import { defineTask } from "../core/registration/define-task.js";
+import { TaskExecutionError } from "../core/utilities/nadle-error.js";
+
+/**
+ * Options for the UnzipTask.
+ */
+export interface UnzipTaskOptions {
+	/** Destination directory. Created if missing. */
+	readonly into: string;
+	/** Path of the zip archive to extract (relative to working directory). */
+	readonly archive: string;
+	/** Glob patterns selecting which entries to extract. Defaults to all. */
+	readonly include?: MaybeArray<string>;
+}
+
+/**
+ * Task for extracting a zip archive into a directory.
+ */
+export const UnzipTask = defineTask<UnzipTaskOptions>({
+	run: async ({ options, context }) => {
+		const archivePath = Path.resolve(context.workingDir, options.archive);
+
+		if (!(await isPathExists(archivePath))) {
+			throw new TaskExecutionError(`Archive '${archivePath}' does not exist.`);
+		}
+
+		const intoPath = Path.resolve(context.workingDir, options.into);
+		const include = MaybeArray.toArray(options.include ?? []);
+		const entries = unzipSync(await Fs.readFile(archivePath));
+		let extracted = 0;
+
+		for (const [entryName, content] of Object.entries(entries)) {
+			if (entryName.endsWith("/") || (include.length > 0 && !micromatch.isMatch(entryName, include))) {
+				continue;
+			}
+
+			const target = Path.join(intoPath, entryName);
+
+			// Zip entry names are attacker-controllable; never write outside `into`.
+			if (Path.relative(intoPath, target).startsWith("..")) {
+				throw new TaskExecutionError(`Archive entry '${entryName}' escapes the destination directory.`);
+			}
+
+			await Fs.mkdir(Path.dirname(target), { recursive: true });
+			await Fs.writeFile(target, content);
+			extracted += 1;
+		}
+
+		context.logger.info(`Extracted ${extracted} entry(ies) from ${options.archive} into ${options.into}`);
+	}
+});

--- a/packages/nadle/src/builtin-tasks/zip-task.ts
+++ b/packages/nadle/src/builtin-tasks/zip-task.ts
@@ -1,0 +1,67 @@
+import Path from "node:path";
+import Fs from "node:fs/promises";
+
+import { zipSync } from "fflate";
+
+import { type MaybeArray } from "../core/index.js";
+import { defineTask } from "../core/registration/define-task.js";
+import { TaskExecutionError } from "../core/utilities/nadle-error.js";
+import { type FileSelection, resolveFileSelections } from "./file-selection.js";
+
+/**
+ * Options for the ZipTask.
+ */
+export interface ZipTaskOptions {
+	/** Path of the zip archive to create (relative to working directory). */
+	readonly archive: string;
+	/** Entry-name prefix, e.g. `"bundle"` stores files as `bundle/...`. */
+	readonly prefix?: string;
+	/** Fail when a source path is missing or no files match. Defaults to false. */
+	readonly strict?: boolean;
+	/** Default include patterns for directory selections without their own. */
+	readonly include?: MaybeArray<string>;
+	/** Default exclude patterns for directory selections without their own. */
+	readonly exclude?: MaybeArray<string>;
+	/** Source file(s), directory(ies), or selector(s) with glob patterns. */
+	readonly from: MaybeArray<FileSelection>;
+}
+
+/**
+ * Task for creating a zip archive from selected files.
+ *
+ * Entry names are the selection-relative paths, optionally under `prefix`.
+ */
+export const ZipTask = defineTask<ZipTaskOptions>({
+	run: async ({ options, context }) => {
+		const files = await resolveFileSelections({
+			logger: context.logger,
+			selections: options.from,
+			workingDir: context.workingDir,
+			strict: options.strict ?? false,
+			defaultInclude: options.include,
+			defaultExclude: options.exclude
+		});
+
+		const entries: Record<string, Uint8Array> = {};
+
+		for (const file of files) {
+			const entryName = options.prefix ? Path.posix.join(options.prefix, toPosixPath(file.relativePath)) : toPosixPath(file.relativePath);
+
+			if (entries[entryName] !== undefined) {
+				throw new TaskExecutionError(`Multiple source files map to the same archive entry '${entryName}'.`);
+			}
+
+			entries[entryName] = await Fs.readFile(file.source);
+		}
+
+		const archivePath = Path.resolve(context.workingDir, options.archive);
+
+		await Fs.mkdir(Path.dirname(archivePath), { recursive: true });
+		await Fs.writeFile(archivePath, zipSync(entries));
+		context.logger.info(`Zipped ${files.length} file(s) into ${options.archive}`);
+	}
+});
+
+function toPosixPath(filePath: string): string {
+	return filePath.split(Path.sep).join("/");
+}

--- a/packages/nadle/test/builtin-tasks/download-task.test.ts
+++ b/packages/nadle/test/builtin-tasks/download-task.test.ts
@@ -1,0 +1,99 @@
+import Http from "node:http";
+import type Net from "node:net";
+import Crypto from "node:crypto";
+
+import fixturify from "fixturify";
+import { isWindows } from "std-env";
+import { it, expect, describe } from "vitest";
+import { settle, fixture, getStdout, withGeneratedFixture } from "setup";
+
+const CONTENT = "downloaded contents";
+const DIGEST = Crypto.createHash("sha256").update(CONTENT).digest("hex");
+
+const makeFixture = (config: string) =>
+	fixture().packageJson("download-task").configRaw([`import { tasks, DownloadTask } from "nadle";`, ``, config].join("\n")).build();
+
+const readFiles = (cwd: string) =>
+	fixturify.readSync(cwd, { ignore: ["nadle.config.ts", "package.json", "node_modules"] }) as Record<string, unknown>;
+
+async function withServer(handler: Http.RequestListener, testFn: (baseUrl: string) => Promise<void>) {
+	const server = Http.createServer(handler);
+
+	await new Promise<void>((resolve) => server.listen(0, "127.0.0.1", resolve));
+
+	try {
+		await testFn(`http://127.0.0.1:${(server.address() as Net.AddressInfo).port}`);
+	} finally {
+		server.close();
+	}
+}
+
+describe.skipIf(isWindows).concurrent("downloadTask", () => {
+	it("downloads a file into the destination", () =>
+		withServer(
+			(_request, response) => response.end(CONTENT),
+			(baseUrl) =>
+				withGeneratedFixture({
+					files: makeFixture(`tasks.register("download", DownloadTask, { url: "${baseUrl}/file.txt", into: "dist" });`),
+					testFn: async ({ cwd, exec }) => {
+						await getStdout(exec`download`);
+
+						expect(readFiles(cwd)["dist"]).toEqual({ "file.txt": CONTENT });
+					}
+				})
+		));
+
+	it("verifies the sha256 digest and fails on mismatch", () =>
+		withServer(
+			(_request, response) => response.end(CONTENT),
+			(baseUrl) =>
+				withGeneratedFixture({
+					files: makeFixture(`tasks.register("download", DownloadTask, { url: "${baseUrl}/file.txt", into: "dist", sha256: "${"0".repeat(64)}" });`),
+					testFn: async ({ cwd, exec }) => {
+						const { stdout, stderr, exitCode } = await settle(exec`download --stacktrace`);
+
+						expect(exitCode).not.toBe(0);
+						expect(stdout + stderr).toContain("Digest mismatch");
+						expect(readFiles(cwd)["dist"]).toEqual({});
+					}
+				})
+		));
+
+	it("skips the download when the existing file matches the digest", () =>
+		withServer(
+			(_request, response) => {
+				response.statusCode = 500;
+				response.end("server must not be hit");
+			},
+			(baseUrl) =>
+				withGeneratedFixture({
+					testFn: async ({ exec }) => {
+						const stdout = await getStdout(exec`download --log-level info`);
+
+						expect(stdout).toContain("Skip download");
+					},
+					files: {
+						...makeFixture(`tasks.register("download", DownloadTask, { url: "${baseUrl}/file.txt", into: "dist", sha256: "${DIGEST}" });`),
+						dist: { "file.txt": CONTENT }
+					}
+				})
+		));
+
+	it("fails on a non-success status", () =>
+		withServer(
+			(_request, response) => {
+				response.statusCode = 404;
+				response.end("not found");
+			},
+			(baseUrl) =>
+				withGeneratedFixture({
+					files: makeFixture(`tasks.register("download", DownloadTask, { url: "${baseUrl}/file.txt", into: "dist" });`),
+					testFn: async ({ exec }) => {
+						const { stdout, stderr, exitCode } = await settle(exec`download --stacktrace`);
+
+						expect(exitCode).not.toBe(0);
+						expect(stdout + stderr).toContain("status 404");
+					}
+				})
+		));
+});

--- a/packages/nadle/test/builtin-tasks/zip-task.test.ts
+++ b/packages/nadle/test/builtin-tasks/zip-task.test.ts
@@ -1,0 +1,87 @@
+import fixturify from "fixturify";
+import { isWindows } from "std-env";
+import { it, expect, describe } from "vitest";
+import { settle, fixture, getStdout, withGeneratedFixture } from "setup";
+
+const makeFixture = (config: string) =>
+	fixture()
+		.packageJson("zip-task")
+		.file("assets/bar.txt", "bar contents")
+		.file("assets/sub/baz.txt", "baz contents")
+		.configRaw([`import { tasks, ZipTask, UnzipTask } from "nadle";`, ``, config].join("\n"))
+		.build();
+
+const readFiles = (cwd: string) =>
+	fixturify.readSync(cwd, { ignore: ["nadle.config.ts", "package.json", "node_modules", "*.zip"] }) as Record<string, unknown>;
+
+describe.skipIf(isWindows).concurrent("zipTask and unzipTask", () => {
+	it("round-trips a directory through zip and unzip", () =>
+		withGeneratedFixture({
+			testFn: async ({ cwd, exec }) => {
+				await getStdout(exec`zip`);
+				await getStdout(exec`unzip`);
+
+				expect(readFiles(cwd)["extracted"]).toEqual({ "bar.txt": "bar contents", sub: { "baz.txt": "baz contents" } });
+			},
+			files: makeFixture(
+				[
+					`tasks.register("zip", ZipTask, { from: "assets", archive: "out/bundle.zip" });`,
+					`tasks.register("unzip", UnzipTask, { archive: "out/bundle.zip", into: "extracted" });`
+				].join("\n")
+			)
+		}));
+
+	it("stores entries under the prefix", () =>
+		withGeneratedFixture({
+			testFn: async ({ cwd, exec }) => {
+				await getStdout(exec`zip`);
+				await getStdout(exec`unzip`);
+
+				expect(readFiles(cwd)["extracted"]).toEqual({ bundle: { "bar.txt": "bar contents", sub: { "baz.txt": "baz contents" } } });
+			},
+			files: makeFixture(
+				[
+					`tasks.register("zip", ZipTask, { from: "assets", archive: "bundle.zip", prefix: "bundle" });`,
+					`tasks.register("unzip", UnzipTask, { archive: "bundle.zip", into: "extracted" });`
+				].join("\n")
+			)
+		}));
+
+	it("extracts only entries matching include patterns", () =>
+		withGeneratedFixture({
+			testFn: async ({ cwd, exec }) => {
+				await getStdout(exec`zip`);
+				await getStdout(exec`unzip`);
+
+				expect(readFiles(cwd)["extracted"]).toEqual({ sub: { "baz.txt": "baz contents" } });
+			},
+			files: makeFixture(
+				[
+					`tasks.register("zip", ZipTask, { from: "assets", archive: "bundle.zip" });`,
+					`tasks.register("unzip", UnzipTask, { archive: "bundle.zip", into: "extracted", include: "sub/**" });`
+				].join("\n")
+			)
+		}));
+
+	it("fails when the archive does not exist", () =>
+		withGeneratedFixture({
+			files: makeFixture(`tasks.register("unzip", UnzipTask, { archive: "missing.zip", into: "extracted" });`),
+			testFn: async ({ exec }) => {
+				const { stdout, stderr, exitCode } = await settle(exec`unzip --stacktrace`);
+
+				expect(exitCode).not.toBe(0);
+				expect(stdout + stderr).toContain("does not exist");
+			}
+		}));
+
+	it("fails on missing source when strict", () =>
+		withGeneratedFixture({
+			files: makeFixture(`tasks.register("zip", ZipTask, { strict: true, from: "missing", archive: "bundle.zip" });`),
+			testFn: async ({ exec }) => {
+				const { stdout, stderr, exitCode } = await settle(exec`zip --stacktrace`);
+
+				expect(exitCode).not.toBe(0);
+				expect(stdout + stderr).toContain("does not exist");
+			}
+		}));
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -277,6 +277,9 @@ importers:
       fastest-levenshtein:
         specifier: ^1.0.16
         version: 1.0.16
+      fflate:
+        specifier: ^0.8.3
+        version: 0.8.3
       fuzzysort:
         specifier: ^3.1.0
         version: 3.1.0
@@ -5348,6 +5351,9 @@ packages:
   feed@4.2.2:
     resolution: {integrity: sha512-u5/sxGfiMfZNtJ3OvQpXcvotFpYkL0n9u9mM2vkui2nGo8b4wvDkJ8gAkYqbA8QpGyFCv3RK0Z+Iv+9veCS9bQ==}
     engines: {node: '>=0.4.0'}
+
+  fflate@0.8.3:
+    resolution: {integrity: sha512-tbZNuJrLwGUp3zshBtdy4W+ORxZuIh8a5ilyIEQDC5rY1f3U20JMry0Ll3WBzU58EZKsEuJFXhb5gwv8CsPvgA==}
 
   figures@6.1.0:
     resolution: {integrity: sha512-d+l3qxjSesT4V7v2fh+QnmFnUWv9lSpjarhShNTgBOfA0ttejbQUAlHLitbjkoRiDulW0OPoQPYIGhIC8ohejg==}
@@ -15536,6 +15542,8 @@ snapshots:
   feed@4.2.2:
     dependencies:
       xml-js: 1.6.11
+
+  fflate@0.8.3: {}
 
   figures@6.1.0:
     dependencies:

--- a/spec/10-builtin-tasks.md
+++ b/spec/10-builtin-tasks.md
@@ -1,6 +1,6 @@
 # 10 — Built-in Task Types
 
-Nadle provides ten built-in reusable task types, all created via `defineTask()`.
+Nadle provides twelve built-in reusable task types, all created via `defineTask()`.
 
 ## Argument Normalization
 
@@ -202,6 +202,40 @@ without an `overwrite` option — existing destination files are always replaced
 3. Prune directories left empty.
 
 The destination ends up containing exactly the selected files (plus preserved ones).
+
+## ZipTask
+
+Creates a zip archive from selected files.
+
+### Options
+
+| Field     | Type                            | Required | Description                                                          |
+| --------- | ------------------------------- | -------- | -------------------------------------------------------------------- |
+| `from`    | file selection or array thereof | Yes      | Source files, directories, or selectors (see File Selections).       |
+| `archive` | string                          | Yes      | Path of the archive to create (relative to working directory).       |
+| `prefix`  | string                          | No       | Entry-name prefix; files are stored as `<prefix>/<relative path>`.   |
+| `include` | string or array of strings      | No       | Default include patterns for directory selections without their own. |
+| `exclude` | string or array of strings      | No       | Default exclude patterns for directory selections without their own. |
+| `strict`  | boolean                         | No       | Fail when a source is missing or nothing matches. Default: `false`.  |
+
+Entry names are the selection-relative paths (always with forward slashes). Two sources
+mapping to the same entry name fail the task. Parent directories of the archive are
+created as needed.
+
+## UnzipTask
+
+Extracts a zip archive into a directory.
+
+### Options
+
+| Field     | Type                       | Required | Description                                                     |
+| --------- | -------------------------- | -------- | --------------------------------------------------------------- |
+| `archive` | string                     | Yes      | Path of the archive to extract (relative to working directory). |
+| `into`    | string                     | Yes      | Destination directory. Created if missing.                      |
+| `include` | string or array of strings | No       | Glob patterns selecting which entries to extract. Default: all. |
+
+A missing archive is an error. Entries whose names would escape the destination
+directory (path traversal) fail the task.
 
 ## DeleteTask
 

--- a/spec/10-builtin-tasks.md
+++ b/spec/10-builtin-tasks.md
@@ -1,6 +1,6 @@
 # 10 — Built-in Task Types
 
-Nadle provides twelve built-in reusable task types, all created via `defineTask()`.
+Nadle provides thirteen built-in reusable task types, all created via `defineTask()`.
 
 ## Argument Normalization
 
@@ -236,6 +236,26 @@ Extracts a zip archive into a directory.
 
 A missing archive is an error. Entries whose names would escape the destination
 directory (path traversal) fail the task.
+
+## DownloadTask
+
+Downloads a file over HTTP(S).
+
+### Options
+
+| Field      | Type   | Required | Description                                                   |
+| ---------- | ------ | -------- | ------------------------------------------------------------- |
+| `url`      | string | Yes      | The URL to download.                                          |
+| `into`     | string | Yes      | Destination directory. Created if missing.                    |
+| `filename` | string | No       | Destination file name. Default: last segment of the URL path. |
+| `sha256`   | string | No       | Expected SHA-256 hex digest; the task fails on mismatch.      |
+
+### Behavior
+
+- A non-success HTTP status fails the task.
+- When `sha256` is given and the destination file already exists with a matching
+  digest, the download is skipped.
+- A digest mismatch after download fails the task and removes the file.
 
 ## DeleteTask
 

--- a/spec/CHANGELOG.md
+++ b/spec/CHANGELOG.md
@@ -8,6 +8,14 @@ Versioning follows [Semantic Versioning](https://semver.org/):
 - **MINOR**: New concept, new section, or materially expanded rules
 - **PATCH**: Clarifications, corrections, wording improvements
 
+## 3.2.0 — 2026-06-11
+
+### Added
+
+- 10-builtin-tasks: DownloadTask — HTTP(S) download into a directory with optional
+  SHA-256 verification; matching existing files skip the download, mismatches fail
+  the task and remove the file.
+
 ## 3.1.0 — 2026-06-11
 
 ### Added

--- a/spec/CHANGELOG.md
+++ b/spec/CHANGELOG.md
@@ -8,6 +8,15 @@ Versioning follows [Semantic Versioning](https://semver.org/):
 - **MINOR**: New concept, new section, or materially expanded rules
 - **PATCH**: Clarifications, corrections, wording improvements
 
+## 3.1.0 — 2026-06-11
+
+### Added
+
+- 10-builtin-tasks: ZipTask — creates a zip archive from file selections, with an
+  optional entry-name `prefix`; duplicate entry names fail the task.
+- 10-builtin-tasks: UnzipTask — extracts an archive into a directory, with optional
+  `include` entry filtering; path-traversal entries fail the task.
+
 ## 3.0.0 — 2026-06-11
 
 ### Changed (BREAKING)

--- a/spec/README.md
+++ b/spec/README.md
@@ -1,6 +1,6 @@
 # Nadle Specification
 
-**Version**: 3.1.0
+**Version**: 3.2.0
 
 This directory contains the language-agnostic specification for Nadle, a type-safe,
 Gradle-inspired task runner for Node.js.

--- a/spec/README.md
+++ b/spec/README.md
@@ -1,6 +1,6 @@
 # Nadle Specification
 
-**Version**: 3.0.0
+**Version**: 3.1.0
 
 This directory contains the language-agnostic specification for Nadle, a type-safe,
 Gradle-inspired task runner for Node.js.


### PR DESCRIPTION
Phases 3+4 of #605 (combined: #611 auto-merged into this branch before retargeting).

## ZipTask / UnzipTask

```ts
tasks.register("bundle", ZipTask, { from: "dist", archive: "out/bundle.zip", prefix: "bundle" });
tasks.register("extract", UnzipTask, { archive: "out/bundle.zip", into: "extracted", include: "bundle/assets/**" });
```

- Shared `FileSelection` sources; posix entry names, optional `prefix`; duplicate entries fail
- `UnzipTask`: missing archive errors; **zip-slip protection** (escaping entries fail the task)
- New dependency `fflate`; size limit raised 150 → 160 KB (155.8 KB actual)

## DownloadTask

```ts
tasks.register("fetchSchema", DownloadTask, { url: "https://example.com/schema.json", into: "vendor", sha256: "ab12…" });
```

- Global `fetch` + `node:crypto`, no new deps; non-2xx fails
- `sha256`: matching existing file skips the download (idempotent, proven by a test whose mock server answers 500); mismatch fails and removes the file

## Tests & spec

- 5 zip/unzip integration tests (round-trip, prefix, include filter, missing archive, strict)
- 4 download tests against a local `node:http` server
- Spec 3.1.0 (Zip/Unzip) + 3.2.0 (Download); rebased over #613's 3.0.0

🤖 Generated with [Claude Code](https://claude.com/claude-code)