### PR TITLE
feat: nadle --graph prints the task dependency graph

### DIFF
--- a/packages/docs/docs/config-reference.md
+++ b/packages/docs/docs/config-reference.md
@@ -77,6 +77,20 @@ Simulate task execution without actually running the tasks. Shows what would be 
 nadle --dry-run build
 ```
 
+### `--graph`
+
+- **Type:** `string`
+- **Choices:** `tree` (default), `mermaid`
+
+Print the task dependency graph instead of executing. `tree` renders an indented forest rooted at
+the requested tasks; `mermaid` emits a `graph TD` block you can paste into docs. Implicit
+(workspace-derived) dependencies are marked.
+
+```bash
+nadle build --graph
+nadle build --graph=mermaid
+```
+
 ### `--stacktrace`
 
 - **Type:** `boolean`

--- a/packages/nadle/src/cli.ts
+++ b/packages/nadle/src/cli.ts
@@ -14,6 +14,7 @@ const argv = yargs(hideBin(Process.argv))
 	.options({
 		[CLIOptions.list.key]: CLIOptions.list.options,
 		[CLIOptions.cache.key]: CLIOptions.cache.options,
+		[CLIOptions.graph.key]: CLIOptions.graph.options,
 		[CLIOptions.dryRun.key]: CLIOptions.dryRun.options,
 		[CLIOptions.footer.key]: CLIOptions.footer.options,
 		[CLIOptions.exclude.key]: CLIOptions.exclude.options,

--- a/packages/nadle/src/core/handlers/graph-handler.ts
+++ b/packages/nadle/src/core/handlers/graph-handler.ts
@@ -1,0 +1,34 @@
+import { BaseHandler } from "./base-handler.js";
+import { Messages } from "../utilities/messages.js";
+import { ResolvedTask } from "../interfaces/resolved-task.js";
+import { type TaskGraph, renderTaskGraph } from "../reporting/task-graph.js";
+
+export class GraphHandler extends BaseHandler {
+	public readonly name = "graph";
+	public readonly description = "Prints the task dependency graph without running tasks.";
+
+	public canHandle(): boolean {
+		return this.context.options.graph !== undefined;
+	}
+
+	public handle(): void {
+		if (this.context.options.tasks.length === 0) {
+			this.context.logger.log(Messages.NoTasksFound());
+
+			return;
+		}
+
+		const scheduler = this.context.taskScheduler.init();
+
+		const nodes: TaskGraph.Node[] = scheduler.scheduledTask.map((taskId) => ({
+			id: taskId,
+			implicitDependencies: scheduler.getImplicitDeps(taskId),
+			label: this.context.taskRegistry.getTaskById(taskId).label,
+			dependencies: [...scheduler.getDirectDependencies(taskId)]
+		}));
+
+		const roots = this.context.options.tasks.map(ResolvedTask.getId);
+
+		this.context.logger.log(renderTaskGraph({ roots, nodes, format: this.context.options.graph ?? "tree" }));
+	}
+}

--- a/packages/nadle/src/core/handlers/index.ts
+++ b/packages/nadle/src/core/handlers/index.ts
@@ -1,4 +1,5 @@
 import { ListHandler } from "./list-handler.js";
+import { GraphHandler } from "./graph-handler.js";
 import { DryRunHandler } from "./dry-run-handler.js";
 import { ExecuteHandler } from "./execute-handler.js";
 import { CleanCacheHandler } from "./clean-cache-handler.js";
@@ -10,6 +11,7 @@ export const Handlers: HandlerConstructor[] = [
 	ListHandler,
 	ListWorkspacesHandler,
 	CleanCacheHandler,
+	GraphHandler,
 	DryRunHandler,
 	ShowConfigHandler,
 	ExecuteHandler

--- a/packages/nadle/src/core/options/cli-options-resolver.ts
+++ b/packages/nadle/src/core/options/cli-options-resolver.ts
@@ -48,6 +48,7 @@ const transformers = [
 	exclude(UNDERSCORE),
 	transform("config", { transformKey: "configFile" }),
 	transform("cache", { transformValue: Boolean }),
+	transform("graph", { transformValue: (value) => (value === "" ? "tree" : value) }),
 	transform("exclude", { transformKey: "excludedTasks" })
 ];
 

--- a/packages/nadle/src/core/options/cli-options.ts
+++ b/packages/nadle/src/core/options/cli-options.ts
@@ -52,6 +52,15 @@ export const CLIOptions = {
 			description: "Run specified tasks in dry run mode"
 		}
 	},
+	graph: {
+		key: "graph",
+		options: {
+			type: "string",
+			// Bare `--graph` yields "" → treated as the default "tree" format in the resolver.
+			choices: ["", "tree", "mermaid"] as const,
+			description: "Print the task dependency graph instead of executing (tree or mermaid)"
+		}
+	},
 	stacktrace: {
 		key: "stacktrace",
 		options: {

--- a/packages/nadle/src/core/options/types.ts
+++ b/packages/nadle/src/core/options/types.ts
@@ -51,6 +51,8 @@ export interface NadleCLIOptions extends NadleBaseOptions {
 	readonly dryRun: boolean;
 	/** Show summary after execution. */
 	readonly summary?: boolean;
+	/** Print the task dependency graph instead of executing. "tree" (default) or "mermaid". */
+	readonly graph?: "tree" | "mermaid";
 
 	/** Show stacktrace on errors. */
 	readonly stacktrace: boolean;
@@ -84,10 +86,13 @@ export type AliasOption = Record<string, string> | ((workspacePath: string) => s
  * Fully resolved Nadle options, including required fields and project reference.
  */
 export interface NadleResolvedOptions extends Required<
-	Omit<NadleCLIOptions, "maxWorkers" | "minWorkers" | "configKey" | "configFile" | "tasks" | "excludedTasks">
+	Omit<NadleCLIOptions, "maxWorkers" | "minWorkers" | "configKey" | "configFile" | "tasks" | "excludedTasks" | "graph">
 > {
 	/** Project information. */
 	readonly project: Project;
+
+	/** Task graph output format, when --graph was requested. */
+	readonly graph?: "tree" | "mermaid";
 
 	/** Minimum number of worker threads (resolved as number). */
 	readonly minWorkers: number;

--- a/packages/nadle/src/core/reporting/task-graph.ts
+++ b/packages/nadle/src/core/reporting/task-graph.ts
@@ -1,0 +1,122 @@
+import c from "tinyrainbow";
+
+export namespace TaskGraph {
+	export interface Node {
+		readonly id: string;
+		readonly label: string;
+		/** Direct dependency task ids (both explicit and implicit). */
+		readonly dependencies: readonly string[];
+		/** Subset of `dependencies` that were derived implicitly (e.g. from workspace deps). */
+		readonly implicitDependencies: readonly string[];
+	}
+
+	export interface Props {
+		readonly nodes: readonly Node[];
+		/** Root task ids the user requested — the entry points of the printed forest. */
+		readonly roots: readonly string[];
+		readonly format: "tree" | "mermaid";
+	}
+}
+
+/**
+ * Render the resolved task dependency graph as text. The `tree` format prints an
+ * indented forest rooted at the requested tasks; the `mermaid` format emits a
+ * Mermaid `graph TD` block suitable for pasting into docs.
+ */
+export function renderTaskGraph({ roots, nodes, format }: TaskGraph.Props): string {
+	const byId = new Map(nodes.map((node) => [node.id, node]));
+
+	return format === "mermaid" ? renderMermaid(roots, byId) : renderTree(roots, byId);
+}
+
+interface Frame {
+	readonly id: string;
+	readonly prefix: string;
+	readonly isLast: boolean;
+	readonly isRoot: boolean;
+	readonly ancestors: Set<string>;
+}
+
+function renderTree(roots: readonly string[], byId: Map<string, TaskGraph.Node>): string {
+	const lines: string[] = [c.bold("Task graph:")];
+
+	const visit = ({ id, prefix, isLast, isRoot, ancestors }: Frame): void => {
+		const node = byId.get(id);
+		const label = node ? node.label : id;
+
+		lines.push(isRoot ? c.bold(label) : `${prefix}${isLast ? "└─ " : "├─ "}${label}`);
+
+		// A cycle would be a config error caught earlier, but guard the renderer anyway.
+		if (ancestors.has(id)) {
+			lines.push(`${prefix}${isRoot ? "" : isLast ? "   " : "│  "}${c.red("↻ cycle")}`);
+
+			return;
+		}
+
+		if (!node) {
+			return;
+		}
+
+		const childPrefix = isRoot ? "" : prefix + (isLast ? "   " : "│  ");
+		const nextAncestors = new Set(ancestors).add(id);
+
+		node.dependencies.forEach((depId, index) => {
+			const beforeLen = lines.length;
+
+			visit({ id: depId, isRoot: false, prefix: childPrefix, ancestors: nextAncestors, isLast: index === node.dependencies.length - 1 });
+
+			if (node.implicitDependencies.includes(depId)) {
+				lines[beforeLen] += c.dim(" (implicit)");
+			}
+		});
+	};
+
+	for (const rootId of roots) {
+		visit({ id: rootId, prefix: "", isLast: true, isRoot: true, ancestors: new Set() });
+	}
+
+	return lines.join("\n");
+}
+
+function renderMermaid(roots: readonly string[], byId: Map<string, TaskGraph.Node>): string {
+	const lines: string[] = ["```mermaid", "graph TD"];
+	const seen = new Set<string>();
+	const queue = [...roots];
+	const ids = new Map<string, string>();
+	let counter = 0;
+
+	const mermaidId = (taskId: string): string => {
+		let id = ids.get(taskId);
+
+		if (id === undefined) {
+			id = `t${counter++}`;
+			ids.set(taskId, id);
+		}
+
+		return id;
+	};
+
+	while (queue.length > 0) {
+		const taskId = queue.shift()!;
+
+		if (seen.has(taskId)) {
+			continue;
+		}
+
+		seen.add(taskId);
+
+		const node = byId.get(taskId);
+		const label = node ? node.label : taskId;
+		lines.push(`  ${mermaidId(taskId)}["${label}"]`);
+
+		for (const depId of node?.dependencies ?? []) {
+			const arrow = node?.implicitDependencies.includes(depId) ? "-.->" : "-->";
+			lines.push(`  ${mermaidId(taskId)} ${arrow} ${mermaidId(depId)}`);
+			queue.push(depId);
+		}
+	}
+
+	lines.push("```");
+
+	return lines.join("\n");
+}

