### PR TITLE
test: redact resolved-options dump in builtin-task snapshots

### DIFF
--- a/packages/nadle/test/__setup__/serialize.ts
+++ b/packages/nadle/test/__setup__/serialize.ts
@@ -13,6 +13,7 @@ export function serialize(input: string): string {
 		serializeRelativePath,
 		serializeAbsoluteFilePath,
 		serializeStackTrace,
+		serializeOptionsDump,
 		serializeHash,
 		serializeVersion,
 		removeUnstableLines,
@@ -85,6 +86,14 @@ function serializeAbsoluteFilePath(input: string) {
 
 function serializeStackTrace(input: string) {
 	return input.replaceAll(/at .+( .+)?(\s+at .+( .+)?)+/g, "{stackTrace...}");
+}
+
+// The info-level "Resolved options: { … }" dump embeds the entire resolved
+// options object. Redact its body so unrelated task snapshots don't churn every
+// time an option is added (the --show-config snapshot, which asserts the dump
+// intentionally, uses a different output shape and is unaffected).
+function serializeOptionsDump(input: string) {
+	return input.replace(/Resolved options: \{[\s\S]*?\n\}/g, "Resolved options: {options}");
 }
 
 function serializeHash(input: string) {

--- a/packages/nadle/test/__snapshots__/builtin-tasks/delete-task.test.ts.snap
+++ b/packages/nadle/test/__snapshots__/builtin-tasks/delete-task.test.ts.snap
@@ -83,61 +83,7 @@ Command: /ROOT/lib/cli.js --max-workers 1 --no-footer deleteJsonFiles --log-leve
 
 [info] Using 1 worker for task execution
 [info] Project directory: /ROOT/test/__fixtures__/delete-task/__temp__/__{hash}__
-[info] Resolved options: {
-  "why": false,
-  "cache": true,
-  "watch": false,
-  "summary": false,
-  "parallel": false,
-  "logLevel": "info",
-  "cleanCache": false,
-  "showConfig": false,
-  "maxCacheEntries": 5,
-  "reporter": "default",
-  "implicitDependencies": true,
-  "excludedTasks": [],
-  "passthroughArgs": [],
-  "footer": false,
-  "isWorkerThread": false,
-  "tasks": [
-    {
-      "corrected": false,
-      "rawInput": "deleteJsonFiles",
-      "taskId": "root:deleteJsonFiles"
-    }
-  ],
-  "maxWorkers": 1,
-  "list": false,
-  "dryRun": false,
-  "stacktrace": false,
-  "listWorkspaces": false,
-  "project": {
-    "rootWorkspace": {
-      "label": "",
-      "packageJson": {
-        "name": "@nadle/internal-nadle-test-fixtures-delete-task",
-        "type": "module",
-        "private": true,
-        "dependencies": {
-          "nadle": "workspace:*"
-        },
-        "nadle": {
-          "root": true
-        }
-      },
-      "absolutePath": "/ROOT/test/__fixtures__/delete-task/__temp__/__{hash}__",
-      "dependencies": [],
-      "relativePath": ".",
-      "configFilePath": "/ROOT/test/__fixtures__/delete-task/__temp__/__{hash}__/nadle.config.ts",
-      "id": "root"
-    },
-    "workspaces": [],
-    "currentWorkspaceId": "root",
-    "packageManager": "npm"
-  },
-  "cacheDir": "/ROOT/test/__fixtures__/delete-task/__temp__/__{hash}__/node_modules/.cache/nadle",
-  "minWorkers": 1
-}
+[info] Resolved options: {options}
 [info] Detected environments: { CI: false, TEST: true }
 [info] Execution started
 [info] Scheduled tasks: root:deleteJsonFiles

--- a/packages/nadle/test/__snapshots__/builtin-tasks/node-task.test.ts.snap
+++ b/packages/nadle/test/__snapshots__/builtin-tasks/node-task.test.ts.snap
@@ -11,61 +11,7 @@ Command: /ROOT/lib/cli.js --max-workers 1 --no-footer pass --log-level info
 
 [info] Using 1 worker for task execution
 [info] Project directory: /ROOT/test/__fixtures__/node-task
-[info] Resolved options: {
-  "why": false,
-  "cache": true,
-  "watch": false,
-  "summary": false,
-  "parallel": false,
-  "logLevel": "info",
-  "cleanCache": false,
-  "showConfig": false,
-  "maxCacheEntries": 5,
-  "reporter": "default",
-  "implicitDependencies": true,
-  "excludedTasks": [],
-  "passthroughArgs": [],
-  "footer": false,
-  "isWorkerThread": false,
-  "tasks": [
-    {
-      "corrected": false,
-      "rawInput": "pass",
-      "taskId": "root:pass"
-    }
-  ],
-  "maxWorkers": 1,
-  "list": false,
-  "dryRun": false,
-  "stacktrace": false,
-  "listWorkspaces": false,
-  "project": {
-    "rootWorkspace": {
-      "label": "",
-      "packageJson": {
-        "name": "@nadle/internal-nadle-test-fixtures-node-task",
-        "type": "module",
-        "private": true,
-        "dependencies": {
-          "nadle": "workspace:*"
-        },
-        "nadle": {
-          "root": true
-        }
-      },
-      "absolutePath": "/ROOT/test/__fixtures__/node-task",
-      "dependencies": [],
-      "relativePath": ".",
-      "configFilePath": "/ROOT/test/__fixtures__/node-task/nadle.config.ts",
-      "id": "root"
-    },
-    "workspaces": [],
-    "currentWorkspaceId": "root",
-    "packageManager": "npm"
-  },
-  "cacheDir": "/ROOT/test/__fixtures__/node-task/node_modules/.cache/nadle",
-  "minWorkers": 1
-}
+[info] Resolved options: {options}
 [info] Detected environments: { CI: false, TEST: true }
 [info] Execution started
 [info] Scheduled tasks: root:pass

--- a/packages/nadle/test/__snapshots__/builtin-tasks/npm-task.test.ts.snap
+++ b/packages/nadle/test/__snapshots__/builtin-tasks/npm-task.test.ts.snap
@@ -11,61 +11,7 @@ Command: /ROOT/lib/cli.js --max-workers 1 --no-footer pass --log-level info
 
 [info] Using 1 worker for task execution
 [info] Project directory: /ROOT/test/__fixtures__/npm-task
-[info] Resolved options: {
-  "why": false,
-  "cache": true,
-  "watch": false,
-  "summary": false,
-  "parallel": false,
-  "logLevel": "info",
-  "cleanCache": false,
-  "showConfig": false,
-  "maxCacheEntries": 5,
-  "reporter": "default",
-  "implicitDependencies": true,
-  "excludedTasks": [],
-  "passthroughArgs": [],
-  "footer": false,
-  "isWorkerThread": false,
-  "tasks": [
-    {
-      "corrected": false,
-      "rawInput": "pass",
-      "taskId": "root:pass"
-    }
-  ],
-  "maxWorkers": 1,
-  "list": false,
-  "dryRun": false,
-  "stacktrace": false,
-  "listWorkspaces": false,
-  "project": {
-    "rootWorkspace": {
-      "label": "",
-      "packageJson": {
-        "name": "@nadle/internal-nadle-test-fixtures-npm-task",
-        "type": "module",
-        "private": true,
-        "dependencies": {
-          "nadle": "workspace:*"
-        },
-        "nadle": {
-          "root": true
-        }
-      },
-      "absolutePath": "/ROOT/test/__fixtures__/npm-task",
-      "dependencies": [],
-      "relativePath": ".",
-      "configFilePath": "/ROOT/test/__fixtures__/npm-task/nadle.config.ts",
-      "id": "root"
-    },
-    "workspaces": [],
-    "currentWorkspaceId": "root",
-    "packageManager": "npm"
-  },
-  "cacheDir": "/ROOT/test/__fixtures__/npm-task/node_modules/.cache/nadle",
-  "minWorkers": 1
-}
+[info] Resolved options: {options}
 [info] Detected environments: { CI: false, TEST: true }
 [info] Execution started
 [info] Scheduled tasks: root:pass

--- a/packages/nadle/test/__snapshots__/builtin-tasks/npx-task.test.ts.snap
+++ b/packages/nadle/test/__snapshots__/builtin-tasks/npx-task.test.ts.snap
@@ -11,61 +11,7 @@ Command: /ROOT/lib/cli.js --max-workers 1 --no-footer pass --log-level info
 
 [info] Using 1 worker for task execution
 [info] Project directory: /ROOT/test/__fixtures__/npx-task
-[info] Resolved options: {
-  "why": false,
-  "cache": true,
-  "watch": false,
-  "summary": false,
-  "parallel": false,
-  "logLevel": "info",
-  "cleanCache": false,
-  "showConfig": false,
-  "maxCacheEntries": 5,
-  "reporter": "default",
-  "implicitDependencies": true,
-  "excludedTasks": [],
-  "passthroughArgs": [],
-  "footer": false,
-  "isWorkerThread": false,
-  "tasks": [
-    {
-      "corrected": false,
-      "rawInput": "pass",
-      "taskId": "root:pass"
-    }
-  ],
-  "maxWorkers": 1,
-  "list": false,
-  "dryRun": false,
-  "stacktrace": false,
-  "listWorkspaces": false,
-  "project": {
-    "rootWorkspace": {
-      "label": "",
-      "packageJson": {
-        "name": "@nadle/internal-nadle-test-fixtures-npx-task",
-        "type": "module",
-        "private": true,
-        "dependencies": {
-          "nadle": "workspace:*"
-        },
-        "nadle": {
-          "root": true
-        }
-      },
-      "absolutePath": "/ROOT/test/__fixtures__/npx-task",
-      "dependencies": [],
-      "relativePath": ".",
-      "configFilePath": "/ROOT/test/__fixtures__/npx-task/nadle.config.ts",
-      "id": "root"
-    },
-    "workspaces": [],
-    "currentWorkspaceId": "root",
-    "packageManager": "npm"
-  },
-  "cacheDir": "/ROOT/test/__fixtures__/npx-task/node_modules/.cache/nadle",
-  "minWorkers": 1
-}
+[info] Resolved options: {options}
 [info] Detected environments: { CI: false, TEST: true }
 [info] Execution started
 [info] Scheduled tasks: root:pass

--- a/packages/nadle/test/__snapshots__/builtin-tasks/pnpm-task.test.ts.snap
+++ b/packages/nadle/test/__snapshots__/builtin-tasks/pnpm-task.test.ts.snap
@@ -11,61 +11,7 @@ Command: /ROOT/lib/cli.js --max-workers 1 --no-footer pass --log-level info
 
 [info] Using 1 worker for task execution
 [info] Project directory: /ROOT/test/__fixtures__/pnpm-task
-[info] Resolved options: {
-  "why": false,
-  "cache": true,
-  "watch": false,
-  "summary": false,
-  "parallel": false,
-  "logLevel": "info",
-  "cleanCache": false,
-  "showConfig": false,
-  "maxCacheEntries": 5,
-  "reporter": "default",
-  "implicitDependencies": true,
-  "excludedTasks": [],
-  "passthroughArgs": [],
-  "footer": false,
-  "isWorkerThread": false,
-  "tasks": [
-    {
-      "corrected": false,
-      "rawInput": "pass",
-      "taskId": "root:pass"
-    }
-  ],
-  "maxWorkers": 1,
-  "list": false,
-  "dryRun": false,
-  "stacktrace": false,
-  "listWorkspaces": false,
-  "project": {
-    "rootWorkspace": {
-      "label": "",
-      "packageJson": {
-        "name": "@nadle/internal-nadle-test-fixtures-pnpm-task",
-        "type": "module",
-        "private": true,
-        "dependencies": {
-          "nadle": "workspace:*"
-        },
-        "nadle": {
-          "root": true
-        }
-      },
-      "absolutePath": "/ROOT/test/__fixtures__/pnpm-task",
-      "dependencies": [],
-      "relativePath": ".",
-      "configFilePath": "/ROOT/test/__fixtures__/pnpm-task/nadle.config.ts",
-      "id": "root"
-    },
-    "workspaces": [],
-    "currentWorkspaceId": "root",
-    "packageManager": "npm"
-  },
-  "cacheDir": "/ROOT/test/__fixtures__/pnpm-task/node_modules/.cache/nadle",
-  "minWorkers": 1
-}
+[info] Resolved options: {options}
 [info] Detected environments: { CI: false, TEST: true }
 [info] Execution started
 [info] Scheduled tasks: root:pass

--- a/packages/nadle/test/__snapshots__/builtin-tasks/pnpx-task.test.ts.snap
+++ b/packages/nadle/test/__snapshots__/builtin-tasks/pnpx-task.test.ts.snap
@@ -11,61 +11,7 @@ Command: /ROOT/lib/cli.js --max-workers 1 --no-footer pass --log-level info
 
 [info] Using 1 worker for task execution
 [info] Project directory: /ROOT/test/__fixtures__/pnpx-task
-[info] Resolved options: {
-  "why": false,
-  "cache": true,
-  "watch": false,
-  "summary": false,
-  "parallel": false,
-  "logLevel": "info",
-  "cleanCache": false,
-  "showConfig": false,
-  "maxCacheEntries": 5,
-  "reporter": "default",
-  "implicitDependencies": true,
-  "excludedTasks": [],
-  "passthroughArgs": [],
-  "footer": false,
-  "isWorkerThread": false,
-  "tasks": [
-    {
-      "corrected": false,
-      "rawInput": "pass",
-      "taskId": "root:pass"
-    }
-  ],
-  "maxWorkers": 1,
-  "list": false,
-  "dryRun": false,
-  "stacktrace": false,
-  "listWorkspaces": false,
-  "project": {
-    "rootWorkspace": {
-      "label": "",
-      "packageJson": {
-        "name": "@nadle/internal-nadle-test-fixtures-pnpx-task",
-        "type": "module",
-        "private": true,
-        "dependencies": {
-          "nadle": "workspace:*"
-        },
-        "nadle": {
-          "root": true
-        }
-      },
-      "absolutePath": "/ROOT/test/__fixtures__/pnpx-task",
-      "dependencies": [],
-      "relativePath": ".",
-      "configFilePath": "/ROOT/test/__fixtures__/pnpx-task/nadle.config.ts",
-      "id": "root"
-    },
-    "workspaces": [],
-    "currentWorkspaceId": "root",
-    "packageManager": "npm"
-  },
-  "cacheDir": "/ROOT/test/__fixtures__/pnpx-task/node_modules/.cache/nadle",
-  "minWorkers": 1
-}
+[info] Resolved options: {options}
 [info] Detected environments: { CI: false, TEST: true }
 [info] Execution started
 [info] Scheduled tasks: root:pass


### PR DESCRIPTION
Closes #656.

## Problem

The info-level `Resolved options: { … }` log embeds the **entire** resolved options object. Every builtin-task test that runs `--log-level info` (node/npm/npx/pnpm/pnpx/delete) snapshotted that full dump — so adding any CLI/resolved option churned 6 unrelated snapshots. When a PR updated its subset but not all of them, `main` went red. This happened **4× this week** (#653 graph, #654 why, #657 watch, + an obsolete-key variant).

## Fix

Redact the dump **body** to `Resolved options: {options}` in the test serializer (`serialize.ts`). Production output is unchanged — only the snapshot assertion becomes option-agnostic. `--show-config` (which asserts the full options dump intentionally, via a different output shape — a bare `stringify`, no `Resolved options:` prefix) is untouched.

Result: a new option now touches **2** focused snapshot files (show-config, config-key — both single files that *should* assert config) instead of **8** scattered ones.

## Diff

+15 / −330 — 330 lines of duplicated option dump removed across 6 builtin-task snapshots, replaced by one `{options}` line each.

## Verification

`CI=true` sweep of builtin-tasks + options: 169 pass (strict mode, catches obsolete keys). `nadle check` + typecheck green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)