### PR TITLE
fix: format landing-page files to green main

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -5,3 +5,4 @@ pnpm-lock.yaml
 **/CHANGELOG.md
 .claude
 .specify
+docs/superpowers

--- a/packages/docs/docs/cli-reference.md
+++ b/packages/docs/docs/cli-reference.md
@@ -22,28 +22,28 @@ nadle [tasks...] [options]
 
 ## Flags
 
-| Flag | Type | Default | Description |
-| --- | --- | --- | --- |
-| `--config`, `-c` | string | `<cwd>/nadle.config.{js,mjs,ts,mts}` | Path to config file |
-| `--list`, `-l` | boolean | `false` | List all available tasks |
-| `--list-workspaces` | boolean | `false` | List all available workspaces |
-| `--parallel` | boolean | `false` | Run all specified tasks in parallel regardless of their order, while still respecting task dependencies. |
-| `--dry-run`, `-m` | boolean | `false` | Run specified tasks in dry run mode |
-| `--watch`, `-w` | boolean | `false` | Re-run the requested tasks when their inputs change |
-| `--graph` | (empty) \| `tree` \| `mermaid` | — | Print the task dependency graph instead of executing (tree or mermaid) |
-| `--explain` | string | — | Explain why a task runs, what depends on it, and its inputs, instead of executing |
-| `--since` | string | — | Run only the requested tasks affected by changes since the given git ref |
-| `--why` | boolean | `false` | Explain each task's cache outcome (hit/miss and what changed) |
-| `--stacktrace` | boolean | `false` | Print stacktrace on error |
-| `--show-config` | boolean | `false` | Print the resolved configuration |
-| `--config-key` | string | `undefined` | Path to a specific resolved configuration value, using dot/bracket notation |
-| `--footer` | boolean | `!isCI && isTTY` | Enables the in-progress summary footer during task execution |
-| `--reporter` | `default` \| `agent` | `default` | Output reporter: 'default' (human) or 'agent' (compact, plain, for agents/scripts) |
-| `--no-cache` | boolean | `false` | Disable task caching. All tasks will be executed and their results will not be stored |
-| `--cache-dir` | string | `<projectDir>/node_modules/.cache/nadle` | Directory to store task cache results |
-| `--clean-cache` | boolean | `false` | Deletes all files in the cache directory. Can be used with --cache-dir to specify a custom location |
-| `--summary` | boolean | `false` | Print a summary of executed tasks at the end of the run |
-| `--exclude`, `-x` | string[] | — | Tasks to exclude from execution |
-| `--log-level` | `error` \| `log` \| `info` \| `debug` | `log` | Set the logging level |
-| `--min-workers` | string | `Os.availableParallelism() - 1` | Minimum number of workers (integer or percentage) |
-| `--max-workers` | string | `Os.availableParallelism() - 1` | Maximum number of workers (integer or percentage) |
+| Flag                | Type                                  | Default                                  | Description                                                                                              |
+| ------------------- | ------------------------------------- | ---------------------------------------- | -------------------------------------------------------------------------------------------------------- |
+| `--config`, `-c`    | string                                | `<cwd>/nadle.config.{js,mjs,ts,mts}`     | Path to config file                                                                                      |
+| `--list`, `-l`      | boolean                               | `false`                                  | List all available tasks                                                                                 |
+| `--list-workspaces` | boolean                               | `false`                                  | List all available workspaces                                                                            |
+| `--parallel`        | boolean                               | `false`                                  | Run all specified tasks in parallel regardless of their order, while still respecting task dependencies. |
+| `--dry-run`, `-m`   | boolean                               | `false`                                  | Run specified tasks in dry run mode                                                                      |
+| `--watch`, `-w`     | boolean                               | `false`                                  | Re-run the requested tasks when their inputs change                                                      |
+| `--graph`           | (empty) \| `tree` \| `mermaid`        | —                                        | Print the task dependency graph instead of executing (tree or mermaid)                                   |
+| `--explain`         | string                                | —                                        | Explain why a task runs, what depends on it, and its inputs, instead of executing                        |
+| `--since`           | string                                | —                                        | Run only the requested tasks affected by changes since the given git ref                                 |
+| `--why`             | boolean                               | `false`                                  | Explain each task's cache outcome (hit/miss and what changed)                                            |
+| `--stacktrace`      | boolean                               | `false`                                  | Print stacktrace on error                                                                                |
+| `--show-config`     | boolean                               | `false`                                  | Print the resolved configuration                                                                         |
+| `--config-key`      | string                                | `undefined`                              | Path to a specific resolved configuration value, using dot/bracket notation                              |
+| `--footer`          | boolean                               | `!isCI && isTTY`                         | Enables the in-progress summary footer during task execution                                             |
+| `--reporter`        | `default` \| `agent`                  | `default`                                | Output reporter: 'default' (human) or 'agent' (compact, plain, for agents/scripts)                       |
+| `--no-cache`        | boolean                               | `false`                                  | Disable task caching. All tasks will be executed and their results will not be stored                    |
+| `--cache-dir`       | string                                | `<projectDir>/node_modules/.cache/nadle` | Directory to store task cache results                                                                    |
+| `--clean-cache`     | boolean                               | `false`                                  | Deletes all files in the cache directory. Can be used with --cache-dir to specify a custom location      |
+| `--summary`         | boolean                               | `false`                                  | Print a summary of executed tasks at the end of the run                                                  |
+| `--exclude`, `-x`   | string[]                              | —                                        | Tasks to exclude from execution                                                                          |
+| `--log-level`       | `error` \| `log` \| `info` \| `debug` | `log`                                    | Set the logging level                                                                                    |
+| `--min-workers`     | string                                | `Os.availableParallelism() - 1`          | Minimum number of workers (integer or percentage)                                                        |
+| `--max-workers`     | string                                | `Os.availableParallelism() - 1`          | Maximum number of workers (integer or percentage)                                                        |

