### PR TITLE
feat: add DownloadTask builtin task

### DIFF
--- a/packages/nadle/index.api.md
+++ b/packages/nadle/index.api.md
@@ -62,6 +62,17 @@ export interface DirDeclaration {
 }
 
 // @public
+export const DownloadTask: Task<DownloadTaskOptions>;
+
+// @public
+export interface DownloadTaskOptions {
+    readonly filename?: string;
+    readonly into: string;
+    readonly sha256?: string;
+    readonly url: string;
+}
+
+// @public
 export const ExecTask: Task<ExecTaskOptions>;
 
 // @public

--- a/packages/nadle/src/builtin-tasks/download-task.ts
+++ b/packages/nadle/src/builtin-tasks/download-task.ts
@@ -1,0 +1,73 @@
+import Path from "node:path";
+import Crypto from "node:crypto";
+import Fs from "node:fs/promises";
+
+import { isPathExists } from "../core/utilities/fs.js";
+import { defineTask } from "../core/registration/define-task.js";
+import { TaskExecutionError } from "../core/utilities/nadle-error.js";
+
+/**
+ * Options for the DownloadTask.
+ */
+export interface DownloadTaskOptions {
+	/** The URL to download. */
+	readonly url: string;
+	/** Destination directory. Created if missing. */
+	readonly into: string;
+	/** Expected SHA-256 hex digest; the task fails on mismatch. */
+	readonly sha256?: string;
+	/** Destination file name. Defaults to the last segment of the URL path. */
+	readonly filename?: string;
+}
+
+/**
+ * Task for downloading a file over HTTP(S).
+ *
+ * When `sha256` is given and the destination file already exists with a matching
+ * digest, the download is skipped. A digest mismatch after download fails the task
+ * and removes the file.
+ */
+export const DownloadTask = defineTask<DownloadTaskOptions>({
+	run: async ({ options, context }) => {
+		const filename = options.filename ?? Path.posix.basename(new URL(options.url).pathname);
+
+		if (filename === "") {
+			throw new TaskExecutionError(`Cannot derive a file name from '${options.url}'. Set the 'filename' option.`);
+		}
+
+		const target = Path.resolve(context.workingDir, options.into, filename);
+
+		if (options.sha256 !== undefined && (await isPathExists(target)) && (await sha256Of(target)) === options.sha256.toLowerCase()) {
+			context.logger.info(`Skip download: ${filename} already matches the expected digest.`);
+
+			return;
+		}
+
+		context.logger.info(`Downloading ${options.url}`);
+		const response = await fetch(options.url);
+
+		if (!response.ok) {
+			throw new TaskExecutionError(`Download of '${options.url}' failed with status ${response.status}.`);
+		}
+
+		await Fs.mkdir(Path.dirname(target), { recursive: true });
+		await Fs.writeFile(target, new Uint8Array(await response.arrayBuffer()));
+
+		if (options.sha256 !== undefined) {
+			const actual = await sha256Of(target);
+
+			if (actual !== options.sha256.toLowerCase()) {
+				await Fs.rm(target);
+				throw new TaskExecutionError(`Digest mismatch for '${options.url}': expected ${options.sha256.toLowerCase()}, got ${actual}.`);
+			}
+		}
+
+		context.logger.info(`Downloaded ${options.url} to ${Path.relative(context.workingDir, target)}`);
+	}
+});
+
+async function sha256Of(filePath: string): Promise<string> {
+	return Crypto.createHash("sha256")
+		.update(await Fs.readFile(filePath))
+		.digest("hex");
+}

--- a/packages/nadle/src/builtin-tasks/index.ts
+++ b/packages/nadle/src/builtin-tasks/index.ts
@@ -10,5 +10,6 @@ export * from "./move-task.js";
 export * from "./sync-task.js";
 export * from "./unzip-task.js";
 export * from "./delete-task.js";
+export * from "./download-task.js";
 export { type FileSelector, type FileSelection } from "./file-selection.js";
 export { type OverwritePolicy, type FileOperationOptions } from "./file-operations.js";

