### PR TITLE
refactor: unify string args semantics across exec-based builtin tasks

### DIFF
--- a/packages/nadle/src/builtin-tasks/exec-task.ts
+++ b/packages/nadle/src/builtin-tasks/exec-task.ts
@@ -1,7 +1,5 @@
-import { parseCommandString } from "execa";
-
-import { runCommand } from "./run-command.js";
 import type { MaybeArray } from "../core/index.js";
+import { runCommand, normalizeArgs } from "./run-command.js";
 import { defineTask } from "../core/registration/define-task.js";
 
 /**
@@ -25,9 +23,9 @@ export const ExecTask = defineTask<ExecTaskOptions>({
 
 		await runCommand(context, {
 			command,
+			args: normalizeArgs(args),
 			doneMessage: `Run completed successfully.`,
-			startMessage: (finalArgs) => `Running command: ${command} ${finalArgs.join(" ")}`,
-			args: args == null ? [] : typeof args === "string" ? parseCommandString(args) : args
+			startMessage: (finalArgs) => `Running command: ${command} ${finalArgs.join(" ")}`
 		});
 	}
 });

--- a/packages/nadle/src/builtin-tasks/node-task.ts
+++ b/packages/nadle/src/builtin-tasks/node-task.ts
@@ -1,5 +1,5 @@
-import { runCommand } from "./run-command.js";
 import type { MaybeArray } from "../core/index.js";
+import { runCommand, normalizeArgs } from "./run-command.js";
 import { defineTask } from "../core/registration/define-task.js";
 
 /**
@@ -19,12 +19,10 @@ export interface NodeTaskOptions {
  */
 export const NodeTask = defineTask<NodeTaskOptions>({
 	run: async ({ options, context }) => {
-		const args = options.args == null ? [] : typeof options.args === "string" ? [options.args] : options.args;
-
 		await runCommand(context, {
 			command: "node",
-			args: [options.script, ...args],
 			doneMessage: `Node script completed successfully.`,
+			args: [options.script, ...normalizeArgs(options.args)],
 			startMessage: (finalArgs) => `Running node script: node ${finalArgs.join(" ")}`
 		});
 	}

--- a/packages/nadle/src/builtin-tasks/npm-task.ts
+++ b/packages/nadle/src/builtin-tasks/npm-task.ts
@@ -1,5 +1,5 @@
-import { runCommand } from "./run-command.js";
-import { MaybeArray } from "../core/index.js";
+import { type MaybeArray } from "../core/index.js";
+import { runCommand, normalizeArgs } from "./run-command.js";
 import { defineTask } from "../core/registration/define-task.js";
 
 /**
@@ -19,7 +19,7 @@ export const NpmTask = defineTask<NpmTaskOptions>({
 	run: async ({ options, context }) => {
 		await runCommand(context, {
 			command: "npm",
-			args: MaybeArray.toArray(options.args),
+			args: normalizeArgs(options.args),
 			doneMessage: `npm command completed successfully.`,
 			startMessage: (finalArgs) => `Running npm command: npm ${finalArgs.join(" ")}`
 		});

--- a/packages/nadle/src/builtin-tasks/npx-task.ts
+++ b/packages/nadle/src/builtin-tasks/npx-task.ts
@@ -1,5 +1,5 @@
-import { runCommand } from "./run-command.js";
-import { MaybeArray } from "../core/index.js";
+import { type MaybeArray } from "../core/index.js";
+import { runCommand, normalizeArgs } from "./run-command.js";
 import { defineTask } from "../core/registration/define-task.js";
 
 /**
@@ -19,12 +19,10 @@ export interface NpxTaskOptions {
  */
 export const NpxTask = defineTask<NpxTaskOptions>({
 	run: async ({ options, context }) => {
-		const args = options.args == null ? [] : MaybeArray.toArray(options.args);
-
 		await runCommand(context, {
 			command: "npx",
-			args: [options.command, ...args],
 			doneMessage: `npx command completed successfully.`,
+			args: [options.command, ...normalizeArgs(options.args)],
 			startMessage: (finalArgs) => `Running npx command: npx ${finalArgs.join(" ")}`
 		});
 	}

--- a/packages/nadle/src/builtin-tasks/pnpm-task.ts
+++ b/packages/nadle/src/builtin-tasks/pnpm-task.ts
@@ -1,5 +1,5 @@
-import { runCommand } from "./run-command.js";
 import { MaybeArray } from "../core/index.js";
+import { runCommand, normalizeArgs } from "./run-command.js";
 import { defineTask } from "../core/registration/define-task.js";
 
 /**
@@ -26,7 +26,7 @@ export const PnpmTask = defineTask<PnpmTaskOptions>({
 		await runCommand(context, {
 			command: "pnpm",
 			doneMessage: `pnpm command completed successfully.`,
-			args: [...filterArgs, ...MaybeArray.toArray(options.args)],
+			args: [...filterArgs, ...normalizeArgs(options.args)],
 			startMessage: (finalArgs) => `Running pnpm command: pnpm ${finalArgs.join(" ")}`
 		});
 	}

--- a/packages/nadle/src/builtin-tasks/pnpx-task.ts
+++ b/packages/nadle/src/builtin-tasks/pnpx-task.ts
@@ -1,5 +1,5 @@
-import { runCommand } from "./run-command.js";
-import { MaybeArray } from "../core/index.js";
+import { type MaybeArray } from "../core/index.js";
+import { runCommand, normalizeArgs } from "./run-command.js";
 import { defineTask } from "../core/registration/define-task.js";
 
 /**
@@ -19,12 +19,10 @@ export interface PnpxTaskOptions {
  */
 export const PnpxTask = defineTask<PnpxTaskOptions>({
 	run: async ({ options, context }) => {
-		const args = options.args == null ? [] : MaybeArray.toArray(options.args);
-
 		await runCommand(context, {
 			command: "pnpm",
-			args: ["exec", options.command, ...args],
 			doneMessage: `pnpm exec command completed successfully.`,
+			args: ["exec", options.command, ...normalizeArgs(options.args)],
 			startMessage: (finalArgs) => `Running pnpm exec command: pnpm ${finalArgs.join(" ")}`
 		});
 	}

--- a/packages/nadle/src/builtin-tasks/run-command.ts
+++ b/packages/nadle/src/builtin-tasks/run-command.ts
@@ -1,7 +1,17 @@
-import { execa } from "execa";
+import { execa, parseCommandString } from "execa";
 
+import { type MaybeArray } from "../core/index.js";
 import { type RunnerContext } from "../core/interfaces/task.js";
 import { TaskExecutionError } from "../core/utilities/nadle-error.js";
+
+/**
+ * Normalizes a task's `args` option: a string is split into arguments on spaces
+ * (backslash-escaped spaces are preserved); an array is taken as-is. One semantic
+ * for all exec-based builtin tasks.
+ */
+export function normalizeArgs(args: MaybeArray<string> | undefined): string[] {
+	return args == null ? [] : typeof args === "string" ? parseCommandString(args) : [...args];
+}
 
 interface RunCommandParams {
 	/** The binary to spawn. */

--- a/packages/nadle/test/unit/normalize-args.test.ts
+++ b/packages/nadle/test/unit/normalize-args.test.ts
@@ -1,0 +1,20 @@
+import { it, expect, describe } from "vitest";
+import { normalizeArgs } from "src/builtin-tasks/run-command.js";
+
+describe.concurrent("normalizeArgs", () => {
+	it("returns an empty array for undefined", () => {
+		expect(normalizeArgs(undefined)).toEqual([]);
+	});
+
+	it("splits a string into arguments", () => {
+		expect(normalizeArgs("run --filter web")).toEqual(["run", "--filter", "web"]);
+	});
+
+	it("keeps escaped spaces together", () => {
+		expect(normalizeArgs(`run a\\ b`)).toEqual(["run", "a b"]);
+	});
+
+	it("returns a copy of an array as-is", () => {
+		expect(normalizeArgs(["a b", "c"])).toEqual(["a b", "c"]);
+	});
+});

--- a/spec/10-builtin-tasks.md
+++ b/spec/10-builtin-tasks.md
@@ -2,20 +2,27 @@
 
 Nadle provides ten built-in reusable task types, all created via `defineTask()`.
 
+## Argument Normalization
+
+All exec-based tasks (ExecTask, NodeTask, NpmTask, NpxTask, PnpmTask, PnpxTask) share one
+semantic for the `args` option: a **string** is split into arguments on spaces, with
+backslash-escaped spaces preserved (`a\ b` stays one argument); an **array** is taken
+as-is, each element one argument.
+
 ## ExecTask
 
 Executes an arbitrary external command.
 
 ### Options
 
-| Field     | Type                       | Required | Description                                                                                 |
-| --------- | -------------------------- | -------- | ------------------------------------------------------------------------------------------- |
-| `command` | string                     | Yes      | The command to execute.                                                                     |
-| `args`    | string or array of strings | No       | Arguments for the command. If a string, it is parsed into arguments by splitting on spaces. |
+| Field     | Type                       | Required | Description                                             |
+| --------- | -------------------------- | -------- | ------------------------------------------------------- |
+| `command` | string                     | Yes      | The command to execute.                                 |
+| `args`    | string or array of strings | No       | Arguments for the command (see Argument Normalization). |
 
 ### Behavior
 
-1. Parse arguments (string arguments are split into an array).
+1. Normalize arguments (see Argument Normalization).
 2. Spawn the process with the command and arguments.
 3. Set working directory to the task's `workingDir`.
 4. Force color output in the subprocess (`FORCE_COLOR=1`).
@@ -36,7 +43,7 @@ Executes a pnpm command. Specialized variant of ExecTask with `pnpm` as the comm
 ### Behavior
 
 1. Normalize `filter` to an array and expand each value into a `--filter <value>` pair.
-2. Normalize `args` to an array and append it after the filter flags.
+2. Normalize `args` (see Argument Normalization) and append it after the filter flags.
 3. Spawn `pnpm` with the combined arguments.
 4. Set working directory to the task's `workingDir`.
 5. Force color output (`FORCE_COLOR=1`).
@@ -56,7 +63,7 @@ Executes a Node.js script. Specialized variant of ExecTask with `node` as the co
 
 ### Behavior
 
-1. Normalize arguments to an array.
+1. Normalize arguments (see Argument Normalization).
 2. Spawn `node <script> <args>`.
 3. Set working directory to the task's `workingDir`.
 4. Force color output (`FORCE_COLOR=1`).
@@ -75,7 +82,7 @@ Executes an npm command. Specialized variant of ExecTask with `npm` as the comma
 
 ### Behavior
 
-1. Normalize arguments to an array.
+1. Normalize arguments (see Argument Normalization).
 2. Spawn `npm` with the arguments.
 3. Set working directory to the task's `workingDir`.
 4. Force color output (`FORCE_COLOR=1`).
@@ -96,7 +103,7 @@ for running binaries from `node_modules/.bin` through pnpm.
 
 ### Behavior
 
-1. Normalize arguments to an array.
+1. Normalize arguments (see Argument Normalization).
 2. Spawn `pnpm exec <command> <args>`.
 3. Set working directory to the task's `workingDir`.
 4. Force color output (`FORCE_COLOR=1`).
@@ -117,7 +124,7 @@ for running binaries from `node_modules/.bin` through npx.
 
 ### Behavior
 
-1. Normalize arguments to an array.
+1. Normalize arguments (see Argument Normalization).
 2. Spawn `npx <command> <args>`.
 3. Set working directory to the task's `workingDir`.
 4. Force color output (`FORCE_COLOR=1`).

--- a/spec/CHANGELOG.md
+++ b/spec/CHANGELOG.md
@@ -8,6 +8,16 @@ Versioning follows [Semantic Versioning](https://semver.org/):
 - **MINOR**: New concept, new section, or materially expanded rules
 - **PATCH**: Clarifications, corrections, wording improvements
 
+## 3.0.0 — 2026-06-11
+
+### Changed (BREAKING)
+
+- 10-builtin-tasks: Argument Normalization — all exec-based tasks now share one
+  semantic for a string `args` value: split into arguments on spaces, with
+  backslash-escaped spaces preserved (previously only ExecTask split;
+  NodeTask/NpmTask/NpxTask/PnpmTask/PnpxTask treated the whole string as a single
+  argument). Array values are unchanged.
+
 ## 2.1.0 — 2026-06-11
 
 ### Added

--- a/spec/README.md
+++ b/spec/README.md
@@ -1,6 +1,6 @@
 # Nadle Specification
 
-**Version**: 2.1.0
+**Version**: 3.0.0
 
 This directory contains the language-agnostic specification for Nadle, a type-safe,
 Gradle-inspired task runner for Node.js.


### PR DESCRIPTION
Fixes #601 (option 1 from the issue).

## BREAKING CHANGE

`args: "a b"` now means the same thing in all six exec-based tasks: split into `["a", "b"]` on spaces, with backslash-escaped spaces preserved (`a\ b` → one argument). Previously only `ExecTask` split; `NodeTask`/`NpmTask`/`NpxTask`/`PnpmTask`/`PnpxTask` passed the whole string as a single argument. Array values are unchanged. Migration: anyone relying on a single argument containing spaces should use the array form.

Note: `execa`'s `parseCommandString` splits on spaces with backslash escaping — it is **not** quote-aware (`"a b"` becomes two tokens with literal quotes); documented accordingly.

## Implementation

- New shared `normalizeArgs()` in `run-command.ts`; all six tasks use it (removes the three divergent normalization branches)
- Spec 3.0.0: new "Argument Normalization" section, per-task behavior steps reference it
- Unit tests for `normalizeArgs`; full builtin-task integration suite passes unchanged (all fixtures use the unaffected array form or single-token strings)

⚠️ Spec CHANGELOG/README may conflict with #610/#611 (parallel spec bumps 2.2.0/2.3.0) — trivial resolution, versions stay ordered.

🤖 Generated with [Claude Code](https://claude.com/claude-code)