--- a/packages/docs/src/components/landing/FeatureGrid.tsx
+++ b/packages/docs/src/components/landing/FeatureGrid.tsx
@@ -25,7 +25,13 @@ const icons: Record<string, ReactNode> = {
 			<path d="M13 18h4" strokeLinecap="round" />
 		</>
 	),
-	builtin: <path d="M14.7 6.3a1 1 0 000 1.4l1.6 1.6a1 1 0 001.4 0l3.77-3.77a6 6 0 01-7.94 7.94l-6.91 6.91a2.12 2.12 0 01-3-3l6.91-6.91a6 6 0 017.94-7.94l-3.76 3.76z" strokeLinecap="round" strokeLinejoin="round" />,
+	builtin: (
+		<path
+			d="M14.7 6.3a1 1 0 000 1.4l1.6 1.6a1 1 0 001.4 0l3.77-3.77a6 6 0 01-7.94 7.94l-6.91 6.91a2.12 2.12 0 01-3-3l6.91-6.91a6 6 0 017.94-7.94l-3.76 3.76z"
+			strokeLinecap="round"
+			strokeLinejoin="round"
+		/>
+	),
 	monorepo: (
 		<>
 			<rect x="3" y="3" width="7" height="7" rx="1.5" />
@@ -43,9 +49,21 @@ interface Card {
 }
 
 const CARDS: Card[] = [
-	{ icon: "cli", title: "Smart CLI", description: "Abbreviation matching, autocorrection, dry run, and summary mode. Run tasks with minimal typing." },
-	{ icon: "progress", title: "Real-time progress", description: "Interactive footer shows scheduled, running, and completed tasks live as they execute." },
-	{ icon: "monorepo", title: "Monorepo-native", description: "First-class workspace support. Run tasks across packages with full dependency awareness." },
+	{
+		icon: "cli",
+		title: "Smart CLI",
+		description: "Abbreviation matching, autocorrection, dry run, and summary mode. Run tasks with minimal typing."
+	},
+	{
+		icon: "progress",
+		title: "Real-time progress",
+		description: "Interactive footer shows scheduled, running, and completed tasks live as they execute."
+	},
+	{
+		icon: "monorepo",
+		title: "Monorepo-native",
+		description: "First-class workspace support. Run tasks across packages with full dependency awareness."
+	},
 	{ icon: "builtin", title: "Built-in tasks", description: "ExecTask, PnpmTask, CopyTask, DeleteTask. Common operations ready out of the box." },
 	{ icon: "architecture", title: "Modern architecture", description: "Pure ESM, Node.js 22+, worker-thread isolation. Zero legacy compromises." },
 	{ icon: "agent", title: "Agent-ready", description: "Ships llms.txt and llms-full.txt so AI agents can discover and reason about your tasks." }

--- a/packages/docs/src/components/landing/Navbar.tsx
+++ b/packages/docs/src/components/landing/Navbar.tsx
@@ -42,9 +42,7 @@ const Navbar: FC = () => {
 						</Link>
 					))}
 					{version && (
-						<Link
-							href={`${GITHUB_URL}/releases/tag/v${version}`}
-							className="navbar-version-label no-underline hover:no-underline">
+						<Link href={`${GITHUB_URL}/releases/tag/v${version}`} className="navbar-version-label no-underline hover:no-underline">
 							v{version}
 						</Link>
 					)}

