### PR TITLE
fix: map eslint-plugin-nadle tag to its package directory in release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -30,7 +30,13 @@ jobs:
 
       - name: Parse tag
         id: parse-tag
-        run: echo "package=${GITHUB_REF_NAME%%/*}" >> "$GITHUB_OUTPUT"
+        # Tag components are npm package names; map the ones whose directory differs.
+        run: |
+          package="${GITHUB_REF_NAME%%/*}"
+          case "$package" in
+            eslint-plugin-nadle) package=eslint-plugin ;;
+          esac
+          echo "package=$package" >> "$GITHUB_OUTPUT"
 
       - name: Build
         run: nadle build


### PR DESCRIPTION
The release workflow derives `working-directory` from the tag component, which is the npm package name. `eslint-plugin-nadle` lives in `packages/eslint-plugin`, so the v0.0.2 release run failed with "No such file or directory". Adds the name→directory mapping.

After merge, the `eslint-plugin-nadle/v0.0.2` tag will be re-pointed at a commit containing this fix to re-trigger the publish (tag-triggered workflows run the workflow file from the tagged commit).

🤖 Generated with [Claude Code](https://claude.com/claude-code)