### PR TITLE
feat: nadle --explain <task> statically explains a task

### DIFF
--- a/docs/superpowers/specs/2026-06-13-explain-task-design.md
+++ b/docs/superpowers/specs/2026-06-13-explain-task-design.md
@@ -7,8 +7,8 @@
 
 Print a static, human-readable explanation of a single task's place in the graph:
 why it would run (what pulls it in), what depends on it, and what its declared
-inputs are. Complements the runtime cache `--why` (#636) — that explains a *past
-run's* cache outcome; this explains the *static graph* without running anything.
+inputs are. Complements the runtime cache `--why` (#636) — that explains a _past
+run's_ cache outcome; this explains the _static graph_ without running anything.
 
 ## Surface
 
@@ -53,6 +53,7 @@ Inputs:
 ```
 
 Section rules:
+
 - **Why it runs** — every dependency path from a requested root down to the task.
   If the task itself was requested, lead with "Requested directly on the command
   line." If nothing pulls it in and it wasn't requested, say "Nothing requests this
@@ -68,8 +69,8 @@ Section rules:
 Mirror the `--graph` slice (#653), which is the closest existing pattern.
 
 - **`core/options/cli-options.ts`** — add `explain` option: `{ key: "explain",
-  options: { type: "string", description: "Explain why a task runs, what depends on
-  it, and its inputs" } }`. Group under "Execution options:" in `cli.ts`.
+options: { type: "string", description: "Explain why a task runs, what depends on
+it, and its inputs" } }`. Group under "Execution options:" in `cli.ts`.
 - **`core/options/types.ts`** — `NadleCLIOptions.explain?: string`; omit `explain`
   from the `Required<>` in `NadleResolvedOptions` and redeclare `explain?: string`
   (same shape as `graph`).
@@ -80,18 +81,18 @@ Mirror the `--graph` slice (#653), which is the closest existing pattern.
   references) so it is unit-testable in isolation, exactly like `renderTaskGraph`.
   ```ts
   export namespace TaskExplanation {
-    export interface Props {
-      readonly taskId: string;
-      readonly requestedDirectly: boolean;
-      /** Each path is root → … → taskId (labels), excluding the direct-request case. */
-      readonly pullPaths: readonly string[][];
-      /** Direct dependents (labels). */
-      readonly dependents: readonly string[];
-      readonly inputs: readonly string[];
-      readonly cachingEnabled: boolean;
-    }
+  	export interface Props {
+  		readonly taskId: string;
+  		readonly requestedDirectly: boolean;
+  		/** Each path is root → … → taskId (labels), excluding the direct-request case. */
+  		readonly pullPaths: readonly string[][];
+  		/** Direct dependents (labels). */
+  		readonly dependents: readonly string[];
+  		readonly inputs: readonly string[];
+  		readonly cachingEnabled: boolean;
+  	}
   }
-  export function renderTaskExplanation(props: TaskExplanation.Props): string
+  export function renderTaskExplanation(props: TaskExplanation.Props): string;
   ```
 - **`core/handlers/explain-handler.ts`** — new `ExplainHandler extends BaseHandler`.
   `canHandle()` → `this.context.options.explain !== undefined`. `handle()`:

--- a/docs/superpowers/specs/2026-06-13-explain-task-design.md
+++ b/docs/superpowers/specs/2026-06-13-explain-task-design.md
@@ -1,0 +1,152 @@
+# `nadle --explain <task>` Design
+
+**Status:** Approved (self-driven; user directed "do features, don't ask").
+**Issue:** [#638](https://github.com/nadlejs/nadle/issues/638) — explain why a task will run and what depends on it.
+
+## Goal
+
+Print a static, human-readable explanation of a single task's place in the graph:
+why it would run (what pulls it in), what depends on it, and what its declared
+inputs are. Complements the runtime cache `--why` (#636) — that explains a *past
+run's* cache outcome; this explains the *static graph* without running anything.
+
+## Surface
+
+A flag, not a positional subcommand:
+
+```
+nadle --explain <task>
+```
+
+**Why a flag, not `nadle why <task>`** (the issue's original spelling): the CLI is a
+single yargs `$0 [tasks...]` command — every other mode is a flag (`--graph`,
+`--why`, `--list`, `--show-config`). A real `why` subcommand would fight the `$0`
+default-command and collide with a user task literally named `why`. A flag is
+collision-free and consistent with the shipped `--graph`/`--why` flag style.
+`--explain` avoids overloading the existing boolean `--why`.
+
+The flag takes a task name in the same syntax accepted positionally
+(`build`, `pkg:build`, `//root:build`). It resolves via `TaskRegistry.parse`,
+which already throws `TaskNotFoundError` with did-you-mean suggestions on a miss.
+
+## Output
+
+Three sections, plain text (tinyrainbow styling like `task-graph.ts`):
+
+```
+Task: //root:build
+
+Why it runs:
+  Requested directly on the command line.
+  Also pulled in by:
+    check → build
+    publish → bundle → build
+
+What depends on it:
+  check
+  publish (via bundle)
+
+Inputs:
+  src/**/*.ts
+  package.json
+  (caching enabled — a change to any input invalidates the cache)
+```
+
+Section rules:
+- **Why it runs** — every dependency path from a requested root down to the task.
+  If the task itself was requested, lead with "Requested directly on the command
+  line." If nothing pulls it in and it wasn't requested, say "Nothing requests this
+  task; run it explicitly with `nadle <task>`."
+- **What depends on it** — direct dependents from `dependentsGraph`. Empty → "Nothing
+  depends on this task."
+- **Inputs** — declared input globs from `task.configResolver().inputs`. None →
+  "No declared inputs (always runs; not cacheable)." Note whether caching is enabled
+  for the task. No runtime fingerprint — that is `--why`'s job.
+
+## Architecture
+
+Mirror the `--graph` slice (#653), which is the closest existing pattern.
+
+- **`core/options/cli-options.ts`** — add `explain` option: `{ key: "explain",
+  options: { type: "string", description: "Explain why a task runs, what depends on
+  it, and its inputs" } }`. Group under "Execution options:" in `cli.ts`.
+- **`core/options/types.ts`** — `NadleCLIOptions.explain?: string`; omit `explain`
+  from the `Required<>` in `NadleResolvedOptions` and redeclare `explain?: string`
+  (same shape as `graph`).
+- **`core/options/options-resolver.ts`** — no default needed (optional, undefined
+  when absent), same as `configKey`/`graph`.
+- **`core/reporting/task-explanation.ts`** — new pure function
+  `renderTaskExplanation(props): string`. Props is plain data (no scheduler/registry
+  references) so it is unit-testable in isolation, exactly like `renderTaskGraph`.
+  ```ts
+  export namespace TaskExplanation {
+    export interface Props {
+      readonly taskId: string;
+      readonly requestedDirectly: boolean;
+      /** Each path is root → … → taskId (labels), excluding the direct-request case. */
+      readonly pullPaths: readonly string[][];
+      /** Direct dependents (labels). */
+      readonly dependents: readonly string[];
+      readonly inputs: readonly string[];
+      readonly cachingEnabled: boolean;
+    }
+  }
+  export function renderTaskExplanation(props: TaskExplanation.Props): string
+  ```
+- **`core/handlers/explain-handler.ts`** — new `ExplainHandler extends BaseHandler`.
+  `canHandle()` → `this.context.options.explain !== undefined`. `handle()`:
+  1. resolve the explain arg via `taskRegistry.parse(explain, rootWorkspaceId)`;
+  2. `scheduler.init()` over all tasks (no roots → full graph);
+  3. walk `dependencyGraph`/`dependentsGraph` to build `pullPaths` (BFS/DFS from each
+     requested root to the target) and direct `dependents`;
+  4. read declared inputs + caching flag from the task config;
+  5. `logger.log(renderTaskExplanation(...))`.
+- **`core/handlers/index.ts`** — register `ExplainHandler` before `ExecuteHandler`,
+  next to `GraphHandler`.
+
+`pullPaths` computation lives in the handler (it needs scheduler/registry); the
+renderer stays pure.
+
+### "Requested roots" for pull paths
+
+When `--explain` is used, the user may also pass positional tasks
+(`nadle build --explain compile`). Those positional tasks are the requested roots
+for the "why it runs" paths. If no positional tasks are given, fall back to all
+top-level tasks as roots so the explanation is still useful (every chain that
+reaches the target). Document this in the help/description is unnecessary; behavior
+is intuitive.
+
+## Errors
+
+- Unknown task → `TaskRegistry.parse` already throws `TaskNotFoundError` with
+  suggestions; let it propagate (consistent with positional task resolution).
+- No task arg (`--explain` with empty string) → yargs gives `""`; treat as a usage
+  error: `logger.error` an explanation that `--explain` needs a task name. (Or rely
+  on yargs requiring a value for a string option — verify in the harness.)
+
+## Testing
+
+Integration-first, matching `test/options/graph.test.ts`:
+
+- **`test/options/explain.test.ts`** — spawn CLI against a fixture with a known
+  graph; assert the three sections appear with expected task names. Cover: direct
+  request, transitive pull-in, a leaf with dependents, a task with inputs vs without,
+  unknown-task error (suggestions).
+- **`test/unit/task-explanation.test.ts`** — unit-test `renderTaskExplanation` with
+  hand-built props for each section's empty/non-empty branches. Pure function, no
+  spawn.
+
+## Out of scope (YAGNI)
+
+- No `mermaid`/JSON output format — plain text only. (`--graph` covers machine
+  formats.)
+- No runtime cache fingerprint in the Inputs section — that is `--why`.
+- No multi-task `--explain a --explain b` — one task per invocation.
+
+## Snapshot tax
+
+The new resolved option `explain` enters the resolved-options object, but #658's
+serializer redaction (`Resolved options: {options}`) already shields builtin-task
+and most snapshots. Still regenerate the option-dump snapshots that assert the dump
+intentionally — `show-config` and `config-key` — and run each alone with `-u` to
+prune obsolete keys, then verify with `CI=true`. (Per MEMORY.md snapshot gotcha.)

--- a/packages/docs/docs/config-reference.md
+++ b/packages/docs/docs/config-reference.md
@@ -106,6 +106,19 @@ nadle build --graph
 nadle build --graph=mermaid
 ```
 
+### `--explain`
+
+- **Type:** `string` (a task name)
+
+Explain a single task without running it: why it would run (the dependency paths that pull it in,
+or whether it was requested directly), what depends on it, and its declared inputs (plus whether
+caching is enabled). Complements `--why`, which explains a past run's cache outcome — `--explain`
+is purely static.
+
+```bash
+nadle build --explain install
+```
+
 ### `--why`
 
 - **Type:** `boolean`

--- a/packages/nadle/src/cli.ts
+++ b/packages/nadle/src/cli.ts
@@ -19,6 +19,7 @@ const argv = yargs(hideBin(Process.argv))
 		[CLIOptions.watch.key]: CLIOptions.watch.options,
 		[CLIOptions.dryRun.key]: CLIOptions.dryRun.options,
 		[CLIOptions.footer.key]: CLIOptions.footer.options,
+		[CLIOptions.explain.key]: CLIOptions.explain.options,
 		[CLIOptions.exclude.key]: CLIOptions.exclude.options,
 		[CLIOptions.noCache.key]: CLIOptions.noCache.options,
 		[CLIOptions.summary.key]: CLIOptions.summary.options,
@@ -49,6 +50,7 @@ const argv = yargs(hideBin(Process.argv))
 			CLIOptions.listWorkspaces.key,
 			CLIOptions.dryRun.key,
 			CLIOptions.watch.key,
+			CLIOptions.explain.key,
 			CLIOptions.showConfig.key,
 			CLIOptions.configKey.key,
 			CLIOptions.stacktrace.key

--- a/packages/nadle/src/core/handlers/explain-handler.ts
+++ b/packages/nadle/src/core/handlers/explain-handler.ts
@@ -1,0 +1,88 @@
+import { ROOT_WORKSPACE_ID } from "@nadle/project-resolver";
+
+import { BaseHandler } from "./base-handler.js";
+import { MaybeArray } from "../utilities/maybe-array.js";
+import { type TaskScheduler } from "../engine/task-scheduler.js";
+import { renderTaskExplanation } from "../reporting/task-explanation.js";
+import { type TaskConfiguration } from "../interfaces/task-configuration.js";
+
+export class ExplainHandler extends BaseHandler {
+	public readonly name = "explain";
+	public readonly description = "Explains why a task runs, what depends on it, and its inputs, without running it.";
+
+	public canHandle(): boolean {
+		return this.context.options.explain !== undefined;
+	}
+
+	public handle(): void {
+		const input = this.context.options.explain;
+
+		if (input === undefined || input === "") {
+			this.context.logger.error("`--explain` needs a task name, e.g. `nadle --explain build`.");
+
+			return;
+		}
+
+		const taskId = this.context.taskRegistry.parse(input, ROOT_WORKSPACE_ID);
+
+		// Seed the scheduler with the requested tasks when present, otherwise the whole
+		// task set, so the target and its relations always exist in the analyzed graph.
+		const requestedRoots = this.context.options.tasks.map(({ taskId: id }) => id);
+		const seed = requestedRoots.length > 0 ? requestedRoots : this.context.taskRegistry.tasks.map((task) => task.id);
+		const scheduler = this.context.taskScheduler.init(seed);
+
+		const task = this.context.taskRegistry.getTaskById(taskId);
+		const config = task.configResolver();
+
+		this.context.logger.log(
+			renderTaskExplanation({
+				label: task.label,
+				inputs: this.collectInputs(config.inputs),
+				cachingEnabled: this.context.options.cache,
+				requestedDirectly: requestedRoots.includes(taskId),
+				dependents: this.collectDependents(scheduler, taskId),
+				pullPaths: this.collectPullPaths(scheduler, requestedRoots, taskId)
+			})
+		);
+	}
+
+	private collectDependents(scheduler: TaskScheduler, taskId: string): string[] {
+		return scheduler.scheduledTask
+			.filter((id) => scheduler.getDirectDependencies(id).has(taskId))
+			.map((id) => this.context.taskRegistry.getTaskById(id).label);
+	}
+
+	private collectPullPaths(scheduler: TaskScheduler, roots: readonly string[], target: string): string[][] {
+		const paths: string[][] = [];
+
+		const walk = (id: string, trail: string[]): void => {
+			const nextTrail = [...trail, id];
+
+			if (id === target && trail.length > 0) {
+				paths.push(nextTrail.map((stepId) => this.context.taskRegistry.getTaskById(stepId).label));
+
+				return;
+			}
+
+			for (const dep of scheduler.getDirectDependencies(id)) {
+				walk(dep, nextTrail);
+			}
+		};
+
+		for (const root of roots) {
+			if (root !== target) {
+				walk(root, []);
+			}
+		}
+
+		return paths;
+	}
+
+	private collectInputs(inputs: TaskConfiguration["inputs"]): string[] {
+		if (inputs === undefined) {
+			return [];
+		}
+
+		return MaybeArray.toArray(inputs).flatMap((declaration) => declaration.patterns.map((pattern) => `${declaration.type}: ${pattern}`));
+	}
+}

--- a/packages/nadle/src/core/handlers/index.ts
+++ b/packages/nadle/src/core/handlers/index.ts
@@ -2,6 +2,7 @@ import { ListHandler } from "./list-handler.js";
 import { GraphHandler } from "./graph-handler.js";
 import { WatchHandler } from "./watch-handler.js";
 import { DryRunHandler } from "./dry-run-handler.js";
+import { ExplainHandler } from "./explain-handler.js";
 import { ExecuteHandler } from "./execute-handler.js";
 import { CleanCacheHandler } from "./clean-cache-handler.js";
 import { ShowConfigHandler } from "./show-config-handler.js";
@@ -13,6 +14,7 @@ export const Handlers: HandlerConstructor[] = [
 	ListWorkspacesHandler,
 	CleanCacheHandler,
 	GraphHandler,
+	ExplainHandler,
 	DryRunHandler,
 	ShowConfigHandler,
 	WatchHandler,

--- a/packages/nadle/src/core/options/cli-options.ts
+++ b/packages/nadle/src/core/options/cli-options.ts
@@ -70,6 +70,13 @@ export const CLIOptions = {
 			description: "Print the task dependency graph instead of executing (tree or mermaid)"
 		}
 	},
+	explain: {
+		key: "explain",
+		options: {
+			type: "string",
+			description: "Explain why a task runs, what depends on it, and its inputs, instead of executing"
+		}
+	},
 	why: {
 		key: "why",
 		options: {

--- a/packages/nadle/src/core/options/types.ts
+++ b/packages/nadle/src/core/options/types.ts
@@ -53,6 +53,8 @@ export interface NadleCLIOptions extends NadleBaseOptions {
 	readonly dryRun: boolean;
 	/** Re-run the requested tasks whenever their declared inputs change. */
 	readonly watch?: boolean;
+	/** Explain why a task runs, what depends on it, and its declared inputs, instead of executing. */
+	readonly explain?: string;
 	/** Show summary after execution. */
 	readonly summary?: boolean;
 	/** Print the task dependency graph instead of executing. "tree" (default) or "mermaid". */
@@ -90,13 +92,16 @@ export type AliasOption = Record<string, string> | ((workspacePath: string) => s
  * Fully resolved Nadle options, including required fields and project reference.
  */
 export interface NadleResolvedOptions extends Required<
-	Omit<NadleCLIOptions, "maxWorkers" | "minWorkers" | "configKey" | "configFile" | "tasks" | "excludedTasks" | "graph">
+	Omit<NadleCLIOptions, "maxWorkers" | "minWorkers" | "configKey" | "configFile" | "tasks" | "excludedTasks" | "graph" | "explain">
 > {
 	/** Project information. */
 	readonly project: Project;
 
 	/** Task graph output format, when --graph was requested. */
 	readonly graph?: "tree" | "mermaid";
+
+	/** Task name to explain, when --explain was requested. */
+	readonly explain?: string;
 
 	/** Minimum number of worker threads (resolved as number). */
 	readonly minWorkers: number;

--- a/packages/nadle/src/core/reporting/task-explanation.ts
+++ b/packages/nadle/src/core/reporting/task-explanation.ts
@@ -1,0 +1,81 @@
+import c from "tinyrainbow";
+
+export namespace TaskExplanation {
+	export interface Props {
+		/** Display label of the task being explained. */
+		readonly label: string;
+		/** Whether caching is enabled for this task. */
+		readonly cachingEnabled: boolean;
+		/** Declared input patterns of the task. */
+		readonly inputs: readonly string[];
+		/** Whether the task was requested directly on the command line. */
+		readonly requestedDirectly: boolean;
+		/** Labels of tasks that directly depend on this task. */
+		readonly dependents: readonly string[];
+		/** Dependency paths (root → … → task, as labels) that transitively pull the task in. */
+		readonly pullPaths: readonly (readonly string[])[];
+	}
+}
+
+/**
+ * Render a static explanation of a single task: why it would run, what depends on
+ * it, and its declared inputs. Pure — takes plain data so it can be unit-tested
+ * without the scheduler or registry.
+ */
+export function renderTaskExplanation(props: TaskExplanation.Props): string {
+	const lines: string[] = [`${c.bold("Task:")} ${props.label}`, ""];
+
+	lines.push(c.bold("Why it runs:"));
+	lines.push(...renderWhyItRuns(props));
+	lines.push("");
+
+	lines.push(c.bold("What depends on it:"));
+	lines.push(...renderDependents(props.dependents));
+	lines.push("");
+
+	lines.push(c.bold("Inputs:"));
+	lines.push(...renderInputs(props));
+
+	return lines.join("\n");
+}
+
+function renderWhyItRuns({ pullPaths, requestedDirectly }: TaskExplanation.Props): string[] {
+	const lines: string[] = [];
+
+	if (requestedDirectly) {
+		lines.push("  Requested directly on the command line.");
+	}
+
+	if (pullPaths.length > 0) {
+		lines.push(requestedDirectly ? "  Also pulled in by:" : "  Pulled in by:");
+		lines.push(...pullPaths.map((path) => `    ${path.join(" → ")}`));
+	}
+
+	if (lines.length === 0) {
+		lines.push(c.dim("  Nothing requests this task; run it explicitly with `nadle <task>`."));
+	}
+
+	return lines;
+}
+
+function renderDependents(dependents: readonly string[]): string[] {
+	if (dependents.length === 0) {
+		return [c.dim("  Nothing depends on this task.")];
+	}
+
+	return dependents.map((dependent) => `  ${dependent}`);
+}
+
+function renderInputs({ inputs, cachingEnabled }: TaskExplanation.Props): string[] {
+	if (inputs.length === 0) {
+		return [c.dim("  No declared inputs (always runs; not cacheable).")];
+	}
+
+	const lines = inputs.map((input) => `  ${input}`);
+
+	lines.push(
+		cachingEnabled ? c.dim("  (caching enabled — a change to any input invalidates the cache)") : c.dim("  (caching disabled — the task always runs)")
+	);
+
+	return lines;
+}

--- a/packages/nadle/test/__snapshots__/options/help.test.ts.snap
+++ b/packages/nadle/test/__snapshots__/options/help.test.ts.snap
@@ -22,6 +22,8 @@ Execution options:
   -m, --dry-run          Run specified tasks in dry run mode              [boolean] [default: false]
   -w, --watch            Re-run the requested tasks when their inputs change
                                                                           [boolean] [default: false]
+      --explain          Explain why a task runs, what depends on it, and its inputs, instead of
+                         executing                                                          [string]
       --show-config      Print the resolved configuration                 [boolean] [default: false]
       --config-key       Path to a specific resolved configuration value, using dot/bracket notation
                                                                        [string] [default: undefined]

--- a/packages/nadle/test/options/explain.test.ts
+++ b/packages/nadle/test/options/explain.test.ts
@@ -1,0 +1,84 @@
+// cspell:ignore biuld
+import { it, expect, describe } from "vitest";
+import { fixture, getStdout, getStderr, readConfig, withGeneratedFixture } from "setup";
+
+const dependsOnFiles = fixture()
+	.packageJson("explain")
+	.configRaw(await readConfig("depends-on.ts"))
+	.build();
+
+const inputsFiles = fixture()
+	.packageJson("explain-inputs")
+	.file("input.txt", "hello")
+	.configRaw(await readConfig("clean-cache.ts"))
+	.build();
+
+describe("--explain", () => {
+	it("explains a directly requested task", () =>
+		withGeneratedFixture({
+			files: dependsOnFiles,
+			testFn: async ({ exec }) => {
+				const stdout = await getStdout(exec`build --explain build`);
+
+				expect(stdout).toContain("Task:");
+				expect(stdout).toContain("Why it runs:");
+				expect(stdout).toContain("Requested directly on the command line.");
+				expect(stdout).toContain("What depends on it:");
+				expect(stdout).toContain("Nothing depends on this task.");
+			}
+		}));
+
+	it("explains why a transitive task is pulled in", () =>
+		withGeneratedFixture({
+			files: dependsOnFiles,
+			testFn: async ({ exec }) => {
+				const stdout = await getStdout(exec`build --explain install`);
+
+				// install is pulled in through a chain that starts at the requested root.
+				expect(stdout).toContain("Pulled in by:");
+				expect(stdout).toContain("build");
+				expect(stdout).toContain("install");
+				expect(stdout).toContain("→");
+
+				// Its direct dependents are listed.
+				expect(stdout).toContain("What depends on it:");
+				expect(stdout).toContain("compileTs");
+				expect(stdout).toContain("compileSvg");
+				expect(stdout).toContain("test");
+			}
+		}));
+
+	it("lists declared inputs and caching state", () =>
+		withGeneratedFixture({
+			files: inputsFiles,
+			testFn: async ({ exec }) => {
+				const stdout = await getStdout(exec`build --explain build`);
+
+				expect(stdout).toContain("Inputs:");
+				expect(stdout).toContain("file: input.txt");
+				expect(stdout).toContain("caching enabled");
+			}
+		}));
+
+	it("does not execute tasks", () =>
+		withGeneratedFixture({
+			files: dependsOnFiles,
+			testFn: async ({ exec }) => {
+				const stdout = await getStdout(exec`build --explain build`);
+
+				expect(stdout).not.toContain("STARTED");
+				expect(stdout).not.toContain("DONE");
+			}
+		}));
+
+	it("errors for an unknown task", () =>
+		withGeneratedFixture({
+			files: dependsOnFiles,
+			testFn: async ({ exec }) => {
+				const stderr = await getStderr(exec`build --explain biuld`);
+
+				expect(stderr).toContain("biuld");
+				expect(stderr).toContain("not found");
+			}
+		}));
+});

--- a/packages/nadle/test/unit/task-explanation.test.ts
+++ b/packages/nadle/test/unit/task-explanation.test.ts
@@ -1,0 +1,66 @@
+import stripAnsi from "strip-ansi";
+import { it, expect, describe } from "vitest";
+
+import { type TaskExplanation, renderTaskExplanation } from "../../src/core/reporting/task-explanation.js";
+
+const base: TaskExplanation.Props = {
+	inputs: [],
+	pullPaths: [],
+	label: "build",
+	dependents: [],
+	cachingEnabled: true,
+	requestedDirectly: false
+};
+
+const render = (props: Partial<TaskExplanation.Props>) => stripAnsi(renderTaskExplanation({ ...base, ...props }));
+
+describe.concurrent("renderTaskExplanation", () => {
+	it("always shows the task label and the three section headers", () => {
+		const out = render({});
+
+		expect(out).toContain("Task: build");
+		expect(out).toContain("Why it runs:");
+		expect(out).toContain("What depends on it:");
+		expect(out).toContain("Inputs:");
+	});
+
+	it("notes a directly requested task", () => {
+		expect(render({ requestedDirectly: true })).toContain("Requested directly on the command line.");
+	});
+
+	it("falls back when nothing requests the task", () => {
+		expect(render({})).toContain("Nothing requests this task");
+	});
+
+	it("renders pull paths with arrows", () => {
+		const out = render({ pullPaths: [["build", "test", "install"]] });
+
+		expect(out).toContain("Pulled in by:");
+		expect(out).toContain("build → test → install");
+	});
+
+	it("uses 'Also pulled in by' when also requested directly", () => {
+		const out = render({ requestedDirectly: true, pullPaths: [["a", "b"]] });
+
+		expect(out).toContain("Requested directly on the command line.");
+		expect(out).toContain("Also pulled in by:");
+	});
+
+	it("lists dependents or notes their absence", () => {
+		expect(render({ dependents: ["check", "publish"] })).toMatch(/check[\s\S]*publish/);
+		expect(render({ dependents: [] })).toContain("Nothing depends on this task.");
+	});
+
+	it("lists inputs with a caching note", () => {
+		const enabled = render({ cachingEnabled: true, inputs: ["file: src/index.ts"] });
+		expect(enabled).toContain("file: src/index.ts");
+		expect(enabled).toContain("caching enabled");
+
+		const disabled = render({ cachingEnabled: false, inputs: ["file: src/index.ts"] });
+		expect(disabled).toContain("caching disabled");
+	});
+
+	it("notes when no inputs are declared", () => {
+		expect(render({ inputs: [] })).toContain("No declared inputs");
+	});
+});

--- a/spec/09-cli.md
+++ b/spec/09-cli.md
@@ -62,21 +62,25 @@ Rules:
 | `--list`            | `-l`  | boolean  | `false` | List all available tasks.                                           |
 | `--list-workspaces` |       | boolean  | `false` | List all available workspaces.                                      |
 | `--dry-run`         | `-m`  | boolean  | `false` | Show execution plan without running tasks.                          |
+| `--watch`           | `-w`  | boolean  | `false` | Re-run the requested tasks when their declared inputs change.       |
+| `--graph`           |       | string   | `tree`  | Print the dependency graph instead of executing. `tree`/`mermaid`.  |
+| `--explain`         |       | string   |         | Explain a single task (why it runs, dependents, inputs); no run.    |
 | `--show-config`     |       | boolean  | `false` | Print the resolved configuration.                                   |
 | `--config-key`      |       | string   |         | Path to a specific config value (dot/bracket notation).             |
 | `--stacktrace`      |       | boolean  | `false` | Print full stacktrace on error.                                     |
 
 ### General Options
 
-| Flag            | Alias | Type    | Default                        | Description                                              |
-| --------------- | ----- | ------- | ------------------------------ | -------------------------------------------------------- |
-| `--config`      | `-c`  | string  | `nadle.config.{js,mjs,ts,mts}` | Path to config file.                                     |
-| `--cache-dir`   |       | string  | `<projectDir>/.nadle`          | Directory to store cache results.                        |
-| `--log-level`   |       | string  | `"log"`                        | Logging level. Choices: `error`, `log`, `info`, `debug`. |
-| `--min-workers` |       | string  | `availableParallelism - 1`     | Minimum workers (integer or percentage).                 |
-| `--max-workers` |       | string  | `availableParallelism - 1`     | Maximum workers (integer or percentage).                 |
-| `--footer`      |       | boolean | `!isCI && isTTY`               | Enable the live progress footer during execution.        |
-| `--summary`     |       | boolean | `false`                        | Print a task execution summary at the end of the run.    |
+| Flag            | Alias | Type    | Default                        | Description                                               |
+| --------------- | ----- | ------- | ------------------------------ | --------------------------------------------------------- |
+| `--config`      | `-c`  | string  | `nadle.config.{js,mjs,ts,mts}` | Path to config file.                                      |
+| `--cache-dir`   |       | string  | `<projectDir>/.nadle`          | Directory to store cache results.                         |
+| `--log-level`   |       | string  | `"log"`                        | Logging level. Choices: `error`, `log`, `info`, `debug`.  |
+| `--min-workers` |       | string  | `availableParallelism - 1`     | Minimum workers (integer or percentage).                  |
+| `--max-workers` |       | string  | `availableParallelism - 1`     | Maximum workers (integer or percentage).                  |
+| `--footer`      |       | boolean | `!isCI && isTTY`               | Enable the live progress footer during execution.         |
+| `--summary`     |       | boolean | `false`                        | Print a task execution summary at the end of the run.     |
+| `--why`         |       | boolean | `false`                        | Explain each task's cache outcome (hit/miss and changes). |
 
 ### Miscellaneous
 
@@ -94,9 +98,12 @@ After options are resolved, Nadle selects a handler using a **first-match-wins**
 | 1        | **List**           | `--list` is `true`               |
 | 2        | **ListWorkspaces** | `--list-workspaces` is `true`    |
 | 3        | **CleanCache**     | `--clean-cache` is `true`        |
-| 4        | **DryRun**         | `--dry-run` is `true`            |
-| 5        | **ShowConfig**     | `--show-config` is `true`        |
-| 6        | **Execute**        | Always matches (default handler) |
+| 4        | **Graph**          | `--graph` is set                 |
+| 5        | **Explain**        | `--explain` is set               |
+| 6        | **DryRun**         | `--dry-run` is `true`            |
+| 7        | **ShowConfig**     | `--show-config` is `true`        |
+| 8        | **Watch**          | `--watch` is `true`              |
+| 9        | **Execute**        | Always matches (default handler) |
 
 Each handler is instantiated and its `canHandle()` method is checked. The first handler
 that returns `true` has its `handle()` method invoked. Only one handler runs per

--- a/spec/CHANGELOG.md
+++ b/spec/CHANGELOG.md
@@ -8,6 +8,17 @@ Versioning follows [Semantic Versioning](https://semver.org/):
 - **MINOR**: New concept, new section, or materially expanded rules
 - **PATCH**: Clarifications, corrections, wording improvements
 
+## 3.3.0 — 2026-06-13
+
+### Added
+
+- 09-cli: Document the introspection flags and their handlers, which had been
+  implemented but not yet specified — `--watch` (re-run on input change), `--graph`
+  (`tree`/`mermaid` dependency graph), `--explain` (static single-task explanation:
+  why it runs, dependents, inputs), and `--why` (per-task cache-outcome explanation).
+  Handler-chain table updated to the actual order: Graph and Explain run before
+  DryRun/ShowConfig; Watch runs before the default Execute handler.
+
 ## 3.2.0 — 2026-06-11
 
 ### Added

--- a/spec/README.md
+++ b/spec/README.md
@@ -1,6 +1,6 @@
 # Nadle Specification
 
-**Version**: 3.2.0
+**Version**: 3.3.0
 
 This directory contains the language-agnostic specification for Nadle, a type-safe,
 Gradle-inspired task runner for Node.js.


### PR DESCRIPTION
## Summary

Adds a `--explain <task>` flag that statically explains a single task without running it:

- **Why it runs** — the dependency paths that pull the task in (or whether it was requested directly).
- **What depends on it** — its direct dependents.
- **Inputs** — the task's declared input patterns plus whether caching is enabled.

Complements the runtime cache `--why` (#636), which explains a *past run's* cache outcome; `--explain` is purely static graph introspection.

```bash
nadle build --explain install
```

## Design notes

- Implemented as a **flag**, not a `nadle why <task>` positional subcommand: a `why` subcommand would collide with a task literally named `why` and fight yargs' `$0` default command. The flag is collision-free and consistent with the shipped `--graph`/`--why` flags.
- A pure `renderTaskExplanation()` (mirroring `renderTaskGraph`) keeps formatting unit-testable; the new `ExplainHandler` resolves the task via `TaskRegistry.parse` (free did-you-mean on a miss), walks the scheduler graph for pull-paths and dependents, and reads declared inputs.

## Spec sync

`spec/09-cli.md` bumped to **3.3.0**: the introspection flags `--watch`, `--graph`, `--why`, `--explain` and the handler-chain order had been implemented but never specified. This PR documents all of them.

## Tests

- `test/options/explain.test.ts` — integration: direct request, transitive pull-in, dependents, inputs + caching note, unknown-task error.
- `test/unit/task-explanation.test.ts` — unit: every section's empty/non-empty branch on the pure renderer.

Closes #638.

🤖 Generated with [Claude Code](https://claude.com/claude-code)