### PR TITLE
perf: copy files concurrently in CopyTask

### DIFF
--- a/packages/nadle/package.json
+++ b/packages/nadle/package.json
@@ -37,6 +37,7 @@
 		"lodash-es": "^4.18.1",
 		"micromatch": "^4.0.8",
 		"object-hash": "^3.0.0",
+		"p-limit": "^7.3.0",
 		"react": "^19.1.0",
 		"rimraf": "^6.1.3",
 		"std-env": "^3.10.0",

--- a/packages/nadle/src/builtin-tasks/copy-task.ts
+++ b/packages/nadle/src/builtin-tasks/copy-task.ts
@@ -1,8 +1,12 @@
 import Path from "node:path";
 import Fs from "node:fs/promises";
 
+import pLimit from "p-limit";
+
 import { defineTask } from "../core/registration/define-task.js";
 import { shouldWrite, resolveTargets, type OverwritePolicy, type FileOperationOptions } from "./file-operations.js";
+
+const COPY_CONCURRENCY = 8;
 
 /**
  * Options for the CopyTask.
@@ -22,17 +26,21 @@ export const CopyTask = defineTask<CopyTaskOptions>({
 	run: async ({ options, context }) => {
 		const targets = await resolveTargets(options, context);
 		const overwrite = options.overwrite ?? "replace";
+		const limit = pLimit(COPY_CONCURRENCY);
 
-		for (const [target, source] of targets) {
-			if (!(await shouldWrite(target, overwrite, context))) {
-				continue;
-			}
+		await Promise.all(
+			[...targets.entries()].map(([target, source]) =>
+				limit(async () => {
+					if (!(await shouldWrite(target, overwrite, context))) {
+						return;
+					}
 
-			await Fs.mkdir(Path.dirname(target), { recursive: true });
-			context.logger.log(`Copy ${Path.relative(context.workingDir, source)} -> ${Path.relative(context.workingDir, target)}`);
-			await Fs.cp(source, target);
-		}
-
+					await Fs.mkdir(Path.dirname(target), { recursive: true });
+					context.logger.log(`Copy ${Path.relative(context.workingDir, source)} -> ${Path.relative(context.workingDir, target)}`);
+					await Fs.cp(source, target);
+				})
+			)
+		);
 		context.logger.info(`Copied ${targets.size} file(s) into ${options.into}`);
 	}
 });

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -298,6 +298,9 @@ importers:
       object-hash:
         specifier: ^3.0.0
         version: 3.0.0
+      p-limit:
+        specifier: ^7.3.0
+        version: 7.3.0
       react:
         specifier: ^19.1.0
         version: 19.1.0
@@ -7067,6 +7070,10 @@ packages:
   p-limit@4.0.0:
     resolution: {integrity: sha512-5b0R4txpzjPWVw/cXXUResoD4hb6U/x9BH08L7nw+GN1sezDzPdxeRvpc9c433fZhBan/wusjbCsqwqm4EIBIQ==}
     engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
+
+  p-limit@7.3.0:
+    resolution: {integrity: sha512-7cIXg/Z0M5WZRblrsOla88S4wAK+zOQQWeBYfV3qJuJXMr+LnbYjaadrFaS0JILfEDPVqHyKnZ1Z/1d6J9VVUw==}
+    engines: {node: '>=20'}
 
   p-locate@4.1.0:
     resolution: {integrity: sha512-R79ZZ/0wAxKGu3oYMlz8jy/kbhsNrS7SKZ7PxEHBgJ5+F2mtFW2fK2cOtBh1cHYkQsbzFV7I+EoRKe6Yt0oK7A==}
@@ -17734,6 +17741,10 @@ snapshots:
       yocto-queue: 0.1.0
 
   p-limit@4.0.0:
+    dependencies:
+      yocto-queue: 1.2.2
+
+  p-limit@7.3.0:
     dependencies:
       yocto-queue: 1.2.2
 


### PR DESCRIPTION
Fixes #604.

`CopyTask` now copies up to 8 files in parallel via `p-limit` (new tiny dependency, ~1 KB) instead of awaiting each `Fs.cp` sequentially. Overwrite policy and per-file log lines unchanged (log order may interleave under concurrency).

All 13 CopyTask + 6 Move/Sync integration tests pass unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)