### PR TITLE
chore: use tsgo (TypeScript native preview) for build and typecheck

### DIFF
--- a/cspell.config.js
+++ b/cspell.config.js
@@ -53,6 +53,7 @@ const config = {
 		"TSES",
 		"nadlejs",
 		"pnpx",
+		"tsgo",
 		"Uncategorized",
 		...extractLibraryNames()
 	],

--- a/nadle.config.ts
+++ b/nadle.config.ts
@@ -52,7 +52,7 @@ tasks.register("check").config({
 
 // --- Building (nadle-specific, kept here due to workspace self-reference limitation) ---
 
-tasks.register("typecheck", PnpxTask, { command: "tsc", args: ["-b", "--noEmit"] }).config({
+tasks.register("typecheck", PnpxTask, { command: "tsgo", args: ["-b", "--noEmit"] }).config({
 	group: "Building",
 	dependsOn: ["packages:nadle:build"],
 	description: "Type-check all project references"

--- a/package.json
+++ b/package.json
@@ -11,6 +11,8 @@
 		"@nadle/eslint-config": "^1.0.2",
 		"@nadle/prettier-config": "^0.0.5",
 		"@nadle/ts-config": "^0.0.2",
+		"@types/node": "^20.19.33",
+		"@typescript/native-preview": "7.0.0-dev.20260611.2",
 		"@vitest/eslint-plugin": "^1.6.19",
 		"cspell": "^9.3.2",
 		"eslint": "^9.39.1",

--- a/packages/create-nadle/nadle.config.ts
+++ b/packages/create-nadle/nadle.config.ts
@@ -1,10 +1,10 @@
 import { tasks, Inputs, Outputs, PnpxTask } from "../../node_modules/nadle/lib/index.js";
 
-tasks.register("build", PnpxTask, { command: "tsc", args: ["-p", "tsconfig.build.json"] }).config({
+tasks.register("build", PnpxTask, { command: "tsgo", args: ["-p", "tsconfig.build.json"] }).config({
 	group: "Building",
 	inputs: [Inputs.dirs("src")],
 	outputs: [Outputs.dirs("lib")],
-	description: "Compile create-nadle with tsc"
+	description: "Compile create-nadle with tsgo"
 });
 
 tasks.register("test", PnpxTask, { args: "run", command: "vitest" }).config({

--- a/packages/create-nadle/tsconfig.json
+++ b/packages/create-nadle/tsconfig.json
@@ -3,9 +3,8 @@
 	"include": ["src", "test", "vitest.config.ts", "tsup.config.ts", "nadle.config.ts"],
 	"compilerOptions": {
 		"allowJs": true,
-		"baseUrl": ".",
 		"paths": {
-			"setup": ["test/__setup__/index.js"]
+			"setup": ["./test/__setup__/index.js"]
 		}
 	}
 }

--- a/packages/docs/package.json
+++ b/packages/docs/package.json
@@ -24,6 +24,7 @@
 		"@docusaurus/module-type-aliases": "^3.10.1",
 		"@docusaurus/tsconfig": "^3.10.1",
 		"@docusaurus/types": "^3.10.1",
+		"@types/node": "^20.19.33",
 		"glob": "^11.1.0",
 		"spec-md": "^3.1.0",
 		"typescript": "^5.9.3"

--- a/packages/eslint-plugin/nadle.config.ts
+++ b/packages/eslint-plugin/nadle.config.ts
@@ -1,10 +1,10 @@
 import { tasks, Inputs, Outputs, PnpxTask } from "../../node_modules/nadle/lib/index.js";
 
-tasks.register("build", PnpxTask, { command: "tsc", args: ["-p", "tsconfig.build.json"] }).config({
+tasks.register("build", PnpxTask, { command: "tsgo", args: ["-p", "tsconfig.build.json"] }).config({
 	group: "Building",
 	inputs: [Inputs.dirs("src")],
 	outputs: [Outputs.dirs("lib")],
-	description: "Compile eslint-plugin with tsc"
+	description: "Compile eslint-plugin with tsgo"
 });
 
 tasks.register("test", PnpxTask, { args: "run", command: "vitest" }).config({

--- a/packages/eslint-plugin/tsconfig.json
+++ b/packages/eslint-plugin/tsconfig.json
@@ -2,7 +2,6 @@
 	"extends": "../../tsconfig.base.json",
 	"include": ["src", "test", "nadle.config.ts"],
 	"compilerOptions": {
-		"baseUrl": ".",
 		"module": "ESNext",
 		"moduleResolution": "Bundler"
 	}

--- a/packages/kernel/nadle.config.ts
+++ b/packages/kernel/nadle.config.ts
@@ -1,10 +1,10 @@
 import { tasks, Inputs, Outputs, PnpxTask } from "../../node_modules/nadle/lib/index.js";
 
-tasks.register("build", PnpxTask, { command: "tsc", args: ["-p", "tsconfig.build.json"] }).config({
+tasks.register("build", PnpxTask, { command: "tsgo", args: ["-p", "tsconfig.build.json"] }).config({
 	group: "Building",
 	inputs: [Inputs.dirs("src")],
 	outputs: [Outputs.dirs("lib")],
-	description: "Compile kernel with tsc"
+	description: "Compile kernel with tsgo"
 });
 
 tasks.register("test", PnpxTask, { args: "run", command: "vitest" }).config({

--- a/packages/kernel/tsconfig.json
+++ b/packages/kernel/tsconfig.json
@@ -1,7 +1,4 @@
 {
 	"extends": "../../tsconfig.base.json",
-	"include": ["src", "test", "nadle.config.ts"],
-	"compilerOptions": {
-		"baseUrl": "."
-	}
+	"include": ["src", "test", "nadle.config.ts"]
 }

--- a/packages/language-server/tsconfig.json
+++ b/packages/language-server/tsconfig.json
@@ -2,8 +2,10 @@
 	"extends": "../../tsconfig.base.json",
 	"include": ["src", "test", "vitest.config.ts", "tsup.config.ts", "nadle.config.ts"],
 	"compilerOptions": {
-		"baseUrl": ".",
 		"module": "ESNext",
-		"moduleResolution": "Bundler"
+		"moduleResolution": "Bundler",
+		"paths": {
+			"src/*": ["./src/*"]
+		}
 	}
 }

--- a/packages/nadle/tsconfig.json
+++ b/packages/nadle/tsconfig.json
@@ -3,9 +3,9 @@
 	"include": ["src", "test", "bench", "vitest.config.ts", "tsup.config.ts", "nadle.config.ts"],
 	"compilerOptions": {
 		"allowJs": true,
-		"baseUrl": ".",
 		"paths": {
-			"setup": ["test/__setup__/index.js"]
+			"setup": ["./test/__setup__/index.js"],
+			"src/*": ["./src/*"]
 		}
 	}
 }

--- a/packages/project-resolver/nadle.config.ts
+++ b/packages/project-resolver/nadle.config.ts
@@ -1,10 +1,10 @@
 import { tasks, Inputs, Outputs, PnpxTask } from "../../node_modules/nadle/lib/index.js";
 
-tasks.register("build", PnpxTask, { command: "tsc", args: ["-p", "tsconfig.build.json"] }).config({
+tasks.register("build", PnpxTask, { command: "tsgo", args: ["-p", "tsconfig.build.json"] }).config({
 	group: "Building",
 	inputs: [Inputs.dirs("src")],
 	outputs: [Outputs.dirs("lib")],
-	description: "Compile project package with tsc"
+	description: "Compile project package with tsgo"
 });
 
 tasks.register("test", PnpxTask, { args: "run", command: "vitest" }).config({

--- a/packages/project-resolver/tsconfig.json
+++ b/packages/project-resolver/tsconfig.json
@@ -1,7 +1,4 @@
 {
 	"extends": "../../tsconfig.base.json",
-	"include": ["src", "test", "nadle.config.ts"],
-	"compilerOptions": {
-		"baseUrl": "."
-	}
+	"include": ["src", "test", "nadle.config.ts"]
 }

--- a/packages/vscode-extension/package.json
+++ b/packages/vscode-extension/package.json
@@ -20,6 +20,7 @@
 	],
 	"main": "./lib/extension.js",
 	"devDependencies": {
+		"@types/node": "^20.19.33",
 		"@types/vscode": "^1.120.0",
 		"@vscode/vsce": "^3.9.2",
 		"tsup": "^8.5.1",

--- a/packages/vscode-extension/tsconfig.json
+++ b/packages/vscode-extension/tsconfig.json
@@ -1,7 +1,4 @@
 {
 	"extends": "../../tsconfig.base.json",
-	"include": ["src", "scripts", "tsup.config.ts", "nadle.config.ts"],
-	"compilerOptions": {
-		"baseUrl": "."
-	}
+	"include": ["src", "scripts", "tsup.config.ts", "nadle.config.ts"]
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -23,19 +23,25 @@ importers:
     devDependencies:
       '@microsoft/api-extractor':
         specifier: ^7.58.7
-        version: 7.58.7(@types/node@25.9.3)
+        version: 7.58.7(@types/node@20.19.33)
       '@nadle/eslint-config':
         specifier: ^1.0.2
-        version: 1.0.2(@typescript-eslint/eslint-plugin@8.60.1(@typescript-eslint/parser@8.60.1(eslint@9.39.2(jiti@2.7.0))(typescript@5.9.3))(eslint@9.39.2(jiti@2.7.0))(typescript@5.9.3))(eslint@9.39.2(jiti@2.7.0))(typescript@5.9.3)(vitest@4.0.18(@opentelemetry/api@1.9.0)(@types/node@25.9.3)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0))
+        version: 1.0.2(@typescript-eslint/eslint-plugin@8.60.1(@typescript-eslint/parser@8.60.1(eslint@9.39.2(jiti@2.7.0))(typescript@5.9.3))(eslint@9.39.2(jiti@2.7.0))(typescript@5.9.3))(eslint@9.39.2(jiti@2.7.0))(typescript@5.9.3)(vitest@4.0.18(@opentelemetry/api@1.9.0)(@types/node@20.19.33)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0))
       '@nadle/prettier-config':
         specifier: ^0.0.5
         version: 0.0.5(prettier@3.8.3)
       '@nadle/ts-config':
         specifier: ^0.0.2
         version: 0.0.2
+      '@types/node':
+        specifier: ^20.19.33
+        version: 20.19.33
+      '@typescript/native-preview':
+        specifier: 7.0.0-dev.20260611.2
+        version: 7.0.0-dev.20260611.2
       '@vitest/eslint-plugin':
         specifier: ^1.6.19
-        version: 1.6.19(@typescript-eslint/eslint-plugin@8.60.1(@typescript-eslint/parser@8.60.1(eslint@9.39.2(jiti@2.7.0))(typescript@5.9.3))(eslint@9.39.2(jiti@2.7.0))(typescript@5.9.3))(eslint@9.39.2(jiti@2.7.0))(typescript@5.9.3)(vitest@4.0.18(@opentelemetry/api@1.9.0)(@types/node@25.9.3)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0))
+        version: 1.6.19(@typescript-eslint/eslint-plugin@8.60.1(@typescript-eslint/parser@8.60.1(eslint@9.39.2(jiti@2.7.0))(typescript@5.9.3))(eslint@9.39.2(jiti@2.7.0))(typescript@5.9.3))(eslint@9.39.2(jiti@2.7.0))(typescript@5.9.3)(vitest@4.0.18(@opentelemetry/api@1.9.0)(@types/node@20.19.33)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0))
       cspell:
         specifier: ^9.3.2
         version: 9.6.4
@@ -56,7 +62,7 @@ importers:
         version: 2.7.0
       knip:
         specifier: ^5.70.2
-        version: 5.83.1(@types/node@25.9.3)(typescript@5.9.3)
+        version: 5.83.1(@types/node@20.19.33)(typescript@5.9.3)
       nadle:
         specifier: https://pkg.pr.new/nadle@368fc65
         version: https://pkg.pr.new/nadle@368fc65(@types/react@19.2.17)
@@ -173,6 +179,9 @@ importers:
       '@docusaurus/types':
         specifier: ^3.10.1
         version: 3.10.1(clean-css@5.3.3)(cssnano@6.1.2(postcss@8.5.15))(html-minifier-terser@7.2.0)(lightningcss@1.32.0)(postcss@8.5.15)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@types/node':
+        specifier: ^20.19.33
+        version: 20.19.33
       glob:
         specifier: ^11.1.0
         version: 11.1.0
@@ -435,6 +444,9 @@ importers:
 
   packages/vscode-extension:
     devDependencies:
+      '@types/node':
+        specifier: ^20.19.33
+        version: 20.19.33
       '@types/vscode':
         specifier: ^1.120.0
         version: 1.120.0
@@ -443,7 +455,7 @@ importers:
         version: 3.9.2
       tsup:
         specifier: ^8.5.1
-        version: 8.5.1(@microsoft/api-extractor@7.58.7(@types/node@25.9.3))(jiti@2.7.0)(postcss@8.5.15)(tsx@4.22.4)(typescript@5.9.3)(yaml@2.9.0)
+        version: 8.5.1(@microsoft/api-extractor@7.58.7(@types/node@20.19.33))(jiti@2.7.0)(postcss@8.5.15)(tsx@4.22.4)(typescript@5.9.3)(yaml@2.9.0)
       typescript:
         specifier: ^5.9.3
         version: 5.9.3
@@ -3615,9 +3627,6 @@ packages:
   '@types/node@20.19.33':
     resolution: {integrity: sha512-Rs1bVAIdBs5gbTIKza/tgpMuG1k3U/UMJLWecIMxNdJFDMzcM5LOiLVRYh3PilWEYDIeUDv7bpiHPLPsbydGcw==}
 
-  '@types/node@25.9.3':
-    resolution: {integrity: sha512-603BddQMv3pUcr4U2dhujk83N2tTDVr/34wII2B6bJy6g+8WD6yUb11jszNs0gdi4PesVWl7ABt8nYMVpnLUcg==}
-
   '@types/normalize-package-data@2.4.4':
     resolution: {integrity: sha512-37i+OaWTh9qeK4LSHPsyRC7NahnGotNuZvjLSgcPzblpHB3rrCJxAOgI5gCdKm7coonsaX1Of0ILiTcnZjbfxA==}
 
@@ -3761,6 +3770,53 @@ packages:
   '@typescript-eslint/visitor-keys@8.60.1':
     resolution: {integrity: sha512-EbGRQg4FhrmwLodl+t3JNAnXHWVr9Vp+Zl1QBZVPY4ByfkzIT8cX3K6QWODHtkIZqqJVEWvhHSx3v5PDHsaQag==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+
+  '@typescript/native-preview-darwin-arm64@7.0.0-dev.20260611.2':
+    resolution: {integrity: sha512-X6NqNmoTnO1vtcsE4qP571BByPi+i16Ynrp6fffcQ38pbRuy4mwECxA9nKb273gscG0wvcIcGM81B+vy1F4nDw==}
+    engines: {node: '>=16.20.0'}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@typescript/native-preview-darwin-x64@7.0.0-dev.20260611.2':
+    resolution: {integrity: sha512-VeguHC/F7EbxNPCrcwCRH2wif6PZKcdUg2DtMyjxohtcVK3vOoVCYqhJBgJVWQ2gbXk+bXcIz8L2/uNYDksN0w==}
+    engines: {node: '>=16.20.0'}
+    cpu: [x64]
+    os: [darwin]
+
+  '@typescript/native-preview-linux-arm64@7.0.0-dev.20260611.2':
+    resolution: {integrity: sha512-19TXmRxxPUNNDAP/4xBwDNud1NvuNgQJhRm87t7/CSh4FGhWeeEm7AuyEvrCB+vzeeI/ExT+J58U1HOo+kYKzg==}
+    engines: {node: '>=16.20.0'}
+    cpu: [arm64]
+    os: [linux]
+
+  '@typescript/native-preview-linux-arm@7.0.0-dev.20260611.2':
+    resolution: {integrity: sha512-szcSb7sSn3OQZ5UWtToG2RTQeDlokd05pXM+rGctBIctDj6E4j9bvAfp6xLZCzqyDuZJhi3cXCJBdSlBD0NjHw==}
+    engines: {node: '>=16.20.0'}
+    cpu: [arm]
+    os: [linux]
+
+  '@typescript/native-preview-linux-x64@7.0.0-dev.20260611.2':
+    resolution: {integrity: sha512-h5Etd2Kc6lvvc+X4MU/EFeYDUZAS4hOqB18piWuy2INHfRvJMOo8jZOwUJRix3NQu75tPbltFCkwFOGqB0fd2Q==}
+    engines: {node: '>=16.20.0'}
+    cpu: [x64]
+    os: [linux]
+
+  '@typescript/native-preview-win32-arm64@7.0.0-dev.20260611.2':
+    resolution: {integrity: sha512-JUUFHNi3asye8iOlVmFEra34LuQ8bw8qvYWp+cW7EXg3mrMxtac/u5chhi8BmICEav2Ff3UFd8ZFL0n+F5EvBA==}
+    engines: {node: '>=16.20.0'}
+    cpu: [arm64]
+    os: [win32]
+
+  '@typescript/native-preview-win32-x64@7.0.0-dev.20260611.2':
+    resolution: {integrity: sha512-1ZPtOctecgkUHBIEoTefE34t4CewqxwdzIkRx22fDEC9bHhN8xO4JSfQyL+OSWDxiZaJKuqR9BnfWSl2eAFtmg==}
+    engines: {node: '>=16.20.0'}
+    cpu: [x64]
+    os: [win32]
+
+  '@typescript/native-preview@7.0.0-dev.20260611.2':
+    resolution: {integrity: sha512-nP/OrQRFTRKHeQiXzMVhQlxSrOPeuDgeGGd9KMlmOFTc/bbQ8Zd6Ep5izsdTkFljd26QUfpm98crp5E5bYAvJg==}
+    engines: {node: '>=16.20.0'}
+    hasBin: true
 
   '@typespec/ts-http-runtime@0.3.6':
     resolution: {integrity: sha512-jIXhD0eWQ1JA6ln/5Dltyx22UxWNrw0hZmhy2rlv6m6KgF7kplHx3g0fzi09lNmTJQRR91OlemYp3xFnvDK9og==}
@@ -8810,9 +8866,6 @@ packages:
   undici-types@6.21.0:
     resolution: {integrity: sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==}
 
-  undici-types@7.24.6:
-    resolution: {integrity: sha512-WRNW+sJgj5OBN4/0JpHFqtqzhpbnV0GuB+OozA9gCL7a993SmU+1JBZCzLNxYsbMfIeDL+lTsphD5jN5N+n0zg==}
-
   undici@7.27.2:
     resolution: {integrity: sha512-uZsKNuzQxDMUY6M3pIMvy5tvlGmtq8XJ2oLAkfRKGNu+1VQAIvLy2xIVG5ATZl5wDXl/tddByAWCizRbOme+TA==}
     engines: {node: '>=20.18.1'}
@@ -12401,15 +12454,6 @@ snapshots:
       '@rushstack/node-core-library': 5.23.1(@types/node@20.19.33)
     transitivePeerDependencies:
       - '@types/node'
-    optional: true
-
-  '@microsoft/api-extractor-model@7.33.8(@types/node@25.9.3)':
-    dependencies:
-      '@microsoft/tsdoc': 0.16.0
-      '@microsoft/tsdoc-config': 0.18.1
-      '@rushstack/node-core-library': 5.23.1(@types/node@25.9.3)
-    transitivePeerDependencies:
-      - '@types/node'
 
   '@microsoft/api-extractor@7.58.7(@types/node@20.19.33)':
     dependencies:
@@ -12428,25 +12472,6 @@ snapshots:
       typescript: 5.9.3
     transitivePeerDependencies:
       - '@types/node'
-    optional: true
-
-  '@microsoft/api-extractor@7.58.7(@types/node@25.9.3)':
-    dependencies:
-      '@microsoft/api-extractor-model': 7.33.8(@types/node@25.9.3)
-      '@microsoft/tsdoc': 0.16.0
-      '@microsoft/tsdoc-config': 0.18.1
-      '@rushstack/node-core-library': 5.23.1(@types/node@25.9.3)
-      '@rushstack/rig-package': 0.7.3
-      '@rushstack/terminal': 0.24.0(@types/node@25.9.3)
-      '@rushstack/ts-command-line': 5.3.9(@types/node@25.9.3)
-      diff: 8.0.4
-      minimatch: 10.2.3
-      resolve: 1.22.12
-      semver: 7.7.4
-      source-map: 0.6.1
-      typescript: 5.9.3
-    transitivePeerDependencies:
-      - '@types/node'
 
   '@microsoft/tsdoc-config@0.18.1':
     dependencies:
@@ -12457,11 +12482,11 @@ snapshots:
 
   '@microsoft/tsdoc@0.16.0': {}
 
-  '@nadle/eslint-config@1.0.2(@typescript-eslint/eslint-plugin@8.60.1(@typescript-eslint/parser@8.60.1(eslint@9.39.2(jiti@2.7.0))(typescript@5.9.3))(eslint@9.39.2(jiti@2.7.0))(typescript@5.9.3))(eslint@9.39.2(jiti@2.7.0))(typescript@5.9.3)(vitest@4.0.18(@opentelemetry/api@1.9.0)(@types/node@25.9.3)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0))':
+  '@nadle/eslint-config@1.0.2(@typescript-eslint/eslint-plugin@8.60.1(@typescript-eslint/parser@8.60.1(eslint@9.39.2(jiti@2.7.0))(typescript@5.9.3))(eslint@9.39.2(jiti@2.7.0))(typescript@5.9.3))(eslint@9.39.2(jiti@2.7.0))(typescript@5.9.3)(vitest@4.0.18(@opentelemetry/api@1.9.0)(@types/node@20.19.33)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0))':
     dependencies:
       '@eslint/js': 9.31.0
       '@stylistic/eslint-plugin': 5.1.0(eslint@9.39.2(jiti@2.7.0))
-      '@vitest/eslint-plugin': 1.6.19(@typescript-eslint/eslint-plugin@8.60.1(@typescript-eslint/parser@8.60.1(eslint@9.39.2(jiti@2.7.0))(typescript@5.9.3))(eslint@9.39.2(jiti@2.7.0))(typescript@5.9.3))(eslint@9.39.2(jiti@2.7.0))(typescript@5.9.3)(vitest@4.0.18(@opentelemetry/api@1.9.0)(@types/node@25.9.3)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0))
+      '@vitest/eslint-plugin': 1.6.19(@typescript-eslint/eslint-plugin@8.60.1(@typescript-eslint/parser@8.60.1(eslint@9.39.2(jiti@2.7.0))(typescript@5.9.3))(eslint@9.39.2(jiti@2.7.0))(typescript@5.9.3))(eslint@9.39.2(jiti@2.7.0))(typescript@5.9.3)(vitest@4.0.18(@opentelemetry/api@1.9.0)(@types/node@20.19.33)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0))
       eslint: 9.39.2(jiti@2.7.0)
       eslint-plugin-n: 17.21.0(eslint@9.39.2(jiti@2.7.0))(typescript@5.9.3)
       eslint-plugin-perfectionist: 4.15.0(eslint@9.39.2(jiti@2.7.0))(typescript@5.9.3)
@@ -12825,29 +12850,10 @@ snapshots:
       semver: 7.7.4
     optionalDependencies:
       '@types/node': 20.19.33
-    optional: true
-
-  '@rushstack/node-core-library@5.23.1(@types/node@25.9.3)':
-    dependencies:
-      ajv: 8.18.0
-      ajv-draft-04: 1.0.0(ajv@8.18.0)
-      ajv-formats: 3.0.1(ajv@8.18.0)
-      fs-extra: 11.3.5
-      import-lazy: 4.0.0
-      jju: 1.4.0
-      resolve: 1.22.12
-      semver: 7.7.4
-    optionalDependencies:
-      '@types/node': 25.9.3
 
   '@rushstack/problem-matcher@0.2.1(@types/node@20.19.33)':
     optionalDependencies:
       '@types/node': 20.19.33
-    optional: true
-
-  '@rushstack/problem-matcher@0.2.1(@types/node@25.9.3)':
-    optionalDependencies:
-      '@types/node': 25.9.3
 
   '@rushstack/rig-package@0.7.3':
     dependencies:
@@ -12861,29 +12867,10 @@ snapshots:
       supports-color: 8.1.1
     optionalDependencies:
       '@types/node': 20.19.33
-    optional: true
-
-  '@rushstack/terminal@0.24.0(@types/node@25.9.3)':
-    dependencies:
-      '@rushstack/node-core-library': 5.23.1(@types/node@25.9.3)
-      '@rushstack/problem-matcher': 0.2.1(@types/node@25.9.3)
-      supports-color: 8.1.1
-    optionalDependencies:
-      '@types/node': 25.9.3
 
   '@rushstack/ts-command-line@5.3.9(@types/node@20.19.33)':
     dependencies:
       '@rushstack/terminal': 0.24.0(@types/node@20.19.33)
-      '@types/argparse': 1.0.38
-      argparse: 1.0.10
-      string-argv: 0.3.2
-    transitivePeerDependencies:
-      - '@types/node'
-    optional: true
-
-  '@rushstack/ts-command-line@5.3.9(@types/node@25.9.3)':
-    dependencies:
-      '@rushstack/terminal': 0.24.0(@types/node@25.9.3)
       '@types/argparse': 1.0.38
       argparse: 1.0.10
       string-argv: 0.3.2
@@ -13378,10 +13365,6 @@ snapshots:
     dependencies:
       undici-types: 6.21.0
 
-  '@types/node@25.9.3':
-    dependencies:
-      undici-types: 7.24.6
-
   '@types/normalize-package-data@2.4.4': {}
 
   '@types/object-hash@3.0.6': {}
@@ -13576,6 +13559,37 @@ snapshots:
       '@typescript-eslint/types': 8.60.1
       eslint-visitor-keys: 5.0.1
 
+  '@typescript/native-preview-darwin-arm64@7.0.0-dev.20260611.2':
+    optional: true
+
+  '@typescript/native-preview-darwin-x64@7.0.0-dev.20260611.2':
+    optional: true
+
+  '@typescript/native-preview-linux-arm64@7.0.0-dev.20260611.2':
+    optional: true
+
+  '@typescript/native-preview-linux-arm@7.0.0-dev.20260611.2':
+    optional: true
+
+  '@typescript/native-preview-linux-x64@7.0.0-dev.20260611.2':
+    optional: true
+
+  '@typescript/native-preview-win32-arm64@7.0.0-dev.20260611.2':
+    optional: true
+
+  '@typescript/native-preview-win32-x64@7.0.0-dev.20260611.2':
+    optional: true
+
+  '@typescript/native-preview@7.0.0-dev.20260611.2':
+    optionalDependencies:
+      '@typescript/native-preview-darwin-arm64': 7.0.0-dev.20260611.2
+      '@typescript/native-preview-darwin-x64': 7.0.0-dev.20260611.2
+      '@typescript/native-preview-linux-arm': 7.0.0-dev.20260611.2
+      '@typescript/native-preview-linux-arm64': 7.0.0-dev.20260611.2
+      '@typescript/native-preview-linux-x64': 7.0.0-dev.20260611.2
+      '@typescript/native-preview-win32-arm64': 7.0.0-dev.20260611.2
+      '@typescript/native-preview-win32-x64': 7.0.0-dev.20260611.2
+
   '@typespec/ts-http-runtime@0.3.6':
     dependencies:
       http-proxy-agent: 7.0.2
@@ -13604,7 +13618,7 @@ snapshots:
       tinyrainbow: 3.1.0
       vitest: 4.0.18(@opentelemetry/api@1.9.0)(@types/node@20.19.33)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0)
 
-  '@vitest/eslint-plugin@1.6.19(@typescript-eslint/eslint-plugin@8.60.1(@typescript-eslint/parser@8.60.1(eslint@9.39.2(jiti@2.7.0))(typescript@5.9.3))(eslint@9.39.2(jiti@2.7.0))(typescript@5.9.3))(eslint@9.39.2(jiti@2.7.0))(typescript@5.9.3)(vitest@4.0.18(@opentelemetry/api@1.9.0)(@types/node@25.9.3)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0))':
+  '@vitest/eslint-plugin@1.6.19(@typescript-eslint/eslint-plugin@8.60.1(@typescript-eslint/parser@8.60.1(eslint@9.39.2(jiti@2.7.0))(typescript@5.9.3))(eslint@9.39.2(jiti@2.7.0))(typescript@5.9.3))(eslint@9.39.2(jiti@2.7.0))(typescript@5.9.3)(vitest@4.0.18(@opentelemetry/api@1.9.0)(@types/node@20.19.33)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0))':
     dependencies:
       '@typescript-eslint/scope-manager': 8.60.1
       '@typescript-eslint/utils': 8.60.1(eslint@9.39.2(jiti@2.7.0))(typescript@5.9.3)
@@ -13612,7 +13626,7 @@ snapshots:
     optionalDependencies:
       '@typescript-eslint/eslint-plugin': 8.60.1(@typescript-eslint/parser@8.60.1(eslint@9.39.2(jiti@2.7.0))(typescript@5.9.3))(eslint@9.39.2(jiti@2.7.0))(typescript@5.9.3)
       typescript: 5.9.3
-      vitest: 4.0.18(@opentelemetry/api@1.9.0)(@types/node@25.9.3)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0)
+      vitest: 4.0.18(@opentelemetry/api@1.9.0)(@types/node@20.19.33)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0)
     transitivePeerDependencies:
       - supports-color
 
@@ -13632,15 +13646,6 @@ snapshots:
       magic-string: 0.30.21
     optionalDependencies:
       vite: 7.3.1(@types/node@20.19.33)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0)
-
-  '@vitest/mocker@4.0.18(vite@7.3.1(@types/node@25.9.3)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0))':
-    dependencies:
-      '@vitest/spy': 4.0.18
-      estree-walker: 3.0.3
-      magic-string: 0.30.21
-    optionalDependencies:
-      vite: 7.3.1(@types/node@25.9.3)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0)
-    optional: true
 
   '@vitest/pretty-format@3.1.2':
     dependencies:
@@ -16667,23 +16672,6 @@ snapshots:
       typescript: 5.9.3
       zod: 4.1.11
 
-  knip@5.83.1(@types/node@25.9.3)(typescript@5.9.3):
-    dependencies:
-      '@nodelib/fs.walk': 1.2.8
-      '@types/node': 25.9.3
-      fast-glob: 3.3.3
-      formatly: 0.3.0
-      jiti: 2.7.0
-      js-yaml: 4.1.1
-      minimist: 1.2.8
-      oxc-resolver: 11.17.1
-      picocolors: 1.1.1
-      picomatch: 4.0.3
-      smol-toml: 1.6.0
-      strip-json-comments: 5.0.3
-      typescript: 5.9.3
-      zod: 4.1.11
-
   latest-version@7.0.0:
     dependencies:
       package-json: 8.1.1
@@ -19617,35 +19605,6 @@ snapshots:
       - tsx
       - yaml
 
-  tsup@8.5.1(@microsoft/api-extractor@7.58.7(@types/node@25.9.3))(jiti@2.7.0)(postcss@8.5.15)(tsx@4.22.4)(typescript@5.9.3)(yaml@2.9.0):
-    dependencies:
-      bundle-require: 5.1.0(esbuild@0.27.3)
-      cac: 6.7.14
-      chokidar: 4.0.3
-      consola: 3.4.2
-      debug: 4.4.3
-      esbuild: 0.27.3
-      fix-dts-default-cjs-exports: 1.0.1
-      joycon: 3.1.1
-      picocolors: 1.1.1
-      postcss-load-config: 6.0.1(jiti@2.7.0)(postcss@8.5.15)(tsx@4.22.4)(yaml@2.9.0)
-      resolve-from: 5.0.0
-      rollup: 4.44.0
-      source-map: 0.7.6
-      sucrase: 3.35.0
-      tinyexec: 0.3.2
-      tinyglobby: 0.2.15
-      tree-kill: 1.2.2
-    optionalDependencies:
-      '@microsoft/api-extractor': 7.58.7(@types/node@25.9.3)
-      postcss: 8.5.15
-      typescript: 5.9.3
-    transitivePeerDependencies:
-      - jiti
-      - supports-color
-      - tsx
-      - yaml
-
   tsx@4.22.4:
     dependencies:
       esbuild: 0.28.0
@@ -19771,8 +19730,6 @@ snapshots:
   underscore@1.13.8: {}
 
   undici-types@6.21.0: {}
-
-  undici-types@7.24.6: {}
 
   undici@7.27.2: {}
 
@@ -19939,24 +19896,6 @@ snapshots:
       tsx: 4.22.4
       yaml: 2.9.0
 
-  vite@7.3.1(@types/node@25.9.3)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0):
-    dependencies:
-      esbuild: 0.27.7
-      fdir: 6.5.0(picomatch@4.0.3)
-      picomatch: 4.0.3
-      postcss: 8.5.15
-      rollup: 4.57.1
-      tinyglobby: 0.2.17
-    optionalDependencies:
-      '@types/node': 25.9.3
-      fsevents: 2.3.3
-      jiti: 2.7.0
-      lightningcss: 1.32.0
-      terser: 5.48.0
-      tsx: 4.22.4
-      yaml: 2.9.0
-    optional: true
-
   vitest@4.0.18(@opentelemetry/api@1.9.0)(@types/node@20.19.33)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0):
     dependencies:
       '@vitest/expect': 4.0.18
@@ -19994,45 +19933,6 @@ snapshots:
       - terser
       - tsx
       - yaml
-
-  vitest@4.0.18(@opentelemetry/api@1.9.0)(@types/node@25.9.3)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0):
-    dependencies:
-      '@vitest/expect': 4.0.18
-      '@vitest/mocker': 4.0.18(vite@7.3.1(@types/node@25.9.3)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0))
-      '@vitest/pretty-format': 3.1.2
-      '@vitest/runner': 4.0.18
-      '@vitest/snapshot': 4.0.18
-      '@vitest/spy': 4.0.18
-      '@vitest/utils': 4.0.18
-      es-module-lexer: 1.7.0
-      expect-type: 1.3.0
-      magic-string: 0.30.21
-      obug: 2.1.1
-      pathe: 2.0.3
-      picomatch: 4.0.3
-      std-env: 3.10.0
-      tinybench: 2.9.0
-      tinyexec: 1.0.2
-      tinyglobby: 0.2.15
-      tinyrainbow: 3.0.3
-      vite: 7.3.1(@types/node@25.9.3)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0)
-      why-is-node-running: 2.3.0
-    optionalDependencies:
-      '@opentelemetry/api': 1.9.0
-      '@types/node': 25.9.3
-    transitivePeerDependencies:
-      - jiti
-      - less
-      - lightningcss
-      - msw
-      - sass
-      - sass-embedded
-      - stylus
-      - sugarss
-      - terser
-      - tsx
-      - yaml
-    optional: true
 
   vscode-jsonrpc@8.2.0: {}
 

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -3,6 +3,7 @@
 	"compilerOptions": {
 		"allowJs": true,
 		"composite": true,
+		"types": ["node"],
 		"skipLibCheck": true,
 		"tsBuildInfoFile": "${configDir}/build/tsconfig.tsbuildinfo.json"
 	}


### PR DESCRIPTION
## Summary

- Switch the root `typecheck` task (`tsc -b --noEmit`) and the four tsc-based package builds (kernel, project-resolver, create-nadle, eslint-plugin) to **tsgo**, the native TypeScript compiler preview.
- Add `@typescript/native-preview` (nightly, currently `7.0.0-dev.20260611.2`) as a root devDependency.

## Migration notes (tsgo = TypeScript 7 semantics)

- `baseUrl` has been removed in TS7 — replaced the `baseUrl: "."` + bare `paths` pattern with relative `paths` mappings (`src/*` → `./src/*`, `setup` → `./test/__setup__/index.js`).
- tsgo does not auto-include `@types/*` packages — added `"types": ["node"]` to `tsconfig.base.json` and `@types/node` to the three projects that were missing it (root, vscode-extension, docs).
- `sample-app`'s `compileTs` demo task intentionally stays on tsc.

## Verification

- `tsgo -b --noEmit` and `tsc -b --noEmit` both pass (configs stay compatible with TS5).
- `nadle build typecheck` green; typecheck now ~1s.
- Smoke test: `vitest run basic` 36/36 pass against tsgo-built packages.

🤖 Generated with [Claude Code](https://claude.com/claude-code)