### PR TITLE
test: fix help snapshot for the new --summary description

### DIFF
--- a/packages/nadle/test/__snapshots__/options/help.test.ts.snap
+++ b/packages/nadle/test/__snapshots__/options/help.test.ts.snap
@@ -43,8 +43,8 @@ General options:
                                                    [string] [default: Os.availableParallelism() - 1]
       --footer       Enables the in-progress summary footer during task execution
                                                                  [boolean] [default: !isCI && isTTY]
-      --summary      Print a summary of executed tasks at the end of the run
-                                                                          [boolean] [default: false]
+      --summary      Print a summary at the end of the run: task durations, critical path, and
+                     cache-miss hotspots                                  [boolean] [default: false]
       --why          Explain each task's cache outcome (hit/miss and what changed)
                                                                           [boolean] [default: false]
 


### PR DESCRIPTION
## Problem

#670 changed the `--summary` flag description (it now covers critical path + cache-miss hotspots) but merged on an earlier passing CI run before the help-snapshot regen landed. The fix commit was orphaned on the feature branch, so main's `help.test.ts.snap` still shows the old `--summary` description — main CI is red.

## Fix

Cherry-pick the help-snapshot regen onto main: the snapshot now matches the updated `--summary` description in `cli-options.ts`.

Follow-up to #670 (same premature-merge race as #662 → #663).

🤖 Generated with [Claude Code](https://claude.com/claude-code)