### PR TITLE
fix: resolve workspace dependencies in published packages

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -50,7 +50,11 @@ jobs:
 
       - name: Publish to npm
         if: ${{ !startsWith(github.ref_name, 'vscode-extension/') }}
-        run: npm publish --provenance --access public
+        # pnpm pack rewrites workspace: protocol deps to real versions;
+        # npm publish then handles OIDC trusted publishing + provenance.
+        run: |
+          pnpm pack --out package.tgz
+          npm publish package.tgz --provenance --access public
         working-directory: packages/${{ steps.parse-tag.outputs.package }}
 
       - name: Publish VS Code Extension

--- a/packages/eslint-plugin/package.json
+++ b/packages/eslint-plugin/package.json
@@ -15,7 +15,7 @@
 	},
 	"types": "lib/index.d.ts",
 	"dependencies": {
-		"@nadle/kernel": "workspace:*"
+		"@nadle/kernel": "workspace:^"
 	},
 	"devDependencies": {
 		"@types/node": "^20.19.25",

--- a/packages/language-server/package.json
+++ b/packages/language-server/package.json
@@ -19,8 +19,8 @@
 	},
 	"types": "lib/index.d.ts",
 	"dependencies": {
-		"@nadle/kernel": "workspace:*",
-		"@nadle/project-resolver": "workspace:*",
+		"@nadle/kernel": "workspace:^",
+		"@nadle/project-resolver": "workspace:^",
 		"typescript": "^5.9.3",
 		"vscode-languageserver": "^9.0.1",
 		"vscode-languageserver-textdocument": "^1.0.12"

--- a/packages/nadle/package.json
+++ b/packages/nadle/package.json
@@ -19,8 +19,8 @@
 	"bin": "lib/cli.js",
 	"types": "lib/index.d.ts",
 	"dependencies": {
-		"@nadle/kernel": "workspace:*",
-		"@nadle/project-resolver": "workspace:*",
+		"@nadle/kernel": "workspace:^",
+		"@nadle/project-resolver": "workspace:^",
 		"consola": "^3.4.2",
 		"execa": "^9.6.1",
 		"fast-glob": "^3.3.3",

--- a/packages/project-resolver/package.json
+++ b/packages/project-resolver/package.json
@@ -20,7 +20,7 @@
 	"dependencies": {
 		"@manypkg/find-root": "^3.1.0",
 		"@manypkg/tools": "^2.1.1",
-		"@nadle/kernel": "workspace:*",
+		"@nadle/kernel": "workspace:^",
 		"find-up": "^8.0.0"
 	},
 	"devDependencies": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -204,7 +204,7 @@ importers:
   packages/eslint-plugin:
     dependencies:
       '@nadle/kernel':
-        specifier: workspace:*
+        specifier: workspace:^
         version: link:../kernel
       eslint:
         specifier: ^9.0.0
@@ -241,10 +241,10 @@ importers:
   packages/language-server:
     dependencies:
       '@nadle/kernel':
-        specifier: workspace:*
+        specifier: workspace:^
         version: link:../kernel
       '@nadle/project-resolver':
-        specifier: workspace:*
+        specifier: workspace:^
         version: link:../project-resolver
       typescript:
         specifier: ^5.9.3
@@ -278,10 +278,10 @@ importers:
   packages/nadle:
     dependencies:
       '@nadle/kernel':
-        specifier: workspace:*
+        specifier: workspace:^
         version: link:../kernel
       '@nadle/project-resolver':
-        specifier: workspace:*
+        specifier: workspace:^
         version: link:../project-resolver
       consola:
         specifier: ^3.4.2
@@ -411,7 +411,7 @@ importers:
         specifier: ^2.1.1
         version: 2.1.1
       '@nadle/kernel':
-        specifier: workspace:*
+        specifier: workspace:^
         version: link:../kernel
       find-up:
         specifier: ^8.0.0


### PR DESCRIPTION
## Problem

`npm publish` ships the `workspace:` protocol verbatim. Four packages released today are uninstallable for npm consumers (`EUNSUPPORTEDPROTOCOL`):

- `nadle@0.5.2`
- `@nadle/project-resolver@0.0.2`
- `@nadle/language-server@0.0.4`
- `eslint-plugin-nadle@0.0.2`

(`@nadle/kernel@0.0.2` and `create-nadle@0.0.5` have no workspace deps and are fine.)

## Fix

- Release workflow packs with `pnpm pack` (rewrites workspace ranges to real versions) and publishes the tarball through `npm publish` — keeping the proven OIDC trusted-publishing path.
- Workspace deps switch from `workspace:*` to `workspace:^` so published manifests get caret ranges (`^0.0.2`) instead of exact pins.
- Verified locally: `pnpm pack` output manifest contains `"@nadle/kernel": "^0.0.2"`.

## Follow-up after merge

This `fix:` commit touches all four package paths, so release-please will queue patch releases (nadle 0.5.3, project-resolver 0.0.3, language-server 0.0.5, eslint-plugin 0.0.3) that republish correctly. The broken versions should then be npm-deprecated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)