### PR TITLE
feat: memoize task config resolution for configuration avoidance

### DIFF
--- a/packages/nadle/src/core/registration/api.ts
+++ b/packages/nadle/src/core/registration/api.ts
@@ -86,9 +86,14 @@ export const tasks: TasksAPI = {
 		let configCollector: Callback<TaskConfiguration> | TaskConfiguration = () => ({});
 
 		const register = () => {
+			// Resolve the config at most once per task (configuration avoidance, #647):
+			// the user's config callback can do real work, and it is read several times
+			// per run (scheduling, execution, reporting). Memoize so it runs only once.
+			let resolved: TaskConfiguration | undefined;
+
 			taskRegistry.register({
 				name,
-				configResolver: () => (typeof configCollector === "function" ? configCollector() : configCollector),
+				configResolver: () => (resolved ??= typeof configCollector === "function" ? configCollector() : configCollector),
 				...computeTaskInfo(task, optionsResolver)
 			});
 		};

--- a/packages/nadle/test/unit/lazy-config.test.ts
+++ b/packages/nadle/test/unit/lazy-config.test.ts
@@ -1,0 +1,50 @@
+import { it, expect, describe } from "vitest";
+import { type Project } from "@nadle/project-resolver";
+
+import { tasks } from "../../src/core/registration/api.js";
+import { runWithInstance } from "../../src/core/nadle-context.js";
+import { TaskRegistry } from "../../src/core/registration/task-registry.js";
+
+// Minimal project with only a root workspace, enough for TaskRegistry.configure.
+const project = {
+	workspaces: [],
+	packageManager: "pnpm",
+	currentWorkspaceId: "root",
+	rootWorkspace: {
+		label: "",
+		id: "root",
+		relativePath: "",
+		dependencies: [],
+		absolutePath: "/repo",
+		configFilePath: "/repo/nadle.config.ts",
+		packageJson: { name: "root", version: "0.0.0" }
+	}
+} as unknown as Project;
+
+describe("lazy task configuration (#647)", () => {
+	it("resolves a task's config callback at most once, regardless of how many times it is read", () => {
+		const registry = new TaskRegistry();
+		let calls = 0;
+
+		runWithInstance({ taskRegistry: registry, fileOptionRegistry: {} as never }, () => {
+			registry.onConfigureWorkspace("root");
+
+			tasks.register("build").config(() => {
+				calls += 1;
+
+				return { group: "build" };
+			});
+		});
+
+		registry.configure(project);
+		const [task] = registry.getTaskByName("build");
+
+		// Read the config several times — the scheduler, worker, and reporter all do.
+		task.configResolver();
+		task.configResolver();
+		const config = task.configResolver();
+
+		expect(calls).toBe(1);
+		expect(config).toEqual({ group: "build" });
+	});
+});

--- a/spec/02-task-configuration.md
+++ b/spec/02-task-configuration.md
@@ -26,6 +26,13 @@ The configuration builder exposes a single method:
 Calling `.config()` **replaces** the entire configuration (it does not merge). The last
 call wins.
 
+A callback form is resolved **lazily and at most once** per task: it is not evaluated at
+registration, only when the configuration is first needed (scheduling, execution, or
+reporting), and the result is memoized so the callback never runs more than once for a
+task in a given invocation (configuration avoidance). Callbacks must therefore be pure
+with respect to that single evaluation; do not rely on a side effect running on every
+read.
+
 ## dependsOn Resolution
 
 Dependency strings are resolved as follows:

--- a/spec/CHANGELOG.md
+++ b/spec/CHANGELOG.md
@@ -8,6 +8,15 @@ Versioning follows [Semantic Versioning](https://semver.org/):
 - **MINOR**: New concept, new section, or materially expanded rules
 - **PATCH**: Clarifications, corrections, wording improvements
 
+## 3.6.0 — 2026-06-13
+
+### Added
+
+- 02-task-configuration: A callback-form `.config()` is now resolved lazily and
+  memoized — evaluated at most once per task per invocation, only when the
+  configuration is first needed (configuration avoidance, #647). Callbacks must be
+  pure with respect to that single evaluation.
+
 ## 3.5.0 — 2026-06-13
 
 ### Changed

--- a/spec/README.md
+++ b/spec/README.md
@@ -1,6 +1,6 @@
 # Nadle Specification
 
-**Version**: 3.5.0
+**Version**: 3.6.0
 
 This directory contains the language-agnostic specification for Nadle, a type-safe,
 Gradle-inspired task runner for Node.js.


### PR DESCRIPTION
## Summary

A callback-form `.config(() => ({...}))` previously re-ran on **every** read of `configResolver()`. The scheduler (dependency analysis), the worker (execution), and the reporter (profiling) each read a task's config — so the callback executed several times per run.

This memoizes it: a task's config is resolved **at most once per invocation**, lazily on first read. Gradle-style configuration avoidance (#647).

## Scope

The scheduler already only walks the reachable subgraph from the requested roots, so unscheduled tasks never pay the resolution cost. The remaining waste was repeated evaluation for the tasks that *do* run — eliminated here. No behavior change for pure callbacks (the common case); the spec now documents the once-only contract.

```ts
// runs once now, not once-per-reader
tasks.register("build").config(() => ({ inputs: [Inputs.files(glob())], /* ... */ }))
```

## Tests

- `test/unit/lazy-config.test.ts` — drives the real registration API and asserts the config callback runs exactly once across three `configResolver()` reads.
- Full unit + caching + depends-on suites pass (904 tests) — config-resolution is exercised throughout, so any mis-cache would surface.

Spec `02-task-configuration.md` bumped to 3.6.0. Pure internal optimization, no public API change.

Closes #647.

🤖 Generated with [Claude Code](https://claude.com/claude-code)