--- a/packages/nadle/test/builtin-tasks/download-task.test.ts
+++ b/packages/nadle/test/builtin-tasks/download-task.test.ts
@@ -1,0 +1,99 @@
+import Http from "node:http";
+import type Net from "node:net";
+import Crypto from "node:crypto";
+
+import fixturify from "fixturify";
+import { isWindows } from "std-env";
+import { it, expect, describe } from "vitest";
+import { settle, fixture, getStdout, withGeneratedFixture } from "setup";
+
+const CONTENT = "downloaded contents";
+const DIGEST = Crypto.createHash("sha256").update(CONTENT).digest("hex");
+
+const makeFixture = (config: string) =>
+	fixture().packageJson("download-task").configRaw([`import { tasks, DownloadTask } from "nadle";`, ``, config].join("\n")).build();
+
+const readFiles = (cwd: string) =>
+	fixturify.readSync(cwd, { ignore: ["nadle.config.ts", "package.json", "node_modules"] }) as Record<string, unknown>;
+
+async function withServer(handler: Http.RequestListener, testFn: (baseUrl: string) => Promise<void>) {
+	const server = Http.createServer(handler);
+
+	await new Promise<void>((resolve) => server.listen(0, "127.0.0.1", resolve));
+
+	try {
+		await testFn(`http://127.0.0.1:${(server.address() as Net.AddressInfo).port}`);
+	} finally {
+		server.close();
+	}
+}
+
+describe.skipIf(isWindows).concurrent("downloadTask", () => {
+	it("downloads a file into the destination", () =>
+		withServer(
+			(_request, response) => response.end(CONTENT),
+			(baseUrl) =>
+				withGeneratedFixture({
+					files: makeFixture(`tasks.register("download", DownloadTask, { url: "${baseUrl}/file.txt", into: "dist" });`),
+					testFn: async ({ cwd, exec }) => {
+						await getStdout(exec`download`);
+
+						expect(readFiles(cwd)["dist"]).toEqual({ "file.txt": CONTENT });
+					}
+				})
+		));
+
+	it("verifies the sha256 digest and fails on mismatch", () =>
+		withServer(
+			(_request, response) => response.end(CONTENT),
+			(baseUrl) =>
+				withGeneratedFixture({
+					files: makeFixture(`tasks.register("download", DownloadTask, { url: "${baseUrl}/file.txt", into: "dist", sha256: "${"0".repeat(64)}" });`),
+					testFn: async ({ cwd, exec }) => {
+						const { stdout, stderr, exitCode } = await settle(exec`download --stacktrace`);
+
+						expect(exitCode).not.toBe(0);
+						expect(stdout + stderr).toContain("Digest mismatch");
+						expect(readFiles(cwd)["dist"]).toEqual({});
+					}
+				})
+		));
+
+	it("skips the download when the existing file matches the digest", () =>
+		withServer(
+			(_request, response) => {
+				response.statusCode = 500;
+				response.end("server must not be hit");
+			},
+			(baseUrl) =>
+				withGeneratedFixture({
+					testFn: async ({ exec }) => {
+						const stdout = await getStdout(exec`download --log-level info`);
+
+						expect(stdout).toContain("Skip download");
+					},
+					files: {
+						...makeFixture(`tasks.register("download", DownloadTask, { url: "${baseUrl}/file.txt", into: "dist", sha256: "${DIGEST}" });`),
+						dist: { "file.txt": CONTENT }
+					}
+				})
+		));
+
+	it("fails on a non-success status", () =>
+		withServer(
+			(_request, response) => {
+				response.statusCode = 404;
+				response.end("not found");
+			},
+			(baseUrl) =>
+				withGeneratedFixture({
+					files: makeFixture(`tasks.register("download", DownloadTask, { url: "${baseUrl}/file.txt", into: "dist" });`),
+					testFn: async ({ exec }) => {
+						const { stdout, stderr, exitCode } = await settle(exec`download --stacktrace`);
+
+						expect(exitCode).not.toBe(0);
+						expect(stdout + stderr).toContain("status 404");
+					}
+				})
+		));
+});

--- a/spec/10-builtin-tasks.md
+++ b/spec/10-builtin-tasks.md
@@ -1,6 +1,6 @@
 # 10 — Built-in Task Types
 
-Nadle provides twelve built-in reusable task types, all created via `defineTask()`.
+Nadle provides thirteen built-in reusable task types, all created via `defineTask()`.
 
 ## ExecTask
 
@@ -229,6 +229,26 @@ Extracts a zip archive into a directory.
 
 A missing archive is an error. Entries whose names would escape the destination
 directory (path traversal) fail the task.
+
+## DownloadTask
+
+Downloads a file over HTTP(S).
+
+### Options
+
+| Field      | Type   | Required | Description                                                   |
+| ---------- | ------ | -------- | ------------------------------------------------------------- |
+| `url`      | string | Yes      | The URL to download.                                          |
+| `into`     | string | Yes      | Destination directory. Created if missing.                    |
+| `filename` | string | No       | Destination file name. Default: last segment of the URL path. |
+| `sha256`   | string | No       | Expected SHA-256 hex digest; the task fails on mismatch.      |
+
+### Behavior
+
+- A non-success HTTP status fails the task.
+- When `sha256` is given and the destination file already exists with a matching
+  digest, the download is skipped.
+- A digest mismatch after download fails the task and removes the file.
 
 ## DeleteTask
 

--- a/spec/CHANGELOG.md
+++ b/spec/CHANGELOG.md
@@ -8,6 +8,14 @@ Versioning follows [Semantic Versioning](https://semver.org/):
 - **MINOR**: New concept, new section, or materially expanded rules
 - **PATCH**: Clarifications, corrections, wording improvements
 
+## 2.3.0 — 2026-06-11
+
+### Added
+
+- 10-builtin-tasks: DownloadTask — HTTP(S) download into a directory with optional
+  SHA-256 verification; matching existing files skip the download, mismatches fail
+  the task and remove the file.
+
 ## 2.2.0 — 2026-06-11
 
 ### Added

--- a/spec/README.md
+++ b/spec/README.md
@@ -1,6 +1,6 @@
 # Nadle Specification
 
-**Version**: 2.2.0
+**Version**: 2.3.0
 
 This directory contains the language-agnostic specification for Nadle, a type-safe,
 Gradle-inspired task runner for Node.js.


### PR DESCRIPTION
Phase 4 of #605 — completes the planned builtin task set. Stacked on #610; will rebase/retarget to main once it merges.

## DownloadTask

```ts
tasks.register("fetchSchema", DownloadTask, {
	url: "https://example.com/schema.json",
	into: "vendor",
	sha256: "abc123…"   // optional integrity check
});
```

- `filename` defaults to the last URL path segment (explicit option required when underivable)
- Non-2xx status fails the task
- With `sha256`: existing file with matching digest **skips the download** (idempotent re-runs); post-download mismatch fails the task and removes the file
- No new dependencies (global `fetch` + `node:crypto`)

## Tests

4 integration tests against a local `node:http` server: plain download, digest mismatch (file removed), skip-on-matching-digest (server answering 500 proves no request is made), non-2xx failure.

Spec 2.3.0; api report regenerated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)