--- a/packages/nadle/test/options/graph.test.ts
+++ b/packages/nadle/test/options/graph.test.ts
@@ -1,0 +1,52 @@
+import { it, expect, describe } from "vitest";
+import { fixture, getStdout, readConfig, withGeneratedFixture } from "setup";
+
+const dependsOnFiles = fixture()
+	.packageJson("graph")
+	.configRaw(await readConfig("depends-on.ts"))
+	.build();
+
+describe("--graph", () => {
+	it("prints the dependency tree for a single task", () =>
+		withGeneratedFixture({
+			files: dependsOnFiles,
+			testFn: async ({ exec }) => {
+				const stdout = await getStdout(exec`build --graph`);
+
+				expect(stdout).toContain("Task graph:");
+
+				// Root plus every transitive dependency appears.
+				for (const task of ["build", "test", "compile", "compileTs", "compileSvg", "install", "node"]) {
+					expect(stdout).toContain(task);
+				}
+
+				// Tree connectors are present.
+				expect(stdout).toMatch(/[├└]─ /);
+				expect(stdout).toContain("RUN SUCCESSFUL");
+			}
+		}));
+
+	it("emits a mermaid graph when --graph=mermaid", () =>
+		withGeneratedFixture({
+			files: dependsOnFiles,
+			testFn: async ({ exec }) => {
+				const stdout = await getStdout(exec`build --graph=mermaid`);
+
+				expect(stdout).toContain("```mermaid");
+				expect(stdout).toContain("graph TD");
+				// An explicit edge uses the solid arrow.
+				expect(stdout).toMatch(/-->/);
+			}
+		}));
+
+	it("does not execute tasks", () =>
+		withGeneratedFixture({
+			files: dependsOnFiles,
+			testFn: async ({ exec }) => {
+				const stdout = await getStdout(exec`build --graph`);
+
+				expect(stdout).not.toContain("STARTED");
+				expect(stdout).not.toContain("DONE");
+			}
+		}));
+});


