### PR TITLE
chore: minimal package scripts, tighter task caching, and shim-free bins

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -77,7 +77,7 @@ jobs:
         with:
           path: |
             node_modules/.cache/eslint
-            node_modules/.cache/prettier
+            node_modules/.cache/cspell
           key: lint-cache-${{ runner.os }}-${{ github.sha }}
           restore-keys: |
             lint-cache-${{ runner.os }}-

--- a/eslint.config.ts
+++ b/eslint.config.ts
@@ -26,15 +26,8 @@ const configs: ConfigArray = tsEslint.config(
 	{
 		languageOptions: {
 			parserOptions: {
-				tsconfigRootDir: import.meta.dirname,
-				projectService: {
-					allowDefaultProject: [
-						"packages/nadle/nadle.mjs",
-						"packages/create-nadle/create-nadle.mjs",
-						"packages/language-server/server.mjs",
-						"packages/project-resolver/cli.mjs"
-					]
-				}
+				projectService: true,
+				tsconfigRootDir: import.meta.dirname
 			}
 		}
 	},

--- a/nadle.config.ts
+++ b/nadle.config.ts
@@ -69,7 +69,7 @@ tasks.register("compile", PnpxTask, { command: "tsgo", args: ["-b", "./tsconfig.
 	outputs: [Outputs.dirs("packages/kernel/lib", "packages/project-resolver/lib", "packages/create-nadle/lib", "packages/eslint-plugin/lib")],
 	inputs: [
 		Inputs.dirs("packages/kernel/src", "packages/project-resolver/src", "packages/create-nadle/src", "packages/eslint-plugin/src"),
-		Inputs.files("tsconfig.compile.json", "tsconfig.src.json", "tsconfig.base.json", "packages/*/tsconfig.build.json")
+		Inputs.files("tsconfig.compile.json", "tsconfig.src.json", "tsconfig.base.json", "packages/*/tsconfig.build.json", "pnpm-lock.yaml")
 	]
 });
 
@@ -80,14 +80,8 @@ tasks.register("bundle", PnpxTask, { command: "tsup" }).config({
 	outputs: [Outputs.dirs("packages/nadle/lib", "packages/language-server/lib", "packages/vscode-extension/lib")],
 	inputs: [
 		Inputs.dirs("packages/nadle/src", "packages/language-server/src", "packages/vscode-extension/src"),
-		Inputs.files("tsup.config.ts", "tsconfig.src.json", "tsconfig.base.json")
+		Inputs.files("tsup.config.ts", "tsconfig.src.json", "tsconfig.base.json", "pnpm-lock.yaml")
 	]
-});
-
-tasks.register("dist").config({
-	group: "Building",
-	description: "Bundle all tsup-based packages",
-	dependsOn: ["bundle", "packages:vscode-extension:copy-server"]
 });
 
 tasks.register("build").config({

--- a/nadle.config.ts
+++ b/nadle.config.ts
@@ -10,10 +10,15 @@ tasks
 
 // --- Checking ---
 
-tasks.register("spell", PnpxTask, { command: "cspell", args: ["**", "--quiet", "--gitignore"] }).config({
-	group: "Checking",
-	description: "Check spelling across all files"
-});
+tasks
+	.register("spell", PnpxTask, {
+		command: "cspell",
+		args: ["**", "--quiet", "--gitignore", "--cache", "--cache-location", "node_modules/.cache/cspell/.cspellcache"]
+	})
+	.config({
+		group: "Checking",
+		description: "Check spelling across all files"
+	});
 
 tasks
 	.register("eslint", PnpxTask, {
@@ -29,7 +34,7 @@ tasks
 tasks
 	.register("prettier", PnpxTask, {
 		command: "prettier",
-		args: ["--experimental-cli", "--check", ".", "--cache", "--cache-location", "node_modules/.cache/prettier/.prettierCache"]
+		args: ["--experimental-cli", "--check", "."]
 	})
 	.config({ group: "Checking", description: "Check formatting with Prettier" });
 
@@ -95,7 +100,7 @@ tasks.register("build").config({
 
 tasks.register("testUnit", PnpxTask, { args: ["run"], command: "vitest" }).config({
 	group: "Testing",
-	dependsOn: ["compile", "bundle"],
+	dependsOn: ["bundle"],
 	description: "Run all vitest projects (filter via passthrough, e.g. nadle testUnit -- --project kernel)"
 });
 

--- a/packages/create-nadle/create-nadle.mjs
+++ b/packages/create-nadle/create-nadle.mjs
@@ -1,2 +1,0 @@
-#!/usr/bin/env node
-import "./lib/cli.js";

--- a/packages/create-nadle/package.json
+++ b/packages/create-nadle/package.json
@@ -8,10 +8,9 @@
 		"build": "nadle compile"
 	},
 	"files": [
-		"lib",
-		"create-nadle.mjs"
+		"lib"
 	],
-	"bin": "create-nadle.mjs",
+	"bin": "lib/cli.js",
 	"dependencies": {
 		"@clack/prompts": "^1.5.1",
 		"execa": "^9.6.1",

--- a/packages/create-nadle/src/cli.ts
+++ b/packages/create-nadle/src/cli.ts
@@ -1,3 +1,4 @@
+#!/usr/bin/env node
 /* eslint-disable no-console */
 import Path from "node:path";
 import Fs from "node:fs/promises";

--- a/packages/docs/package.json
+++ b/packages/docs/package.json
@@ -2,9 +2,7 @@
 	"name": "@nadle/internal-docs",
 	"private": true,
 	"scripts": {
-		"clean": "docusaurus clear",
 		"dev": "docusaurus start",
-		"build": "nadle build",
 		"serve": "docusaurus serve"
 	},
 	"dependencies": {

--- a/packages/language-server/package.json
+++ b/packages/language-server/package.json
@@ -6,7 +6,6 @@
 	"type": "module",
 	"files": [
 		"lib",
-		"server.mjs",
 		"LICENSE"
 	],
 	"exports": {
@@ -16,7 +15,7 @@
 		}
 	},
 	"bin": {
-		"nadle-language-server": "server.mjs"
+		"nadle-language-server": "lib/server.js"
 	},
 	"types": "lib/index.d.ts",
 	"dependencies": {

--- a/packages/language-server/server.mjs
+++ b/packages/language-server/server.mjs
@@ -1,3 +1,0 @@
-#!/usr/bin/env node
-process.argv.push("--stdio");
-await import("./lib/server.js");

--- a/packages/language-server/src/server.ts
+++ b/packages/language-server/src/server.ts
@@ -18,6 +18,12 @@ import { type ProjectContext, discoverProjectContext } from "./project-context.j
 const DEBOUNCE_MS = 200;
 const CONFIG_PATTERN = /^nadle\.config\.[cm]?[jt]s$/;
 
+// Default to stdio transport when launched directly (e.g. via the package bin)
+// without an explicit transport flag from the client.
+if (!process.argv.some((arg) => arg === "--stdio" || arg === "--node-ipc" || arg.startsWith("--socket") || arg.startsWith("--pipe"))) {
+	process.argv.push("--stdio");
+}
+
 const connection = createConnection(ProposedFeatures.all);
 const documents = new TextDocuments(TextDocument);
 const store = new DocumentStore();

--- a/packages/nadle/nadle.config.ts
+++ b/packages/nadle/nadle.config.ts
@@ -1,7 +1,7 @@
 import Path from "node:path";
 import Fs from "node:fs/promises";
 
-import { tasks, PnpxTask } from "../../node_modules/nadle/lib/index.js";
+import { tasks, Inputs, Outputs, PnpxTask } from "../../node_modules/nadle/lib/index.js";
 
 tasks.register("build").config({
 	group: "Building",
@@ -12,7 +12,9 @@ tasks.register("build").config({
 tasks.register("generateMarkdown", PnpxTask, { command: "typedoc" }).config({
 	group: "Building",
 	dependsOn: ["build"],
-	description: "Generate API markdown with typedoc"
+	outputs: [Outputs.dirs("../docs/docs/api")],
+	description: "Generate API markdown with typedoc",
+	inputs: [Inputs.dirs("lib"), Inputs.files("typedoc.json")]
 });
 
 // --- Testing (nadle-specific, kept here due to workspace self-reference limitation) ---
@@ -20,7 +22,9 @@ tasks.register("generateMarkdown", PnpxTask, { command: "typedoc" }).config({
 tasks.register("testAPI", PnpxTask, { args: ["run"], command: "api-extractor" }).config({
 	group: "Testing",
 	dependsOn: ["build"],
-	description: "Verify API surface with api-extractor"
+	outputs: [Outputs.dirs("build/api")],
+	description: "Verify API surface with api-extractor",
+	inputs: [Inputs.files("lib/index.d.ts", "api-extractor.json", "../../api-extractor.json", "index.api.md")]
 });
 
 tasks

--- a/packages/nadle/nadle.mjs
+++ b/packages/nadle/nadle.mjs
@@ -1,2 +1,0 @@
-#!/usr/bin/env node
-import "./lib/cli.js";

--- a/packages/nadle/package.json
+++ b/packages/nadle/package.json
@@ -5,10 +5,7 @@
 	"license": "MIT",
 	"type": "module",
 	"scripts": {
-		"build": "nadle build",
-		"test": "nadle test",
-		"update": "vitest -u --project nadle --config ../../vitest.config.ts",
-		"bench": "vitest bench --project nadle --config ../../vitest.config.ts"
+		"build": "nadle build"
 	},
 	"files": [
 		"lib",

--- a/packages/nadle/package.json
+++ b/packages/nadle/package.json
@@ -8,8 +8,7 @@
 		"build": "nadle build"
 	},
 	"files": [
-		"lib",
-		"nadle.mjs"
+		"lib"
 	],
 	"exports": {
 		".": {
@@ -17,7 +16,7 @@
 			"import": "./lib/index.js"
 		}
 	},
-	"bin": "nadle.mjs",
+	"bin": "lib/cli.js",
 	"types": "lib/index.d.ts",
 	"dependencies": {
 		"@nadle/kernel": "workspace:*",

--- a/packages/nadle/test/__snapshots__/builtin-tasks/copy-task.test.ts.snap
+++ b/packages/nadle/test/__snapshots__/builtin-tasks/copy-task.test.ts.snap
@@ -3,7 +3,7 @@
 exports[`copyTask > given a file path > copies it into the destination directory 1`] = `
 ---------- Context -----------
 Working Directory: /ROOT/test/__fixtures__/copy-task/__temp__/__{hash}__
-Command: /ROOT/nadle.mjs --max-workers 1 --no-footer copyFoo
+Command: /ROOT/lib/cli.js --max-workers 1 --no-footer copyFoo
 ---------- Stdout ------------
 [log] <Bold><Cyan>▶ Welcome to Nadle {version}!</Cyan></BoldDim>
 [log] Using Nadle from /ROOT/lib/index.js
@@ -22,7 +22,7 @@ Command: /ROOT/nadle.mjs --max-workers 1 --no-footer copyFoo
 exports[`copyTask > given a folder path > can copy it 1`] = `
 ---------- Context -----------
 Working Directory: /ROOT/test/__fixtures__/copy-task/__temp__/__{hash}__
-Command: /ROOT/nadle.mjs --max-workers 1 --no-footer copyAssets
+Command: /ROOT/lib/cli.js --max-workers 1 --no-footer copyAssets
 ---------- Stdout ------------
 [log] <Bold><Cyan>▶ Welcome to Nadle {version}!</Cyan></BoldDim>
 [log] Using Nadle from /ROOT/lib/index.js
@@ -42,7 +42,7 @@ Command: /ROOT/nadle.mjs --max-workers 1 --no-footer copyAssets
 exports[`copyTask > given a nested destination > creates directories automatically 1`] = `
 ---------- Context -----------
 Working Directory: /ROOT/test/__fixtures__/copy-task/__temp__/__{hash}__
-Command: /ROOT/nadle.mjs --max-workers 1 --no-footer copyToNested
+Command: /ROOT/lib/cli.js --max-workers 1 --no-footer copyToNested
 ---------- Stdout ------------
 [log] <Bold><Cyan>▶ Welcome to Nadle {version}!</Cyan></BoldDim>
 [log] Using Nadle from /ROOT/lib/index.js
@@ -61,7 +61,7 @@ Command: /ROOT/nadle.mjs --max-workers 1 --no-footer copyToNested
 exports[`copyTask > with include and exclude options > copies only matching files 1`] = `
 ---------- Context -----------
 Working Directory: /ROOT/test/__fixtures__/copy-task/__temp__/__{hash}__
-Command: /ROOT/nadle.mjs --max-workers 1 --no-footer copyWithFilter
+Command: /ROOT/lib/cli.js --max-workers 1 --no-footer copyWithFilter
 ---------- Stdout ------------
 [log] <Bold><Cyan>▶ Welcome to Nadle {version}!</Cyan></BoldDim>
 [log] Using Nadle from /ROOT/lib/index.js

--- a/packages/nadle/test/__snapshots__/builtin-tasks/delete-task.test.ts.snap
+++ b/packages/nadle/test/__snapshots__/builtin-tasks/delete-task.test.ts.snap
@@ -3,7 +3,7 @@
 exports[`deleteTask > given a file path > can delete it 1`] = `
 ---------- Context -----------
 Working Directory: /ROOT/test/__fixtures__/delete-task/__temp__/__{hash}__
-Command: /ROOT/nadle.mjs --max-workers 1 --no-footer deleteFileBaz
+Command: /ROOT/lib/cli.js --max-workers 1 --no-footer deleteFileBaz
 ---------- Stdout ------------
 [log] <Bold><Cyan>▶ Welcome to Nadle {version}!</Cyan></BoldDim>
 [log] Using Nadle from /ROOT/lib/index.js
@@ -21,7 +21,7 @@ Command: /ROOT/nadle.mjs --max-workers 1 --no-footer deleteFileBaz
 exports[`deleteTask > given a folder name > can delete it 1`] = `
 ---------- Context -----------
 Working Directory: /ROOT/test/__fixtures__/delete-task/__temp__/__{hash}__
-Command: /ROOT/nadle.mjs --max-workers 1 --no-footer deleteFolderA
+Command: /ROOT/lib/cli.js --max-workers 1 --no-footer deleteFolderA
 ---------- Stdout ------------
 [log] <Bold><Cyan>▶ Welcome to Nadle {version}!</Cyan></BoldDim>
 [log] Using Nadle from /ROOT/lib/index.js
@@ -39,7 +39,7 @@ Command: /ROOT/nadle.mjs --max-workers 1 --no-footer deleteFolderA
 exports[`deleteTask > given a folder path > can delete it 1`] = `
 ---------- Context -----------
 Working Directory: /ROOT/test/__fixtures__/delete-task/__temp__/__{hash}__
-Command: /ROOT/nadle.mjs --max-workers 1 --no-footer deleteFolderB1
+Command: /ROOT/lib/cli.js --max-workers 1 --no-footer deleteFolderB1
 ---------- Stdout ------------
 [log] <Bold><Cyan>▶ Welcome to Nadle {version}!</Cyan></BoldDim>
 [log] Using Nadle from /ROOT/lib/index.js
@@ -57,7 +57,7 @@ Command: /ROOT/nadle.mjs --max-workers 1 --no-footer deleteFolderB1
 exports[`deleteTask > given a glob > can delete all files match the glob 1`] = `
 ---------- Context -----------
 Working Directory: /ROOT/test/__fixtures__/delete-task/__temp__/__{hash}__
-Command: /ROOT/nadle.mjs --max-workers 1 --no-footer deleteJsonFiles
+Command: /ROOT/lib/cli.js --max-workers 1 --no-footer deleteJsonFiles
 ---------- Stdout ------------
 [log] <Bold><Cyan>▶ Welcome to Nadle {version}!</Cyan></BoldDim>
 [log] Using Nadle from /ROOT/lib/index.js
@@ -75,7 +75,7 @@ Command: /ROOT/nadle.mjs --max-workers 1 --no-footer deleteJsonFiles
 exports[`deleteTask > given a glob with enable info log > can print will-delete files 1`] = `
 ---------- Context -----------
 Working Directory: /ROOT/test/__fixtures__/delete-task/__temp__/__{hash}__
-Command: /ROOT/nadle.mjs --max-workers 1 --no-footer deleteJsonFiles --log-level info
+Command: /ROOT/lib/cli.js --max-workers 1 --no-footer deleteJsonFiles --log-level info
 ---------- Stdout ------------
 [log] <Bold><Cyan>▶ Welcome to Nadle {version}!</Cyan></BoldDim>
 [log] Using Nadle from /ROOT/lib/index.js
@@ -154,7 +154,7 @@ Command: /ROOT/nadle.mjs --max-workers 1 --no-footer deleteJsonFiles --log-level
 exports[`deleteTask > given multiple file paths > can delete them 1`] = `
 ---------- Context -----------
 Working Directory: /ROOT/test/__fixtures__/delete-task/__temp__/__{hash}__
-Command: /ROOT/nadle.mjs --max-workers 1 --no-footer deleteFilesFooBar
+Command: /ROOT/lib/cli.js --max-workers 1 --no-footer deleteFilesFooBar
 ---------- Stdout ------------
 [log] <Bold><Cyan>▶ Welcome to Nadle {version}!</Cyan></BoldDim>
 [log] Using Nadle from /ROOT/lib/index.js

--- a/packages/nadle/test/__snapshots__/builtin-tasks/node-task.test.ts.snap
+++ b/packages/nadle/test/__snapshots__/builtin-tasks/node-task.test.ts.snap
@@ -3,7 +3,7 @@
 exports[`node Task > can print command when log level = info 1`] = `
 ---------- Context -----------
 Working Directory: /ROOT/test/__fixtures__/node-task
-Command: /ROOT/nadle.mjs --max-workers 1 --no-footer pass --log-level info
+Command: /ROOT/lib/cli.js --max-workers 1 --no-footer pass --log-level info
 ---------- Stdout ------------
 [log] <Bold><Cyan>▶ Welcome to Nadle {version}!</Cyan></BoldDim>
 [log] Using Nadle from /ROOT/lib/index.js
@@ -84,7 +84,7 @@ Command: /ROOT/nadle.mjs --max-workers 1 --no-footer pass --log-level info
 exports[`node Task > can run node script with no error 1`] = `
 ---------- Context -----------
 Working Directory: /ROOT/test/__fixtures__/node-task
-Command: /ROOT/nadle.mjs --max-workers 1 --no-footer pass
+Command: /ROOT/lib/cli.js --max-workers 1 --no-footer pass
 ---------- Stdout ------------
 [log] <Bold><Cyan>▶ Welcome to Nadle {version}!</Cyan></BoldDim>
 [log] Using Nadle from /ROOT/lib/index.js
@@ -104,7 +104,7 @@ Command: /ROOT/nadle.mjs --max-workers 1 --no-footer pass
 exports[`node Task > throw error when running node script that exits with error 1`] = `
 ---------- Context -----------
 Working Directory: /ROOT/test/__fixtures__/node-task
-Command: /ROOT/nadle.mjs --max-workers 1 --no-footer fail
+Command: /ROOT/lib/cli.js --max-workers 1 --no-footer fail
 ---------- Stdout ------------
 [log] <Bold><Cyan>▶ Welcome to Nadle {version}!</Cyan></BoldDim>
 [log] Using Nadle from /ROOT/lib/index.js

--- a/packages/nadle/test/__snapshots__/builtin-tasks/npm-task.test.ts.snap
+++ b/packages/nadle/test/__snapshots__/builtin-tasks/npm-task.test.ts.snap
@@ -3,7 +3,7 @@
 exports[`npm Task > can print command when log level = info 1`] = `
 ---------- Context -----------
 Working Directory: /ROOT/test/__fixtures__/npm-task
-Command: /ROOT/nadle.mjs --max-workers 1 --no-footer pass --log-level info
+Command: /ROOT/lib/cli.js --max-workers 1 --no-footer pass --log-level info
 ---------- Stdout ------------
 [log] <Bold><Cyan>▶ Welcome to Nadle {version}!</Cyan></BoldDim>
 [log] Using Nadle from /ROOT/lib/index.js
@@ -82,7 +82,7 @@ Command: /ROOT/nadle.mjs --max-workers 1 --no-footer pass --log-level info
 exports[`npm Task > can run tsc command with no error ts file 1`] = `
 ---------- Context -----------
 Working Directory: /ROOT/test/__fixtures__/npm-task
-Command: /ROOT/nadle.mjs --max-workers 1 --no-footer pass
+Command: /ROOT/lib/cli.js --max-workers 1 --no-footer pass
 ---------- Stdout ------------
 [log] <Bold><Cyan>▶ Welcome to Nadle {version}!</Cyan></BoldDim>
 [log] Using Nadle from /ROOT/lib/index.js
@@ -100,7 +100,7 @@ Command: /ROOT/nadle.mjs --max-workers 1 --no-footer pass
 exports[`npm Task > throw error when running tsc command with error ts file 1`] = `
 ---------- Context -----------
 Working Directory: /ROOT/test/__fixtures__/npm-task
-Command: /ROOT/nadle.mjs --max-workers 1 --no-footer fail
+Command: /ROOT/lib/cli.js --max-workers 1 --no-footer fail
 ---------- Stdout ------------
 [log] <Bold><Cyan>▶ Welcome to Nadle {version}!</Cyan></BoldDim>
 [log] Using Nadle from /ROOT/lib/index.js

--- a/packages/nadle/test/__snapshots__/builtin-tasks/npx-task.test.ts.snap
+++ b/packages/nadle/test/__snapshots__/builtin-tasks/npx-task.test.ts.snap
@@ -3,7 +3,7 @@
 exports[`npx Task > can print command when log level = info 1`] = `
 ---------- Context -----------
 Working Directory: /ROOT/test/__fixtures__/npx-task
-Command: /ROOT/nadle.mjs --max-workers 1 --no-footer pass --log-level info
+Command: /ROOT/lib/cli.js --max-workers 1 --no-footer pass --log-level info
 ---------- Stdout ------------
 [log] <Bold><Cyan>▶ Welcome to Nadle {version}!</Cyan></BoldDim>
 [log] Using Nadle from /ROOT/lib/index.js
@@ -82,7 +82,7 @@ Command: /ROOT/nadle.mjs --max-workers 1 --no-footer pass --log-level info
 exports[`npx Task > can run tsc command with no error ts file 1`] = `
 ---------- Context -----------
 Working Directory: /ROOT/test/__fixtures__/npx-task
-Command: /ROOT/nadle.mjs --max-workers 1 --no-footer pass
+Command: /ROOT/lib/cli.js --max-workers 1 --no-footer pass
 ---------- Stdout ------------
 [log] <Bold><Cyan>▶ Welcome to Nadle {version}!</Cyan></BoldDim>
 [log] Using Nadle from /ROOT/lib/index.js
@@ -100,7 +100,7 @@ Command: /ROOT/nadle.mjs --max-workers 1 --no-footer pass
 exports[`npx Task > throw error when running tsc command with error ts file 1`] = `
 ---------- Context -----------
 Working Directory: /ROOT/test/__fixtures__/npx-task
-Command: /ROOT/nadle.mjs --max-workers 1 --no-footer fail
+Command: /ROOT/lib/cli.js --max-workers 1 --no-footer fail
 ---------- Stdout ------------
 [log] <Bold><Cyan>▶ Welcome to Nadle {version}!</Cyan></BoldDim>
 [log] Using Nadle from /ROOT/lib/index.js

--- a/packages/nadle/test/__snapshots__/builtin-tasks/pnpm-task.test.ts.snap
+++ b/packages/nadle/test/__snapshots__/builtin-tasks/pnpm-task.test.ts.snap
@@ -3,7 +3,7 @@
 exports[`pnpm Task > can print command when log level = info 1`] = `
 ---------- Context -----------
 Working Directory: /ROOT/test/__fixtures__/pnpm-task
-Command: /ROOT/nadle.mjs --max-workers 1 --no-footer pass --log-level info
+Command: /ROOT/lib/cli.js --max-workers 1 --no-footer pass --log-level info
 ---------- Stdout ------------
 [log] <Bold><Cyan>▶ Welcome to Nadle {version}!</Cyan></BoldDim>
 [log] Using Nadle from /ROOT/lib/index.js
@@ -82,7 +82,7 @@ Command: /ROOT/nadle.mjs --max-workers 1 --no-footer pass --log-level info
 exports[`pnpm Task > can run tsc command with no error ts file 1`] = `
 ---------- Context -----------
 Working Directory: /ROOT/test/__fixtures__/pnpm-task
-Command: /ROOT/nadle.mjs --max-workers 1 --no-footer pass
+Command: /ROOT/lib/cli.js --max-workers 1 --no-footer pass
 ---------- Stdout ------------
 [log] <Bold><Cyan>▶ Welcome to Nadle {version}!</Cyan></BoldDim>
 [log] Using Nadle from /ROOT/lib/index.js
@@ -100,7 +100,7 @@ Command: /ROOT/nadle.mjs --max-workers 1 --no-footer pass
 exports[`pnpm Task > throw error when running tsc command with error ts file 1`] = `
 ---------- Context -----------
 Working Directory: /ROOT/test/__fixtures__/pnpm-task
-Command: /ROOT/nadle.mjs --max-workers 1 --no-footer fail
+Command: /ROOT/lib/cli.js --max-workers 1 --no-footer fail
 ---------- Stdout ------------
 [log] <Bold><Cyan>▶ Welcome to Nadle {version}!</Cyan></BoldDim>
 [log] Using Nadle from /ROOT/lib/index.js

--- a/packages/nadle/test/__snapshots__/builtin-tasks/pnpx-task.test.ts.snap
+++ b/packages/nadle/test/__snapshots__/builtin-tasks/pnpx-task.test.ts.snap
@@ -3,7 +3,7 @@
 exports[`pnpx Task > can print command when log level = info 1`] = `
 ---------- Context -----------
 Working Directory: /ROOT/test/__fixtures__/pnpx-task
-Command: /ROOT/nadle.mjs --max-workers 1 --no-footer pass --log-level info
+Command: /ROOT/lib/cli.js --max-workers 1 --no-footer pass --log-level info
 ---------- Stdout ------------
 [log] <Bold><Cyan>▶ Welcome to Nadle {version}!</Cyan></BoldDim>
 [log] Using Nadle from /ROOT/lib/index.js
@@ -82,7 +82,7 @@ Command: /ROOT/nadle.mjs --max-workers 1 --no-footer pass --log-level info
 exports[`pnpx Task > can run tsc command with no error ts file 1`] = `
 ---------- Context -----------
 Working Directory: /ROOT/test/__fixtures__/pnpx-task
-Command: /ROOT/nadle.mjs --max-workers 1 --no-footer pass
+Command: /ROOT/lib/cli.js --max-workers 1 --no-footer pass
 ---------- Stdout ------------
 [log] <Bold><Cyan>▶ Welcome to Nadle {version}!</Cyan></BoldDim>
 [log] Using Nadle from /ROOT/lib/index.js
@@ -100,7 +100,7 @@ Command: /ROOT/nadle.mjs --max-workers 1 --no-footer pass
 exports[`pnpx Task > throw error when running tsc command with error ts file 1`] = `
 ---------- Context -----------
 Working Directory: /ROOT/test/__fixtures__/pnpx-task
-Command: /ROOT/nadle.mjs --max-workers 1 --no-footer fail
+Command: /ROOT/lib/cli.js --max-workers 1 --no-footer fail
 ---------- Stdout ------------
 [log] <Bold><Cyan>▶ Welcome to Nadle {version}!</Cyan></BoldDim>
 [log] Using Nadle from /ROOT/lib/index.js

--- a/packages/nadle/test/__snapshots__/errors.test.ts.snap
+++ b/packages/nadle/test/__snapshots__/errors.test.ts.snap
@@ -3,7 +3,7 @@
 exports[`when a task fails > should report correctly 1`] = `
 ---------- Context -----------
 Working Directory: /ROOT/test/__fixtures__/main
-Command: /ROOT/nadle.mjs --max-workers 1 --no-footer throwable
+Command: /ROOT/lib/cli.js --max-workers 1 --no-footer throwable
 ---------- Stdout ------------
 [log] <Bold><Cyan>▶ Welcome to Nadle {version}!</Cyan></BoldDim>
 [log] Using Nadle from /ROOT/lib/index.js

--- a/packages/nadle/test/__snapshots__/features/abbreviation.test.ts.snap
+++ b/packages/nadle/test/__snapshots__/features/abbreviation.test.ts.snap
@@ -3,7 +3,7 @@
 exports[`abbreviation > should log resolved tasks only 1`] = `
 ---------- Context -----------
 Working Directory: /ROOT/test/__fixtures__/main
-Command: /ROOT/nadle.mjs --max-workers 1 --no-footer hell goodbye cop
+Command: /ROOT/lib/cli.js --max-workers 1 --no-footer hell goodbye cop
 ---------- Stdout ------------
 [log] <Bold><Cyan>▶ Welcome to Nadle {version}!</Cyan></BoldDim>
 [log] Using Nadle from /ROOT/lib/index.js
@@ -34,7 +34,7 @@ Command: /ROOT/nadle.mjs --max-workers 1 --no-footer hell goodbye cop
 exports[`abbreviation > should resolve abbr task properly 1`] = `
 ---------- Context -----------
 Working Directory: /ROOT/test/__fixtures__/main
-Command: /ROOT/nadle.mjs --max-workers 1 --no-footer hell
+Command: /ROOT/lib/cli.js --max-workers 1 --no-footer hell
 ---------- Stdout ------------
 [log] <Bold><Cyan>▶ Welcome to Nadle {version}!</Cyan></BoldDim>
 [log] Using Nadle from /ROOT/lib/index.js

--- a/packages/nadle/test/__snapshots__/features/graceful-cancellation.test.ts.snap
+++ b/packages/nadle/test/__snapshots__/features/graceful-cancellation.test.ts.snap
@@ -3,7 +3,7 @@
 exports[`graceful cancellation > should report other running tasks as canceled instead of failed 1`] = `
 ---------- Context -----------
 Working Directory: /ROOT/test/__temp__/__{hash}__
-Command: /ROOT/nadle.mjs --no-footer main-task --max-workers 2
+Command: /ROOT/lib/cli.js --no-footer main-task --max-workers 2
 ---------- Stdout ------------
 [log] <Bold><Cyan>▶ Welcome to Nadle {version}!</Cyan></BoldDim>
 [log] Using Nadle from /ROOT/lib/index.js

--- a/packages/nadle/test/__snapshots__/features/workspaces/workspaces-alias.test.ts.snap
+++ b/packages/nadle/test/__snapshots__/features/workspaces/workspaces-alias.test.ts.snap
@@ -3,7 +3,7 @@
 exports[`workspaces alias > function style 1`] = `
 ---------- Context -----------
 Working Directory: /ROOT/test/__fixtures__/monorepo/__temp__/__{hash}__
-Command: /ROOT/nadle.mjs --max-workers 1 --no-footer build
+Command: /ROOT/lib/cli.js --max-workers 1 --no-footer build
 ---------- Stdout ------------
 [log] <Bold><Cyan>▶ Welcome to Nadle {version}!</Cyan></BoldDim>
 [log] Using Nadle from /ROOT/lib/index.js
@@ -20,7 +20,7 @@ Command: /ROOT/nadle.mjs --max-workers 1 --no-footer build
 exports[`workspaces alias > object style 1`] = `
 ---------- Context -----------
 Working Directory: /ROOT/test/__fixtures__/monorepo/__temp__/__{hash}__
-Command: /ROOT/nadle.mjs --max-workers 1 --no-footer build
+Command: /ROOT/lib/cli.js --max-workers 1 --no-footer build
 ---------- Stdout ------------
 [log] <Bold><Cyan>▶ Welcome to Nadle {version}!</Cyan></BoldDim>
 [log] Using Nadle from /ROOT/lib/index.js
@@ -37,7 +37,7 @@ Command: /ROOT/nadle.mjs --max-workers 1 --no-footer build
 exports[`workspaces alias > root alias 1`] = `
 ---------- Context -----------
 Working Directory: /ROOT/test/__fixtures__/monorepo/__temp__/__{hash}__
-Command: /ROOT/nadle.mjs --max-workers 1 --no-footer build
+Command: /ROOT/lib/cli.js --max-workers 1 --no-footer build
 ---------- Stdout ------------
 [log] <Bold><Cyan>▶ Welcome to Nadle {version}!</Cyan></BoldDim>
 [log] Using Nadle from /ROOT/lib/index.js

--- a/packages/nadle/test/__snapshots__/features/workspaces/workspaces-basic-tasks.test.ts.snap
+++ b/packages/nadle/test/__snapshots__/features/workspaces/workspaces-basic-tasks.test.ts.snap
@@ -3,7 +3,7 @@
 exports[`workspaces basic tasks > should register all tasks from all config files 1`] = `
 ---------- Context -----------
 Working Directory: /ROOT/test/__fixtures__/monorepo/__temp__/__{hash}__
-Command: /ROOT/nadle.mjs --max-workers 1 --no-footer --list
+Command: /ROOT/lib/cli.js --max-workers 1 --no-footer --list
 ---------- Stdout ------------
 [log] <Bold><Cyan>▶ Welcome to Nadle {version}!</Cyan></BoldDim>
 [log] Using Nadle from /ROOT/lib/index.js
@@ -24,7 +24,7 @@ Command: /ROOT/nadle.mjs --max-workers 1 --no-footer --list
 exports[`workspaces basic tasks > when running a task from a workspace > with specifying workspace explicitly > when the task is defined in the workspace > should run the that task 1`] = `
 ---------- Context -----------
 Working Directory: /ROOT/test/__fixtures__/monorepo/__temp__/__{hash}__/packages/one
-Command: /ROOT/nadle.mjs --max-workers 1 --no-footer packages:two:build
+Command: /ROOT/lib/cli.js --max-workers 1 --no-footer packages:two:build
 ---------- Stdout ------------
 [log] <Bold><Cyan>▶ Welcome to Nadle {version}!</Cyan></BoldDim>
 [log] Using Nadle from /ROOT/lib/index.js
@@ -39,7 +39,7 @@ Command: /ROOT/nadle.mjs --max-workers 1 --no-footer packages:two:build
 exports[`workspaces basic tasks > when running a task from a workspace > with specifying workspace explicitly > when the task is defined in the workspace > should run the that task 2`] = `
 ---------- Context -----------
 Working Directory: /ROOT/test/__fixtures__/monorepo/__temp__/__{hash}__/packages/one
-Command: /ROOT/nadle.mjs --max-workers 1 --no-footer root:build
+Command: /ROOT/lib/cli.js --max-workers 1 --no-footer root:build
 ---------- Stdout ------------
 [log] <Bold><Cyan>▶ Welcome to Nadle {version}!</Cyan></BoldDim>
 [log] Using Nadle from /ROOT/lib/index.js
@@ -57,7 +57,7 @@ Command: /ROOT/nadle.mjs --max-workers 1 --no-footer root:build
 exports[`workspaces basic tasks > when running a task from a workspace > without specifying the workspace > when the task is defined in the workspace > should run that task 1`] = `
 ---------- Context -----------
 Working Directory: /ROOT/test/__fixtures__/monorepo/__temp__/__{hash}__/packages/one
-Command: /ROOT/nadle.mjs --max-workers 1 --no-footer build
+Command: /ROOT/lib/cli.js --max-workers 1 --no-footer build
 ---------- Stdout ------------
 [log] <Bold><Cyan>▶ Welcome to Nadle {version}!</Cyan></BoldDim>
 [log] Using Nadle from /ROOT/lib/index.js
@@ -72,7 +72,7 @@ Command: /ROOT/nadle.mjs --max-workers 1 --no-footer build
 exports[`workspaces basic tasks > when running a task from a workspace > without specifying the workspace > when the task is not defined in the workspace > should run the root task if defined 1`] = `
 ---------- Context -----------
 Working Directory: /ROOT/test/__fixtures__/monorepo/__temp__/__{hash}__/packages/one
-Command: /ROOT/nadle.mjs --max-workers 1 --no-footer test
+Command: /ROOT/lib/cli.js --max-workers 1 --no-footer test
 ---------- Stdout ------------
 [log] <Bold><Cyan>▶ Welcome to Nadle {version}!</Cyan></BoldDim>
 [log] Using Nadle from /ROOT/lib/index.js
@@ -90,7 +90,7 @@ Command: /ROOT/nadle.mjs --max-workers 1 --no-footer test
 exports[`workspaces basic tasks > when specifying a workspace task then the root task with the same name > should run the workspace task first, then the root and and finally other workspace tasks with the same name 1`] = `
 ---------- Context -----------
 Working Directory: /ROOT/test/__fixtures__/monorepo/__temp__/__{hash}__
-Command: /ROOT/nadle.mjs --max-workers 1 --no-footer packages:two:build build
+Command: /ROOT/lib/cli.js --max-workers 1 --no-footer packages:two:build build
 ---------- Stdout ------------
 [log] <Bold><Cyan>▶ Welcome to Nadle {version}!</Cyan></BoldDim>
 [log] Using Nadle from /ROOT/lib/index.js
@@ -108,7 +108,7 @@ Command: /ROOT/nadle.mjs --max-workers 1 --no-footer packages:two:build build
 exports[`workspaces basic tasks > when specifying root task > should run that task first then all sub-workspace task with the same name 1`] = `
 ---------- Context -----------
 Working Directory: /ROOT/test/__fixtures__/monorepo/__temp__/__{hash}__
-Command: /ROOT/nadle.mjs --max-workers 1 --no-footer build
+Command: /ROOT/lib/cli.js --max-workers 1 --no-footer build
 ---------- Stdout ------------
 [log] <Bold><Cyan>▶ Welcome to Nadle {version}!</Cyan></BoldDim>
 [log] Using Nadle from /ROOT/lib/index.js
@@ -126,7 +126,7 @@ Command: /ROOT/nadle.mjs --max-workers 1 --no-footer build
 exports[`workspaces basic tasks > when specifying sub-workspace tasks > should run those tasks only 1`] = `
 ---------- Context -----------
 Working Directory: /ROOT/test/__fixtures__/monorepo/__temp__/__{hash}__
-Command: /ROOT/nadle.mjs --max-workers 1 --no-footer packages:two:build packages:one:build
+Command: /ROOT/lib/cli.js --max-workers 1 --no-footer packages:two:build packages:one:build
 ---------- Stdout ------------
 [log] <Bold><Cyan>▶ Welcome to Nadle {version}!</Cyan></BoldDim>
 [log] Using Nadle from /ROOT/lib/index.js

--- a/packages/nadle/test/__snapshots__/features/workspaces/workspaces-dependencies.test.ts.snap
+++ b/packages/nadle/test/__snapshots__/features/workspaces/workspaces-dependencies.test.ts.snap
@@ -3,7 +3,7 @@
 exports[`workspaces > dependencies > given a pnpm workspaces project > should resolve dependencies correctly 1`] = `
 ---------- Context -----------
 Working Directory: /ROOT/test/__fixtures__/monorepo/__temp__/__{hash}__
-Command: /ROOT/nadle.mjs --max-workers 1 --no-footer --show-config --config-key project.workspaces
+Command: /ROOT/lib/cli.js --max-workers 1 --no-footer --show-config --config-key project.workspaces
 ---------- Stdout ------------
 [log] [
   {
@@ -62,7 +62,7 @@ Command: /ROOT/nadle.mjs --max-workers 1 --no-footer --show-config --config-key 
 exports[`workspaces > dependencies > given a yarn workspaces project > should resolve dependencies correctly 1`] = `
 ---------- Context -----------
 Working Directory: /ROOT/test/__fixtures__/monorepo/__temp__/__{hash}__
-Command: /ROOT/nadle.mjs --max-workers 1 --no-footer --show-config --config-key project.workspaces
+Command: /ROOT/lib/cli.js --max-workers 1 --no-footer --show-config --config-key project.workspaces
 ---------- Stdout ------------
 [log] [
   {
@@ -121,7 +121,7 @@ Command: /ROOT/nadle.mjs --max-workers 1 --no-footer --show-config --config-key 
 exports[`workspaces > dependencies > given an npm workspaces project > should resolve dependencies correctly 1`] = `
 ---------- Context -----------
 Working Directory: /ROOT/test/__fixtures__/monorepo/__temp__/__{hash}__
-Command: /ROOT/nadle.mjs --max-workers 1 --no-footer --show-config --config-key project.workspaces
+Command: /ROOT/lib/cli.js --max-workers 1 --no-footer --show-config --config-key project.workspaces
 ---------- Stdout ------------
 [log] [
   {

--- a/packages/nadle/test/__snapshots__/features/workspaces/workspaces-detection.test.ts.snap
+++ b/packages/nadle/test/__snapshots__/features/workspaces/workspaces-detection.test.ts.snap
@@ -3,7 +3,7 @@
 exports[`workspaces detection > multiple packages 1`] = `
 ---------- Context -----------
 Working Directory: /ROOT/test/__fixtures__/monorepo/__temp__/__{hash}__
-Command: /ROOT/nadle.mjs --max-workers 1 --no-footer --show-config --config-key project
+Command: /ROOT/lib/cli.js --max-workers 1 --no-footer --show-config --config-key project
 ---------- Stdout ------------
 [log] {
   "rootWorkspace": {
@@ -61,7 +61,7 @@ Command: /ROOT/nadle.mjs --max-workers 1 --no-footer --show-config --config-key 
 exports[`workspaces detection > multiple packages with config files 1`] = `
 ---------- Context -----------
 Working Directory: /ROOT/test/__fixtures__/monorepo/__temp__/__{hash}__
-Command: /ROOT/nadle.mjs --max-workers 1 --no-footer --show-config --config-key project
+Command: /ROOT/lib/cli.js --max-workers 1 --no-footer --show-config --config-key project
 ---------- Stdout ------------
 [log] {
   "rootWorkspace": {
@@ -119,7 +119,7 @@ Command: /ROOT/nadle.mjs --max-workers 1 --no-footer --show-config --config-key 
 exports[`workspaces detection > multiple packages with custom config file 1`] = `
 ---------- Context -----------
 Working Directory: /ROOT/test/__fixtures__/monorepo/__temp__/__{hash}__
-Command: /ROOT/nadle.mjs --max-workers 1 --no-footer --config config/nadle.config.js --show-config --config-key project
+Command: /ROOT/lib/cli.js --max-workers 1 --no-footer --config config/nadle.config.js --show-config --config-key project
 ---------- Stdout ------------
 [log] {
   "rootWorkspace": {
@@ -155,7 +155,7 @@ Command: /ROOT/nadle.mjs --max-workers 1 --no-footer --config config/nadle.confi
 exports[`workspaces detection > multiple packages with ignore packages 1`] = `
 ---------- Context -----------
 Working Directory: /ROOT/test/__fixtures__/monorepo/__temp__/__{hash}__
-Command: /ROOT/nadle.mjs --max-workers 1 --no-footer --show-config --config-key project
+Command: /ROOT/lib/cli.js --max-workers 1 --no-footer --show-config --config-key project
 ---------- Stdout ------------
 [log] {
   "rootWorkspace": {
@@ -202,7 +202,7 @@ Command: /ROOT/nadle.mjs --max-workers 1 --no-footer --show-config --config-key 
 exports[`workspaces detection > one package 1`] = `
 ---------- Context -----------
 Working Directory: /ROOT/test/__fixtures__/monorepo/__temp__/__{hash}__
-Command: /ROOT/nadle.mjs --max-workers 1 --no-footer --show-config --config-key project
+Command: /ROOT/lib/cli.js --max-workers 1 --no-footer --show-config --config-key project
 ---------- Stdout ------------
 [log] {
   "rootWorkspace": {

--- a/packages/nadle/test/__snapshots__/features/workspaces/workspaces-excluded-tasks.test.ts.snap
+++ b/packages/nadle/test/__snapshots__/features/workspaces/workspaces-excluded-tasks.test.ts.snap
@@ -3,7 +3,7 @@
 exports[`workspaces > excluded tasks > should not run excluded tasks 1`] = `
 ---------- Context -----------
 Working Directory: /ROOT/test/__fixtures__/monorepo/__temp__/__{hash}__/packages/one
-Command: /ROOT/nadle.mjs --max-workers 1 --no-footer check --exclude build
+Command: /ROOT/lib/cli.js --max-workers 1 --no-footer check --exclude build
 ---------- Stdout ------------
 [log] <Bold><Cyan>▶ Welcome to Nadle {version}!</Cyan></BoldDim>
 [log] Using Nadle from /ROOT/lib/index.js
@@ -20,7 +20,7 @@ Command: /ROOT/nadle.mjs --max-workers 1 --no-footer check --exclude build
 exports[`workspaces > excluded tasks > should not run excluded tasks 2`] = `
 ---------- Context -----------
 Working Directory: /ROOT/test/__fixtures__/monorepo/__temp__/__{hash}__/packages/one
-Command: /ROOT/nadle.mjs --max-workers 1 --no-footer check --exclude two:build
+Command: /ROOT/lib/cli.js --max-workers 1 --no-footer check --exclude two:build
 ---------- Stdout ------------
 [log] <Bold><Cyan>▶ Welcome to Nadle {version}!</Cyan></BoldDim>
 [log] Using Nadle from /ROOT/lib/index.js
@@ -40,7 +40,7 @@ Command: /ROOT/nadle.mjs --max-workers 1 --no-footer check --exclude two:build
 exports[`workspaces > excluded tasks > should not run excluded tasks 3`] = `
 ---------- Context -----------
 Working Directory: /ROOT/test/__fixtures__/monorepo/__temp__/__{hash}__/packages/one
-Command: /ROOT/nadle.mjs --max-workers 1 --no-footer check --exclude packages:two:build
+Command: /ROOT/lib/cli.js --max-workers 1 --no-footer check --exclude packages:two:build
 ---------- Stdout ------------
 [log] <Bold><Cyan>▶ Welcome to Nadle {version}!</Cyan></BoldDim>
 [log] Using Nadle from /ROOT/lib/index.js

--- a/packages/nadle/test/__snapshots__/features/workspaces/workspaces-list.test.ts.snap
+++ b/packages/nadle/test/__snapshots__/features/workspaces/workspaces-list.test.ts.snap
@@ -3,7 +3,7 @@
 exports[`workspaces > list > should list all nested workspaces 1`] = `
 ---------- Context -----------
 Working Directory: /ROOT/test/__fixtures__/monorepo/__temp__/__{hash}__
-Command: /ROOT/nadle.mjs --max-workers 1 --no-footer --list-workspaces
+Command: /ROOT/lib/cli.js --max-workers 1 --no-footer --list-workspaces
 ---------- Stdout ------------
 [log] <Bold><Cyan>▶ Welcome to Nadle {version}!</Cyan></BoldDim>
 [log] Using Nadle from /ROOT/lib/index.js
@@ -25,7 +25,7 @@ Command: /ROOT/nadle.mjs --max-workers 1 --no-footer --list-workspaces
 exports[`workspaces > list > should list all nested workspaces 2 1`] = `
 ---------- Context -----------
 Working Directory: /ROOT/test/__fixtures__/monorepo/__temp__/__{hash}__
-Command: /ROOT/nadle.mjs --max-workers 1 --no-footer --list-workspaces
+Command: /ROOT/lib/cli.js --max-workers 1 --no-footer --list-workspaces
 ---------- Stdout ------------
 [log] <Bold><Cyan>▶ Welcome to Nadle {version}!</Cyan></BoldDim>
 [log] Using Nadle from /ROOT/lib/index.js
@@ -48,7 +48,7 @@ Command: /ROOT/nadle.mjs --max-workers 1 --no-footer --list-workspaces
 exports[`workspaces > list > should list all workspaces 1`] = `
 ---------- Context -----------
 Working Directory: /ROOT/test/__fixtures__/monorepo/__temp__/__{hash}__
-Command: /ROOT/nadle.mjs --max-workers 1 --no-footer --list-workspaces
+Command: /ROOT/lib/cli.js --max-workers 1 --no-footer --list-workspaces
 ---------- Stdout ------------
 [log] <Bold><Cyan>▶ Welcome to Nadle {version}!</Cyan></BoldDim>
 [log] Using Nadle from /ROOT/lib/index.js

--- a/packages/nadle/test/__snapshots__/features/workspaces/workspaces-resolve-tasks.test.ts.snap
+++ b/packages/nadle/test/__snapshots__/features/workspaces/workspaces-resolve-tasks.test.ts.snap
@@ -3,7 +3,7 @@
 exports[`workspaces resolve tasks > should correct typo tasks 1`] = `
 ---------- Context -----------
 Working Directory: /ROOT/test/__fixtures__/monorepo/__temp__/__{hash}__
-Command: /ROOT/nadle.mjs --max-workers 1 --no-footer backend:biuld biuld
+Command: /ROOT/lib/cli.js --max-workers 1 --no-footer backend:biuld biuld
 ---------- Stdout ------------
 [log] <Bold><Cyan>▶ Welcome to Nadle {version}!</Cyan></BoldDim>
 [log] Using Nadle from /ROOT/lib/index.js
@@ -26,7 +26,7 @@ Command: /ROOT/nadle.mjs --max-workers 1 --no-footer backend:biuld biuld
 exports[`workspaces resolve tasks > should correct typo workspaces 1`] = `
 ---------- Context -----------
 Working Directory: /ROOT/test/__fixtures__/monorepo/__temp__/__{hash}__
-Command: /ROOT/nadle.mjs --max-workers 1 --no-footer fronte:build backe:biuld
+Command: /ROOT/lib/cli.js --max-workers 1 --no-footer fronte:build backe:biuld
 ---------- Stdout ------------
 [log] <Bold><Cyan>▶ Welcome to Nadle {version}!</Cyan></BoldDim>
 [log] Using Nadle from /ROOT/lib/index.js

--- a/packages/nadle/test/__snapshots__/options/config-key.test.ts.snap
+++ b/packages/nadle/test/__snapshots__/options/config-key.test.ts.snap
@@ -3,7 +3,7 @@
 exports[`--config-key > should have no effect if not specified any value 1`] = `
 ---------- Context -----------
 Working Directory: /ROOT/test/__fixtures__/main
-Command: /ROOT/nadle.mjs --max-workers 1 --no-footer --show-config --config-key
+Command: /ROOT/lib/cli.js --max-workers 1 --no-footer --show-config --config-key
 ---------- Stdout ------------
 [log] {
   "cache": true,
@@ -58,7 +58,7 @@ Command: /ROOT/nadle.mjs --max-workers 1 --no-footer --show-config --config-key
 exports[`--config-key > should print undefined if config key does not exist 1`] = `
 ---------- Context -----------
 Working Directory: /ROOT/test/__fixtures__/main
-Command: /ROOT/nadle.mjs --max-workers 1 --no-footer --show-config --config-key notFound
+Command: /ROOT/lib/cli.js --max-workers 1 --no-footer --show-config --config-key notFound
 ---------- Stdout ------------
 [log] undefined
 `;
@@ -66,7 +66,7 @@ Command: /ROOT/nadle.mjs --max-workers 1 --no-footer --show-config --config-key 
 exports[`--config-key > should use the specified config key and show correct config 1`] = `
 ---------- Context -----------
 Working Directory: /ROOT/test/__fixtures__/main
-Command: /ROOT/nadle.mjs --max-workers 1 --no-footer --show-config --config-key project
+Command: /ROOT/lib/cli.js --max-workers 1 --no-footer --show-config --config-key project
 ---------- Stdout ------------
 [log] {
   "rootWorkspace": {
@@ -97,7 +97,7 @@ Command: /ROOT/nadle.mjs --max-workers 1 --no-footer --show-config --config-key 
 exports[`--config-key > should work with nested key 1`] = `
 ---------- Context -----------
 Working Directory: /ROOT/test/__fixtures__/pnpm-workspaces
-Command: /ROOT/nadle.mjs --max-workers 1 --no-footer --show-config --config-key project.rootWorkspace.absolutePath
+Command: /ROOT/lib/cli.js --max-workers 1 --no-footer --show-config --config-key project.rootWorkspace.absolutePath
 ---------- Stdout ------------
 [log] "/ROOT/test/__fixtures__/pnpm-workspaces"
 `;
@@ -105,7 +105,7 @@ Command: /ROOT/nadle.mjs --max-workers 1 --no-footer --show-config --config-key 
 exports[`--config-key > should work with nested key 2`] = `
 ---------- Context -----------
 Working Directory: /ROOT/test/__fixtures__/pnpm-workspaces
-Command: /ROOT/nadle.mjs --max-workers 1 --no-footer --show-config --config-key project.workspaces[1]
+Command: /ROOT/lib/cli.js --max-workers 1 --no-footer --show-config --config-key project.workspaces[1]
 ---------- Stdout ------------
 [log] {
   "id": "frontend",
@@ -130,7 +130,7 @@ Command: /ROOT/nadle.mjs --max-workers 1 --no-footer --show-config --config-key 
 exports[`--config-key > should work with nested key 3`] = `
 ---------- Context -----------
 Working Directory: /ROOT/test/__fixtures__/pnpm-workspaces
-Command: /ROOT/nadle.mjs --max-workers 1 --no-footer --show-config --config-key project.workspaces[1].id
+Command: /ROOT/lib/cli.js --max-workers 1 --no-footer --show-config --config-key project.workspaces[1].id
 ---------- Stdout ------------
 [log] "frontend"
 `;
@@ -138,7 +138,7 @@ Command: /ROOT/nadle.mjs --max-workers 1 --no-footer --show-config --config-key 
 exports[`--config-key > should work with nested key 4`] = `
 ---------- Context -----------
 Working Directory: /ROOT/test/__fixtures__/pnpm-workspaces
-Command: /ROOT/nadle.mjs --max-workers 1 --no-footer --show-config --config-key project.workspaces.1.id
+Command: /ROOT/lib/cli.js --max-workers 1 --no-footer --show-config --config-key project.workspaces.1.id
 ---------- Stdout ------------
 [log] "frontend"
 `;
@@ -146,7 +146,7 @@ Command: /ROOT/nadle.mjs --max-workers 1 --no-footer --show-config --config-key 
 exports[`--config-key > should work with nested key 5`] = `
 ---------- Context -----------
 Working Directory: /ROOT/test/__fixtures__/pnpm-workspaces
-Command: /ROOT/nadle.mjs --max-workers 1 --no-footer build --show-config --config-key tasks[0].taskId
+Command: /ROOT/lib/cli.js --max-workers 1 --no-footer build --show-config --config-key tasks[0].taskId
 ---------- Stdout ------------
 [log] "root:build"
 `;

--- a/packages/nadle/test/__snapshots__/options/config.test.ts.snap
+++ b/packages/nadle/test/__snapshots__/options/config.test.ts.snap
@@ -3,7 +3,7 @@
 exports[`--config > should precedence the js config file over the ts config file 1`] = `
 ---------- Context -----------
 Working Directory: /ROOT/test/__temp__/__{hash}__
-Command: /ROOT/nadle.mjs --max-workers 1 --no-footer hello
+Command: /ROOT/lib/cli.js --max-workers 1 --no-footer hello
 ---------- Stdout ------------
 [log] <Bold><Cyan>▶ Welcome to Nadle {version}!</Cyan></BoldDim>
 [log] Using Nadle from /ROOT/lib/index.js
@@ -18,7 +18,7 @@ Command: /ROOT/nadle.mjs --max-workers 1 --no-footer hello
 exports[`--config > should precedence the ts config file over the mts config file 1`] = `
 ---------- Context -----------
 Working Directory: /ROOT/test/__temp__/__{hash}__
-Command: /ROOT/nadle.mjs --max-workers 1 --no-footer hello
+Command: /ROOT/lib/cli.js --max-workers 1 --no-footer hello
 ---------- Stdout ------------
 [log] <Bold><Cyan>▶ Welcome to Nadle {version}!</Cyan></BoldDim>
 [log] Using Nadle from /ROOT/lib/index.js
@@ -33,7 +33,7 @@ Command: /ROOT/nadle.mjs --max-workers 1 --no-footer hello
 exports[`--config > should use the existent config path if not specify --config in cjs-js package 1`] = `
 ---------- Context -----------
 Working Directory: /ROOT/test/__temp__/__{hash}__
-Command: /ROOT/nadle.mjs --max-workers 1 --no-footer hello
+Command: /ROOT/lib/cli.js --max-workers 1 --no-footer hello
 ---------- Stdout ------------
 [log] <Bold><Cyan>▶ Welcome to Nadle {version}!</Cyan></BoldDim>
 [log] Using Nadle from /ROOT/lib/index.js
@@ -48,7 +48,7 @@ Command: /ROOT/nadle.mjs --max-workers 1 --no-footer hello
 exports[`--config > should use the existent config path if not specify --config in cjs-ts package 1`] = `
 ---------- Context -----------
 Working Directory: /ROOT/test/__temp__/__{hash}__
-Command: /ROOT/nadle.mjs --max-workers 1 --no-footer hello
+Command: /ROOT/lib/cli.js --max-workers 1 --no-footer hello
 ---------- Stdout ------------
 [log] <Bold><Cyan>▶ Welcome to Nadle {version}!</Cyan></BoldDim>
 [log] Using Nadle from /ROOT/lib/index.js
@@ -63,7 +63,7 @@ Command: /ROOT/nadle.mjs --max-workers 1 --no-footer hello
 exports[`--config > should use the existent config path if not specify --config in esm-js package 1`] = `
 ---------- Context -----------
 Working Directory: /ROOT/test/__temp__/__{hash}__
-Command: /ROOT/nadle.mjs --max-workers 1 --no-footer hello
+Command: /ROOT/lib/cli.js --max-workers 1 --no-footer hello
 ---------- Stdout ------------
 [log] <Bold><Cyan>▶ Welcome to Nadle {version}!</Cyan></BoldDim>
 [log] Using Nadle from /ROOT/lib/index.js
@@ -78,7 +78,7 @@ Command: /ROOT/nadle.mjs --max-workers 1 --no-footer hello
 exports[`--config > should use the existent config path if not specify --config in esm-ts package 1`] = `
 ---------- Context -----------
 Working Directory: /ROOT/test/__temp__/__{hash}__
-Command: /ROOT/nadle.mjs --max-workers 1 --no-footer hello
+Command: /ROOT/lib/cli.js --max-workers 1 --no-footer hello
 ---------- Stdout ------------
 [log] <Bold><Cyan>▶ Welcome to Nadle {version}!</Cyan></BoldDim>
 [log] Using Nadle from /ROOT/lib/index.js

--- a/packages/nadle/test/__snapshots__/options/dry-run.test.ts.snap
+++ b/packages/nadle/test/__snapshots__/options/dry-run.test.ts.snap
@@ -3,7 +3,7 @@
 exports[`--dry-run > should list for one task 1`] = `
 ---------- Context -----------
 Working Directory: /ROOT/test/__fixtures__/main
-Command: /ROOT/nadle.mjs --max-workers 1 --no-footer hello --dry-run
+Command: /ROOT/lib/cli.js --max-workers 1 --no-footer hello --dry-run
 ---------- Stdout ------------
 [log] <Bold><Cyan>▶ Welcome to Nadle {version}!</Cyan></BoldDim>
 [log] Using Nadle from /ROOT/lib/index.js

--- a/packages/nadle/test/__snapshots__/options/help.test.ts.snap
+++ b/packages/nadle/test/__snapshots__/options/help.test.ts.snap
@@ -3,7 +3,7 @@
 exports[`--help > prints help 1`] = `
 ---------- Context -----------
 Working Directory: /ROOT/test/__fixtures__/main
-Command: /ROOT/nadle.mjs --max-workers 1 --no-footer --help
+Command: /ROOT/lib/cli.js --max-workers 1 --no-footer --help
 ---------- Stdout ------------
 nadle [tasks...]
 

--- a/packages/nadle/test/__snapshots__/options/list-workspaces.test.ts.snap
+++ b/packages/nadle/test/__snapshots__/options/list-workspaces.test.ts.snap
@@ -3,7 +3,7 @@
 exports[`--list-workspaces > prints root workspace 1`] = `
 ---------- Context -----------
 Working Directory: /ROOT/test/__fixtures__/main
-Command: /ROOT/nadle.mjs --max-workers 1 --no-footer --list-workspaces
+Command: /ROOT/lib/cli.js --max-workers 1 --no-footer --list-workspaces
 ---------- Stdout ------------
 [log] <Bold><Cyan>▶ Welcome to Nadle {version}!</Cyan></BoldDim>
 [log] Using Nadle from /ROOT/lib/index.js

--- a/packages/nadle/test/__snapshots__/options/list.test.ts.snap
+++ b/packages/nadle/test/__snapshots__/options/list.test.ts.snap
@@ -3,7 +3,7 @@
 exports[`--list > prints all available tasks 1`] = `
 ---------- Context -----------
 Working Directory: /ROOT/test/__fixtures__/main
-Command: /ROOT/nadle.mjs --max-workers 1 --no-footer --list
+Command: /ROOT/lib/cli.js --max-workers 1 --no-footer --list
 ---------- Stdout ------------
 [log] <Bold><Cyan>▶ Welcome to Nadle {version}!</Cyan></BoldDim>
 [log] Using Nadle from /ROOT/lib/index.js
@@ -30,7 +30,7 @@ Command: /ROOT/nadle.mjs --max-workers 1 --no-footer --list
 exports[`--list > prints all tasks in workspace order 1`] = `
 ---------- Context -----------
 Working Directory: /ROOT/test/__fixtures__/monorepo/__temp__/__{hash}__
-Command: /ROOT/nadle.mjs --max-workers 1 --no-footer --list
+Command: /ROOT/lib/cli.js --max-workers 1 --no-footer --list
 ---------- Stdout ------------
 [log] <Bold><Cyan>▶ Welcome to Nadle {version}!</Cyan></BoldDim>
 [log] Using Nadle from /ROOT/lib/index.js

--- a/packages/nadle/test/__snapshots__/options/log-level.test.ts.snap
+++ b/packages/nadle/test/__snapshots__/options/log-level.test.ts.snap
@@ -3,5 +3,5 @@
 exports[`--log-level > shows error log only when passing --log-level=error 1`] = `
 ---------- Context -----------
 Working Directory: /ROOT/test/__fixtures__/main
-Command: /ROOT/nadle.mjs --max-workers 1 --no-footer hello --log-level=error
+Command: /ROOT/lib/cli.js --max-workers 1 --no-footer hello --log-level=error
 `;

--- a/packages/nadle/test/__snapshots__/options/show-config.test.ts.snap
+++ b/packages/nadle/test/__snapshots__/options/show-config.test.ts.snap
@@ -3,7 +3,7 @@
 exports[`--show-config > should show config 1`] = `
 ---------- Context -----------
 Working Directory: /ROOT/test/__fixtures__/main
-Command: /ROOT/nadle.mjs --max-workers 1 --no-footer hello --show-config
+Command: /ROOT/lib/cli.js --max-workers 1 --no-footer hello --show-config
 ---------- Stdout ------------
 [log] {
   "cache": true,
@@ -63,7 +63,7 @@ Command: /ROOT/nadle.mjs --max-workers 1 --no-footer hello --show-config
 exports[`--show-config > should show config with extra options 1`] = `
 ---------- Context -----------
 Working Directory: /ROOT/test/__fixtures__/main
-Command: /ROOT/nadle.mjs --no-footer hello --show-config --min-workers 2 --max-workers 3
+Command: /ROOT/lib/cli.js --no-footer hello --show-config --min-workers 2 --max-workers 3
 ---------- Stdout ------------
 [log] {
   "cache": true,

--- a/packages/nadle/test/__snapshots__/options/stacktrace.test.ts.snap
+++ b/packages/nadle/test/__snapshots__/options/stacktrace.test.ts.snap
@@ -3,7 +3,7 @@
 exports[`--stacktrace > should show stack trace 1`] = `
 ---------- Context -----------
 Working Directory: /ROOT/test/__fixtures__/main
-Command: /ROOT/nadle.mjs --max-workers 1 --no-footer throwable --stacktrace
+Command: /ROOT/lib/cli.js --max-workers 1 --no-footer throwable --stacktrace
 ---------- Stdout ------------
 [log] <Bold><Cyan>▶ Welcome to Nadle {version}!</Cyan></BoldDim>
 [log] Using Nadle from /ROOT/lib/index.js

--- a/packages/project-resolver/cli.mjs
+++ b/packages/project-resolver/cli.mjs
@@ -1,2 +1,0 @@
-#!/usr/bin/env node
-await import("./lib/cli.js");

--- a/packages/project-resolver/package.json
+++ b/packages/project-resolver/package.json
@@ -5,8 +5,7 @@
 	"license": "MIT",
 	"type": "module",
 	"files": [
-		"lib",
-		"cli.mjs"
+		"lib"
 	],
 	"exports": {
 		".": {
@@ -15,7 +14,7 @@
 		}
 	},
 	"bin": {
-		"nadle-project-resolver": "cli.mjs"
+		"nadle-project-resolver": "lib/cli.js"
 	},
 	"types": "lib/index.d.ts",
 	"dependencies": {

--- a/packages/project-resolver/src/cli.ts
+++ b/packages/project-resolver/src/cli.ts
@@ -1,3 +1,4 @@
+#!/usr/bin/env node
 import Process from "node:process";
 
 import type { Workspace, RootWorkspace } from "./types.js";

--- a/packages/vscode-extension/package.json
+++ b/packages/vscode-extension/package.json
@@ -7,11 +7,6 @@
 	"description": "VS Code extension for nadle.config.ts language support",
 	"license": "MIT",
 	"type": "commonjs",
-	"scripts": {
-		"build": "nadle build",
-		"package": "vsce package",
-		"publish": "vsce publish"
-	},
 	"files": [
 		"lib",
 		"server",

--- a/tsup.config.ts
+++ b/tsup.config.ts
@@ -7,6 +7,7 @@ export default defineConfig([
 		target: "node22",
 		skipNodeModulesBundle: true,
 		outDir: "packages/nadle/lib",
+		banner: { js: "#!/usr/bin/env node" },
 		tsconfig: "packages/nadle/tsconfig.build.json",
 		dts: { entry: "packages/nadle/src/index.ts", compilerOptions: { rootDir: "packages/nadle/src" } },
 		entry: {
@@ -28,7 +29,7 @@ export default defineConfig([
 		dts: { entry: "packages/language-server/src/index.ts", compilerOptions: { rootDir: "packages/language-server/src" } },
 		noExternal: ["vscode-languageserver", "vscode-languageserver-textdocument", "typescript", "@nadle/kernel", "@nadle/project-resolver"],
 		banner: {
-			js: "import { createRequire } from 'module'; import { fileURLToPath } from 'url'; import { dirname } from 'path'; const require = createRequire(import.meta.url); const __filename = fileURLToPath(import.meta.url); const __dirname = dirname(__filename);"
+			js: "#!/usr/bin/env node\nimport { createRequire } from 'module'; import { fileURLToPath } from 'url'; import { dirname } from 'path'; const require = createRequire(import.meta.url); const __filename = fileURLToPath(import.meta.url); const __dirname = dirname(__filename);"
 		}
 	},
 	{


### PR DESCRIPTION
## Summary

Three cleanups continuing the pipeline unification:

### Scripts trimmed
- `packages/nadle`: dropped `test`/`update`/`bench` (use `nadle testUnit -- --project nadle [-u]`); kept `build` for the size-limit action.
- `packages/docs`: dropped `clean`/`build`; kept `dev`/`serve`.
- `packages/vscode-extension`: scripts removed entirely (release workflow calls vsce directly).
- `spell` task uses `cspell --cache`, wired into the CI lint cache. Prettier's `--cache` removed: the experimental CLI returned inconsistent results with it (silent false pass on an unformatted file).

### Task caching correctness
- `pnpm-lock.yaml` added to `compile`/`bundle` inputs - dependency bumps now invalidate cached lib output (previously a bumped bundled dep could serve stale artifacts).
- typedoc (`generateMarkdown`) and api-extractor (`testAPI`) runs are now cached with proper inputs/outputs.
- Redundant `dist` aggregate removed (`build` covers it).

### Bin shims removed
- `nadle.mjs`, `create-nadle.mjs`, `cli.mjs`, `server.mjs` deleted; `bin` points straight at `lib/` outputs.
- Shebang via tsup `banner` (nadle, language-server) and preserved source shebangs (tsgo-built create-nadle, project-resolver).
- Language server defaults to `--stdio` only when no transport flag is present (replaces the argv shim, safe for the VS Code client which passes its own transport).
- `allowDefaultProject` collapsed to `projectService: true`.

## Verification

- Full nadle + create-nadle suites: 1148/1148 pass, snapshots regenerated for the new bin path.
- All four bins verified executable (direct node, shebang exec, pnpm shim).
- `nadle check` and clean `nadle build` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)