### PR TITLE
ci: report CI Status for docs-only pull requests

### DIFF
--- a/.github/workflows/ci-docs-only.yml
+++ b/.github/workflows/ci-docs-only.yml
@@ -1,0 +1,25 @@
+# Companion to ci.yml: branch protection requires the "CI Status" check, but ci.yml
+# skips docs-only changes via paths-ignore, leaving those PRs blocked on a check that
+# never reports. This workflow runs on exactly the inverted paths and reports an
+# instant "CI Status" success. Keep the paths lists in sync with ci.yml.
+name: CI
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened, ready_for_review]
+    paths:
+      - "*.md"
+      - "packages/docs/**"
+      - "LICENSE"
+
+permissions:
+  contents: read
+
+jobs:
+  status:
+    name: CI Status
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - name: Docs-only change
+        run: echo "Docs-only change — full CI skipped."


### PR DESCRIPTION
Branch protection requires the `CI Status` check, but `ci.yml` skips docs-only changes via `paths-ignore` — so docs-only PRs (like #614) block forever on a check that never reports.

This adds a companion workflow with the same workflow name and job name (`CI Status`) that triggers on exactly the inverted paths (`*.md`, `packages/docs/**`, `LICENSE`) and reports an instant success. Mixed docs+code PRs trigger both workflows; the real one still runs and gates.

This is GitHub's [documented pattern](https://docs.github.com/en/repositories/configuring-branches-and-merges-in-your-repository/defining-the-mergeability-of-pull-requests/troubleshooting-required-status-checks#handling-skipped-but-required-checks) for skipped-but-required checks.

#614 was admin-merged to unblock; future docs-only PRs merge normally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)