### PR DESCRIPTION
Closes #110.

## What

`nadle <task> --graph` renders the resolved dependency DAG instead of executing — part of the v0.7 Trust milestone (debugging dependency issues).

**Tree** (default, `nadle build --graph`):
```
Task graph:
build
├─ test
│  └─ install
│     └─ node
└─ compile
   ├─ compileSvg
   │  └─ install
   │     └─ node
   └─ compileTs
      └─ install
         └─ node
```

**Mermaid** (`nadle build --graph=mermaid`): a `graph TD` block with solid `-->` (explicit) and dotted `-.->` (implicit/workspace-derived) edges, nodes deduped.

## How

- `GraphHandler` mirrors `DryRunHandler` — builds the scheduler, reads `scheduledTask` / `getDirectDependencies` / `getImplicitDeps`, renders, exits without running.
- `renderTaskGraph` is a pure function (testable in isolation), tree path cycle-guarded.
- Bare `--graph` → `tree` (resolver maps the empty value); `--graph=tree|mermaid` explicit.
- Docs added to config-reference; 3 integration tests (tree content + connectors, mermaid block, no-execution).

## Verification

3/3 graph tests pass; `nadle check` + typecheck green. Implicit deps marked with `(implicit)` in tree.

🤖 Generated with [Claude Code](https://claude.com/claude-code)