### PR TITLE
chore: self-host on published nadle 0.5.3

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
 		"husky": "^9.1.7",
 		"jiti": "^2.7.0",
 		"knip": "^6.16.1",
-		"nadle": "https://pkg.pr.new/nadle@40659bc",
+		"nadle": "^0.5.3",
 		"prettier": "^3.8.3",
 		"rimraf": "^6.1.3",
 		"std-env": "^3.10.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -67,8 +67,8 @@ importers:
         specifier: ^6.16.1
         version: 6.16.1
       nadle:
-        specifier: https://pkg.pr.new/nadle@40659bc
-        version: https://pkg.pr.new/nadle@40659bc(@types/react@19.2.17)
+        specifier: ^0.5.3
+        version: 0.5.3(@types/react@19.2.17)
       prettier:
         specifier: ^3.8.3
         version: 3.8.3
@@ -2705,9 +2705,8 @@ packages:
     peerDependencies:
       eslint: ^9.30.1
 
-  '@nadle/kernel@https://pkg.pr.new/nadlejs/nadle/@nadle/kernel@40659bccb71bb7d2b7c4849802e3d6c2dbd496a4':
-    resolution: {integrity: sha512-pat7Q24UcPNgEAGEHcE47DE0f663pYDJT2+F9ZUi5NOlmUkLJllvRmqxR9z1rrKO2Vb2jI7VyiMw5sAkIdcftQ==, tarball: https://pkg.pr.new/nadlejs/nadle/@nadle/kernel@40659bccb71bb7d2b7c4849802e3d6c2dbd496a4}
-    version: 0.0.1
+  '@nadle/kernel@0.0.2':
+    resolution: {integrity: sha512-J43dusMefpYeHx3jKKjGlvYZBYAEsGmmQDK4u4eeagJUsanuw18eKFSTt2mw0OaOqgNPvUWxFnXvXi52+W+BCA==}
     engines: {node: '>=22'}
 
   '@nadle/prettier-config@0.0.5':
@@ -2716,9 +2715,8 @@ packages:
     peerDependencies:
       prettier: ^3.6.2
 
-  '@nadle/project-resolver@https://pkg.pr.new/nadlejs/nadle/@nadle/project-resolver@40659bccb71bb7d2b7c4849802e3d6c2dbd496a4':
-    resolution: {integrity: sha512-YxWRf/es05f+Br8dxF6pTcfS6iaJX9aa8zTBCsLGHyHfe7wvguuwSgGIxfG7BxVeJTJhGaXHfMSSrsWZ+wCpDw==, tarball: https://pkg.pr.new/nadlejs/nadle/@nadle/project-resolver@40659bccb71bb7d2b7c4849802e3d6c2dbd496a4}
-    version: 0.0.1
+  '@nadle/project-resolver@0.0.3':
+    resolution: {integrity: sha512-kElU5QIcRdR0y3ZkjfvaGDBqvEHlxrMzMF10Uq2ikgSGgnA6RD62qYFzp/0acNzTMS54euj1AMyS5kcDTTsBPA==}
     engines: {node: '>=22'}
     hasBin: true
 
@@ -7053,9 +7051,8 @@ packages:
   mz@2.7.0:
     resolution: {integrity: sha512-z81GNO7nnYMEhrGh9LeymoE4+Yr0Wn5McHIZMK5cfQCl+NDX08sCZgUc9/6MHni9IWuFLm1Z3HTCXu2z9fN62Q==}
 
-  nadle@https://pkg.pr.new/nadle@40659bc:
-    resolution: {integrity: sha512-QPq2i/pmYMedPsqOXTZPPlRIaJ3QMoBCx8XvqQ025H5OedAyR6PbjGV4aG0MqVVSGiklI+xrdc+AIhEZMiB+8g==, tarball: https://pkg.pr.new/nadle@40659bc}
-    version: 0.5.1
+  nadle@0.5.3:
+    resolution: {integrity: sha512-wz8O/FGCNe9YqGhmUoKn7BBtYoN41Aol6fkEs03QFbC/8qEj5a/9wDpzgjP7paH/0mk1/k5lTCWavIZckPnNkw==}
     engines: {node: '>=22'}
     hasBin: true
 
@@ -12621,17 +12618,17 @@ snapshots:
       - typescript
       - vitest
 
-  '@nadle/kernel@https://pkg.pr.new/nadlejs/nadle/@nadle/kernel@40659bccb71bb7d2b7c4849802e3d6c2dbd496a4': {}
+  '@nadle/kernel@0.0.2': {}
 
   '@nadle/prettier-config@0.0.5(prettier@3.8.3)':
     dependencies:
       prettier: 3.8.3
 
-  '@nadle/project-resolver@https://pkg.pr.new/nadlejs/nadle/@nadle/project-resolver@40659bccb71bb7d2b7c4849802e3d6c2dbd496a4':
+  '@nadle/project-resolver@0.0.3':
     dependencies:
       '@manypkg/find-root': 3.1.0
       '@manypkg/tools': 2.1.1
-      '@nadle/kernel': https://pkg.pr.new/nadlejs/nadle/@nadle/kernel@40659bccb71bb7d2b7c4849802e3d6c2dbd496a4
+      '@nadle/kernel': 0.0.2
       find-up: 8.0.0
 
   '@nadle/ts-config@0.0.2': {}
@@ -17689,10 +17686,10 @@ snapshots:
       object-assign: 4.1.1
       thenify-all: 1.6.0
 
-  nadle@https://pkg.pr.new/nadle@40659bc(@types/react@19.2.17):
+  nadle@0.5.3(@types/react@19.2.17):
     dependencies:
-      '@nadle/kernel': https://pkg.pr.new/nadlejs/nadle/@nadle/kernel@40659bccb71bb7d2b7c4849802e3d6c2dbd496a4
-      '@nadle/project-resolver': https://pkg.pr.new/nadlejs/nadle/@nadle/project-resolver@40659bccb71bb7d2b7c4849802e3d6c2dbd496a4
+      '@nadle/kernel': 0.0.2
+      '@nadle/project-resolver': 0.0.3
       consola: 3.4.2
       execa: 9.6.1
       fast-glob: 3.3.3

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -10,10 +10,9 @@ packages:
 # default 24h minimumReleaseAge supply-chain delay.
 minimumReleaseAgeExclude:
   - "@typescript/native-preview*"
-
-# Nadle dogfoods itself via pkg.pr.new snapshots whose workspace deps
-# (@nadle/kernel etc.) resolve as URL tarballs - exotic subdeps by design.
-blockExoticSubdeps: false
+  - "@nadle/kernel@0.0.2"
+  - "@nadle/project-resolver@0.0.3"
+  - nadle@0.5.3
 
 # Only esbuild needs its install script; the rest were silently skipped
 # under pnpm 10 as well and work fine without building.


### PR DESCRIPTION
Replaces the `pkg.pr.new` snapshot devDependency with the released `nadle@^0.5.3`.

- Lockfile drops all URL-tarball entries — including the hand-injected integrity hashes pnpm 11 required for them
- `blockExoticSubdeps: false` override removed (no more URL subdeps)
- pnpm auto-recorded `minimumReleaseAge` excludes for today's own releases; inert after the packages age past 24h
- Verified: `nadle build`, `nadle testUnit -- --project kernel`, `nadle check` all green on 0.5.3

🤖 Generated with [Claude Code](https://claude.com/claude-code)