--- a/packages/docs/src/components/landing/ProofStrip.tsx
+++ b/packages/docs/src/components/landing/ProofStrip.tsx
@@ -23,9 +23,7 @@ const ProofStrip: FC = () => (
 			</Link>
 			<ul className="flex flex-wrap items-center justify-center gap-2.5 list-none p-0 m-0">
 				{CHIPS.map((chip) => (
-					<li
-						key={chip}
-						className="font-mono text-xs text-slate-400 bg-white/[0.04] border border-white/[0.08] rounded-full px-3 py-1.5">
+					<li key={chip} className="font-mono text-xs text-slate-400 bg-white/[0.04] border border-white/[0.08] rounded-full px-3 py-1.5">
 						{chip}
 					</li>
 				))}

--- a/packages/docs/src/components/landing/TaskGraph.tsx
+++ b/packages/docs/src/components/landing/TaskGraph.tsx
@@ -61,14 +61,7 @@ const TaskGraph: FC = () => (
 			</g>
 			{NODES.map((node) => (
 				<g key={node.id} className="landing-dag-node" style={{ ["--dag-step" as string]: node.step }}>
-					<rect
-						rx={10}
-						width={NODE_W}
-						height={NODE_H}
-						x={node.cx - NODE_W / 2}
-						y={node.cy - NODE_H / 2}
-						className="landing-dag-rect"
-					/>
+					<rect rx={10} width={NODE_W} height={NODE_H} x={node.cx - NODE_W / 2} y={node.cy - NODE_H / 2} className="landing-dag-rect" />
 					<circle r={4} cx={node.cx - NODE_W / 2 + 16} cy={node.cy} className="landing-dag-dot" />
 					<text x={node.cx + 4} y={node.cy} dominantBaseline="central" textAnchor="middle" className="landing-dag-text">
 						{node.label}

--- a/packages/docs/src/components/landing/shared.tsx
+++ b/packages/docs/src/components/landing/shared.tsx
@@ -31,7 +31,7 @@ export const CodeWindow: FC<{ code: string; title: string; language?: string }> 
 	</div>
 );
 
-export const TerminalBlock: FC<{ title?: string; content: string; }> = ({ content, title = "Terminal" }) => (
+export const TerminalBlock: FC<{ title?: string; content: string }> = ({ content, title = "Terminal" }) => (
 	<div className="relative rounded-xl overflow-hidden border border-white/[0.08] bg-[#0b0d12] shadow-2xl">
 		<WindowChrome title={title} />
 		<pre className="p-5 text-sm leading-relaxed font-mono overflow-x-auto !bg-transparent !m-0 !rounded-none text-slate-300">{content}</pre>
@@ -85,7 +85,7 @@ export const InstallCommand: FC = () => {
 
 /* ── Scroll-reveal wrapper (IntersectionObserver) ────────────────────────── */
 
-export const SectionReveal: FC<{ className?: string; children: ReactNode; }> = ({ children, className }) => {
+export const SectionReveal: FC<{ className?: string; children: ReactNode }> = ({ children, className }) => {
 	const ref = useRef<HTMLDivElement>(null);
 	const [visible, setVisible] = useState(false);
 

--- a/packages/docs/src/css/custom.css
+++ b/packages/docs/src/css/custom.css
@@ -303,9 +303,7 @@ body:has(.landing-root) .navbar {
 }
 
 .landing-cta-panel {
-	background:
-		radial-gradient(ellipse at top, rgba(59, 130, 246, 0.12), transparent 60%),
-		rgba(255, 255, 255, 0.02);
+	background: radial-gradient(ellipse at top, rgba(59, 130, 246, 0.12), transparent 60%), rgba(255, 255, 255, 0.02);
 	border: 1px solid rgba(148, 163, 184, 0.12);
 }
 


### PR DESCRIPTION
## Problem

The landing-page redesign (#672) merged with unformatted sources, so main's `prettier` check is red.

## Fix

- Reformat the 7 landing-page files (`packages/docs/src/components/landing/*`, `custom.css`, `cli-reference.md`).
- Add `docs/superpowers` to `.prettierignore` — agent planning docs (already cspell-ignored) that aren't project content and were breaking prettier.

Greens main.

🤖 Generated with [Claude Code](https://claude.com/claude-code)