### PR TITLE
feat: plugin system (definePlugin, use, lifecycle hooks, reporters)

### DIFF
--- a/cspell.config.js
+++ b/cspell.config.js
@@ -63,6 +63,7 @@ const config = {
 		"hotspot",
 		"hotspots",
 		"codemod",
+		"dedup",
 		"SARIF",
 		"subdeps",
 		"esbuild",

--- a/eslint.config.ts
+++ b/eslint.config.ts
@@ -135,6 +135,14 @@ const configs: ConfigArray = tsEslint.config(
 		}
 	},
 	{
+		// Test config files exercising the plugin API. `use()` collides with the React
+		// `use` hook name, so react-hooks misfires here; these are nadle configs, not React.
+		files: ["packages/nadle/test/__configs__/**"],
+		rules: {
+			"react-hooks/rules-of-hooks": "off"
+		}
+	},
+	{
 		files: ["packages/language-server/test/__fixtures__/**"],
 		rules: {
 			"n/no-extraneous-import": "off",

--- a/packages/docs/docs/config-reference.md
+++ b/packages/docs/docs/config-reference.md
@@ -353,3 +353,84 @@ configure({
 	footer: false
 });
 ```
+
+## Plugins
+
+A plugin is a package that contributes task types, lifecycle hooks, and/or custom reporters
+to your build. Author one with `definePlugin` and apply it in `nadle.config.ts` with `use`:
+
+```ts
+import { use } from "nadle";
+import { myPlugin } from "my-nadle-plugin";
+
+use(myPlugin, {
+	/* plugin options (typed) */
+});
+```
+
+`use(plugin, options?)` registers the plugin's task types (so they behave exactly like tasks
+you register yourself, with full `inputs`/`outputs`/`dependsOn` config), records its options,
+and wires its hooks. Applying the same plugin twice is a no-op if the options match and an
+error if they differ.
+
+### Authoring a plugin
+
+```ts
+import { definePlugin } from "nadle";
+
+export const myPlugin = definePlugin<{ threshold?: number }>({
+	name: "timing", // required, unique
+	enforce: "post", // optional ordering: "pre" | "post"
+	tasks: [
+		{
+			name: "deploy",
+			task: DeployTask,
+			config: {
+				inputs: [
+					/* … */
+				]
+			}
+		}
+	],
+	hooks: {
+		beforeAll: (ctx) => {
+			/* once, before scheduling — throw to abort the run */
+		},
+		afterAll: (ctx) => {
+			/* once, after the run settles — ctx.outcome is "success" | "failed" */
+		},
+		beforeTask: (ctx) => {
+			/* a task is about to execute — NOT fired for cache hits */
+		},
+		afterTask: (ctx) => {
+			/* a task settled — ctx.result: "done" | "failed" | "up-to-date" | "from-cache" | "canceled" */
+		}
+	}
+});
+```
+
+All hooks are optional and run on the main thread. **`beforeTask` and `afterTask` are not a
+guaranteed pair:** `beforeTask` fires only when a task actually executes (not for cache hits),
+while `afterTask` fires for every terminal outcome. Treat `beforeTask` as "about to do real
+work" and `afterTask` as "settled — check `result`". Hook ordering follows `enforce` (`pre`
+plugins first, then normal, then `post`); errors thrown from `afterAll`/`beforeTask`/`afterTask`
+are logged as warnings and never fail the run, while a throwing `beforeAll` aborts it.
+
+### Custom reporters
+
+A plugin can contribute a reporter (a `Listener`), selected with `--reporter <name>`:
+
+```ts
+export const jsonPlugin = definePlugin({
+	name: "json-reporter",
+	reporters: [{ name: "json", create: (context) => new JsonReporter(context.logger) }]
+});
+```
+
+```bash
+nadle build --reporter json
+```
+
+Exactly one reporter is active at a time (a plugin reporter replaces the default). A reporter
+name may not shadow the built-in `default`/`agent`; an unknown `--reporter` name errors with
+the list of available reporters.

--- a/packages/nadle/index.api.md
+++ b/packages/nadle/index.api.md
@@ -5,7 +5,6 @@
 ```ts
 
 import { InputLogObject } from 'consola';
-import { Project } from '@nadle/project-resolver';
 import { RimrafAsyncOptions } from 'rimraf';
 
 // @public
@@ -119,6 +118,21 @@ export namespace Inputs {
 }
 
 // @public
+export interface Listener {
+    readonly onExecutionFailed?: (error: unknown) => Awaitable<void>;
+    readonly onExecutionFinish?: () => Awaitable<void>;
+    readonly onExecutionStart?: () => Awaitable<void>;
+    readonly onInitialize?: () => Awaitable<this>;
+    readonly onTaskCanceled?: (task: RegisteredTask) => Awaitable<void>;
+    readonly onTaskFailed?: (task: RegisteredTask) => Awaitable<void>;
+    readonly onTaskFinish?: (task: RegisteredTask) => Awaitable<void>;
+    readonly onTaskRestoreFromCache?: (task: RegisteredTask) => Awaitable<void>;
+    readonly onTasksScheduled?: (tasks: RegisteredTask[]) => Awaitable<void>;
+    readonly onTaskStart?: (task: RegisteredTask, threadId: number) => Awaitable<void>;
+    readonly onTaskUpToDate?: (task: RegisteredTask) => Awaitable<void>;
+}
+
+// @public
 export interface Logger {
     debug(message: InputLogObject | string, ...args: unknown[]): void;
     error(message: InputLogObject | string, ...args: unknown[]): void;
@@ -171,15 +185,10 @@ export interface NadleFileOptions extends Partial<NadleBaseOptions> {
 
 // @public
 export interface NadlePlugin<Options = void> {
-    // (undocumented)
     readonly enforce?: "pre" | "post";
-    // (undocumented)
     readonly hooks?: PluginHooks<Options>;
-    // (undocumented)
     readonly name: string;
-    // (undocumented)
     readonly reporters?: readonly PluginReporter[];
-    // (undocumented)
     readonly tasks?: readonly PluginTask[];
 }
 
@@ -220,36 +229,23 @@ export type OverwritePolicy = "error" | "replace" | "skip";
 
 // @public
 export interface PluginHooks<Options> {
-    // (undocumented)
     readonly afterAll?: (ctx: RunHookContext<Options>) => Awaitable<void>;
-    // (undocumented)
     readonly afterTask?: (ctx: TaskHookContext<Options>) => Awaitable<void>;
-    // (undocumented)
     readonly beforeAll?: (ctx: RunHookContext<Options>) => Awaitable<void>;
-    // (undocumented)
     readonly beforeTask?: (ctx: TaskHookContext<Options>) => Awaitable<void>;
 }
 
 // @public
 export interface PluginReporter {
-    // Warning: (ae-forgotten-export) The symbol "ExecutionContext" needs to be exported by the entry point index.d.ts
-    // Warning: (ae-forgotten-export) The symbol "Listener" needs to be exported by the entry point index.d.ts
-    //
-    // (undocumented)
-    readonly create: (context: ExecutionContext) => Listener;
-    // (undocumented)
+    readonly create: (context: ReporterContext) => Listener;
     readonly name: string;
 }
 
 // @public
 export interface PluginTask {
-    // (undocumented)
     readonly config?: TaskConfiguration;
-    // (undocumented)
     readonly name: string;
-    // (undocumented)
     readonly optionsResolver?: Resolver;
-    // (undocumented)
     readonly task: Task<never> | Task;
 }
 
@@ -272,21 +268,30 @@ export interface PnpxTaskOptions {
 }
 
 // @public
+export interface RegisteredTask extends Task {
+    readonly configResolver: Callback<TaskConfiguration>;
+    readonly empty: boolean;
+    readonly id: TaskIdentifier;
+    readonly label: string;
+    readonly name: string;
+    readonly optionsResolver: Resolver | undefined;
+    readonly workspaceId: string;
+}
+
+// @public
+export interface ReporterContext {
+    readonly logger: Logger;
+}
+
+// @public
 export type Resolver<T = unknown> = T | Callback<T>;
 
 // @public
 export interface RunHookContext<Options> {
-    // (undocumented)
     readonly error?: unknown;
-    // (undocumented)
     readonly logger: Logger;
-    // (undocumented)
     readonly outcome?: "success" | "failed";
-    // (undocumented)
     readonly pluginOptions: Options;
-    // Warning: (ae-forgotten-export) The symbol "RegisteredTask" needs to be exported by the entry point index.d.ts
-    //
-    // (undocumented)
     readonly tasks: readonly RegisteredTask[];
 }
 
@@ -357,18 +362,24 @@ export type TaskFn = Callback<Awaitable<void>, {
 
 // @public
 export interface TaskHookContext<Options> {
-    // (undocumented)
     readonly error?: unknown;
-    // (undocumented)
     readonly logger: Logger;
-    // (undocumented)
     readonly pluginOptions: Options;
-    // (undocumented)
     readonly result?: "done" | "failed" | "up-to-date" | "from-cache" | "canceled";
-    // (undocumented)
     readonly task: RegisteredTask;
-    // (undocumented)
     readonly threadId?: number;
+}
+
+// @public
+export type TaskIdentifier = string;
+
+// @public
+export namespace TaskIdentifier {
+    export function create(workspaceIdOrLabel: string, taskName: string): TaskIdentifier;
+    export function parser(taskInput: string): {
+        taskNameInput: string;
+        workspaceInput: string | undefined;
+    };
 }
 
 // @public
@@ -387,6 +398,18 @@ export interface TasksAPI {
 }
 
 // @public
+export enum TaskStatus {
+    Canceled = "canceled",
+    Failed = "failed",
+    Finished = "finished",
+    FromCache = "from-cache",
+    Registered = "registered",
+    Running = "running",
+    Scheduled = "scheduled",
+    UpToDate = "up-to-date"
+}
+
+// @public
 export const UnzipTask: Task<UnzipTaskOptions>;
 
 // @public
@@ -395,6 +418,9 @@ export interface UnzipTaskOptions {
     readonly include?: MaybeArray<string>;
     readonly into: string;
 }
+
+// @public
+export function use<Options = void>(plugin: NadlePlugin<Options>, options?: Options): void;
 
 // @public
 export const ZipTask: Task<ZipTaskOptions>;

--- a/packages/nadle/index.api.md
+++ b/packages/nadle/index.api.md
@@ -5,6 +5,7 @@
 ```ts
 
 import { InputLogObject } from 'consola';
+import { Project } from '@nadle/project-resolver';
 import { RimrafAsyncOptions } from 'rimraf';
 
 // @public
@@ -39,6 +40,9 @@ export class CyclicDependencyError extends NadleError {
 
 // @public
 export type Declaration = FileDeclaration | DirDeclaration;
+
+// @public
+export function definePlugin<Options = void>(plugin: NadlePlugin<Options>): NadlePlugin<Options>;
 
 // @public
 export function defineTask<Options>(params: DefineTaskParams<Options>): Task<Options>;
@@ -166,6 +170,20 @@ export interface NadleFileOptions extends Partial<NadleBaseOptions> {
 }
 
 // @public
+export interface NadlePlugin<Options = void> {
+    // (undocumented)
+    readonly enforce?: "pre" | "post";
+    // (undocumented)
+    readonly hooks?: PluginHooks<Options>;
+    // (undocumented)
+    readonly name: string;
+    // (undocumented)
+    readonly reporters?: readonly PluginReporter[];
+    // (undocumented)
+    readonly tasks?: readonly PluginTask[];
+}
+
+// @public
 export const NodeTask: Task<NodeTaskOptions>;
 
 // @public
@@ -201,6 +219,41 @@ export namespace Outputs {
 export type OverwritePolicy = "error" | "replace" | "skip";
 
 // @public
+export interface PluginHooks<Options> {
+    // (undocumented)
+    readonly afterAll?: (ctx: RunHookContext<Options>) => Awaitable<void>;
+    // (undocumented)
+    readonly afterTask?: (ctx: TaskHookContext<Options>) => Awaitable<void>;
+    // (undocumented)
+    readonly beforeAll?: (ctx: RunHookContext<Options>) => Awaitable<void>;
+    // (undocumented)
+    readonly beforeTask?: (ctx: TaskHookContext<Options>) => Awaitable<void>;
+}
+
+// @public
+export interface PluginReporter {
+    // Warning: (ae-forgotten-export) The symbol "ExecutionContext" needs to be exported by the entry point index.d.ts
+    // Warning: (ae-forgotten-export) The symbol "Listener" needs to be exported by the entry point index.d.ts
+    //
+    // (undocumented)
+    readonly create: (context: ExecutionContext) => Listener;
+    // (undocumented)
+    readonly name: string;
+}
+
+// @public
+export interface PluginTask {
+    // (undocumented)
+    readonly config?: TaskConfiguration;
+    // (undocumented)
+    readonly name: string;
+    // (undocumented)
+    readonly optionsResolver?: Resolver;
+    // (undocumented)
+    readonly task: Task<never> | Task;
+}
+
+// @public
 export const PnpmTask: Task<PnpmTaskOptions>;
 
 // @public
@@ -220,6 +273,22 @@ export interface PnpxTaskOptions {
 
 // @public
 export type Resolver<T = unknown> = T | Callback<T>;
+
+// @public
+export interface RunHookContext<Options> {
+    // (undocumented)
+    readonly error?: unknown;
+    // (undocumented)
+    readonly logger: Logger;
+    // (undocumented)
+    readonly outcome?: "success" | "failed";
+    // (undocumented)
+    readonly pluginOptions: Options;
+    // Warning: (ae-forgotten-export) The symbol "RegisteredTask" needs to be exported by the entry point index.d.ts
+    //
+    // (undocumented)
+    readonly tasks: readonly RegisteredTask[];
+}
 
 // @public
 export interface RunnerContext {
@@ -285,6 +354,22 @@ export class TaskExecutionError extends NadleError {
 export type TaskFn = Callback<Awaitable<void>, {
     context: RunnerContext;
 }>;
+
+// @public
+export interface TaskHookContext<Options> {
+    // (undocumented)
+    readonly error?: unknown;
+    // (undocumented)
+    readonly logger: Logger;
+    // (undocumented)
+    readonly pluginOptions: Options;
+    // (undocumented)
+    readonly result?: "done" | "failed" | "up-to-date" | "from-cache" | "canceled";
+    // (undocumented)
+    readonly task: RegisteredTask;
+    // (undocumented)
+    readonly threadId?: number;
+}
 
 // @public
 export class TaskNotFoundError extends NadleError {

--- a/packages/nadle/index.api.md
+++ b/packages/nadle/index.api.md
@@ -169,7 +169,7 @@ export interface NadleBaseOptions {
     readonly maxWorkers?: number | string;
     readonly minWorkers?: number | string;
     readonly parallel?: boolean;
-    readonly reporter?: SupportReporter;
+    readonly reporter?: string;
 }
 
 // @public

--- a/packages/nadle/src/core/index.ts
+++ b/packages/nadle/src/core/index.ts
@@ -4,4 +4,5 @@ export * from "./plugins/index.js";
 export * from "./utilities/index.js";
 export * from "./interfaces/index.js";
 export * from "./registration/index.js";
+export { type TaskIdentifier } from "./models/task-identifier.js";
 export { type SupportReporter, SupportReporters } from "./reporting/reporters.js";

--- a/packages/nadle/src/core/index.ts
+++ b/packages/nadle/src/core/index.ts
@@ -1,5 +1,6 @@
 export * from "./models/index.js";
 export * from "./options/index.js";
+export * from "./plugins/index.js";
 export * from "./utilities/index.js";
 export * from "./interfaces/index.js";
 export * from "./registration/index.js";

--- a/packages/nadle/src/core/interfaces/defaults/default-logger.ts
+++ b/packages/nadle/src/core/interfaces/defaults/default-logger.ts
@@ -4,7 +4,6 @@ import c from "tinyrainbow";
 
 import { type Logger } from "../logger.js";
 import { FileLogger } from "../../utilities/file-logger.js";
-import { type SupportReporter } from "../../reporting/reporters.js";
 import { ERASE_DOWN, HIDE_CURSOR, CLEAR_SCREEN, CURSOR_TO_START, ERASE_SCROLLBACK } from "../../utilities/constants.js";
 import { LogLevels, createNadleConsola, type InputLogObject, createPlainReporters, type SupportLogLevel } from "../../utilities/consola.js";
 
@@ -18,7 +17,7 @@ interface LoggerOptions {
 	readonly logLevel?: SupportLogLevel;
 
 	/** Output reporter; the agent reporter forces plain, ANSI-free output. */
-	readonly reporter?: SupportReporter;
+	readonly reporter?: string;
 
 	/** @internal True if running in a worker thread. */
 	readonly isWorkerThread?: boolean;

--- a/packages/nadle/src/core/interfaces/index.ts
+++ b/packages/nadle/src/core/interfaces/index.ts
@@ -1,3 +1,5 @@
 export * from "./task.js";
 export * from "./logger.js";
+export * from "./listener.js";
+export * from "./registered-task.js";
 export * from "./task-configuration.js";

--- a/packages/nadle/src/core/nadle-context.ts
+++ b/packages/nadle/src/core/nadle-context.ts
@@ -1,10 +1,12 @@
 import AsyncHooks from "node:async_hooks";
 
+import { type PluginRegistry } from "./plugins/plugin-registry.js";
 import { type TaskRegistry } from "./registration/task-registry.js";
 import { type FileOptionRegistry } from "./registration/file-option-registry.js";
 
 interface NadleInstance {
 	readonly taskRegistry: TaskRegistry;
+	readonly pluginRegistry: PluginRegistry;
 	readonly fileOptionRegistry: FileOptionRegistry;
 }
 

--- a/packages/nadle/src/core/nadle.ts
+++ b/packages/nadle/src/core/nadle.ts
@@ -8,6 +8,7 @@ import { EventEmitter } from "./models/event-emitter.js";
 import { DefaultReporter } from "./reporting/reporter.js";
 import { TaskScheduler } from "./engine/task-scheduler.js";
 import { AgentReporter } from "./reporting/agent-reporter.js";
+import { PluginRegistry } from "./plugins/plugin-registry.js";
 import { TaskRegistry } from "./registration/task-registry.js";
 import { OptionsResolver } from "./options/options-resolver.js";
 import { type State, type ExecutionContext } from "./context.js";
@@ -27,6 +28,7 @@ export class Nadle implements ExecutionContext {
 
 	public readonly logger = new DefaultLogger();
 	public readonly taskRegistry = new TaskRegistry();
+	public readonly pluginRegistry = new PluginRegistry();
 	public readonly fileOptionRegistry = new FileOptionRegistry();
 	public readonly taskScheduler = new TaskScheduler(this);
 	public readonly executionTracker = new ExecutionTracker();

--- a/packages/nadle/src/core/nadle.ts
+++ b/packages/nadle/src/core/nadle.ts
@@ -9,6 +9,7 @@ import { DefaultReporter } from "./reporting/reporter.js";
 import { TaskScheduler } from "./engine/task-scheduler.js";
 import { AgentReporter } from "./reporting/agent-reporter.js";
 import { PluginRegistry } from "./plugins/plugin-registry.js";
+import { PluginListener } from "./plugins/plugin-listener.js";
 import { TaskRegistry } from "./registration/task-registry.js";
 import { OptionsResolver } from "./options/options-resolver.js";
 import { type State, type ExecutionContext } from "./context.js";
@@ -43,9 +44,18 @@ export class Nadle implements ExecutionContext {
 			new OptionsResolver(this.logger, this.taskRegistry, this.fileOptionRegistry).resolve(this.cliOptions)
 		);
 		this.eventEmitter.addListener(this.#options.reporter === "agent" ? new AgentReporter(this) : new DefaultReporter(this));
+
+		if (this.hasPluginHooks()) {
+			this.eventEmitter.addListener(new PluginListener(this, this.pluginRegistry));
+		}
+
 		await this.eventEmitter.onInitialize();
 
 		return this;
+	}
+
+	private hasPluginHooks(): boolean {
+		return this.pluginRegistry.getApplied().some(({ plugin }) => plugin.hooks !== undefined && Object.keys(plugin.hooks).length > 0);
 	}
 
 	public async initForWorker(resolvedOptions: NadleResolvedOptions): Promise<this> {

--- a/packages/nadle/src/core/nadle.ts
+++ b/packages/nadle/src/core/nadle.ts
@@ -5,6 +5,7 @@ import { getWorkspaceById, ROOT_WORKSPACE_ID, isRootWorkspaceId } from "@nadle/p
 import { Handlers } from "./handlers/index.js";
 import { runWithInstance } from "./nadle-context.js";
 import { EventEmitter } from "./models/event-emitter.js";
+import { type Listener } from "./interfaces/listener.js";
 import { DefaultReporter } from "./reporting/reporter.js";
 import { TaskScheduler } from "./engine/task-scheduler.js";
 import { AgentReporter } from "./reporting/agent-reporter.js";
@@ -17,10 +18,10 @@ import { ExecutionTracker } from "./models/execution-tracker.js";
 import { type SchedulerTask } from "./engine/scheduler-types.js";
 import { type TaskIdentifier } from "./models/task-identifier.js";
 import { DefaultLogger } from "./interfaces/defaults/default-logger.js";
-import { NadleError, TaskExecutionError } from "./utilities/nadle-error.js";
 import { FileOptionRegistry } from "./registration/file-option-registry.js";
 import { DefaultFileReader } from "./interfaces/defaults/default-file-reader.js";
 import { type NadleCLIOptions, type NadleResolvedOptions } from "./options/types.js";
+import { NadleError, ConfigurationError, TaskExecutionError } from "./utilities/nadle-error.js";
 
 export class Nadle implements ExecutionContext {
 	public static readonly version: string = "0.5.3"; // x-release-please-version
@@ -43,7 +44,7 @@ export class Nadle implements ExecutionContext {
 		this.#options = await runWithInstance(this, () =>
 			new OptionsResolver(this.logger, this.taskRegistry, this.fileOptionRegistry).resolve(this.cliOptions)
 		);
-		this.eventEmitter.addListener(this.#options.reporter === "agent" ? new AgentReporter(this) : new DefaultReporter(this));
+		this.eventEmitter.addListener(this.resolveReporter());
 
 		if (this.hasPluginHooks()) {
 			this.eventEmitter.addListener(new PluginListener(this, this.pluginRegistry));
@@ -52,6 +53,27 @@ export class Nadle implements ExecutionContext {
 		await this.eventEmitter.onInitialize();
 
 		return this;
+	}
+
+	private resolveReporter(): Listener {
+		const name = this.options.reporter;
+
+		if (name === "agent") {
+			return new AgentReporter(this);
+		}
+
+		if (name === "default") {
+			return new DefaultReporter(this);
+		}
+
+		const factory = this.pluginRegistry.getReporter(name);
+
+		if (factory === undefined) {
+			const available = ["default", "agent", ...this.pluginRegistry.getReporterNames()].join(", ");
+			throw new ConfigurationError(`Unknown reporter "${name}". Available reporters: ${available}.`);
+		}
+
+		return factory(this);
 	}
 
 	private hasPluginHooks(): boolean {

--- a/packages/nadle/src/core/options/cli-options.ts
+++ b/packages/nadle/src/core/options/cli-options.ts
@@ -5,7 +5,6 @@ import { CONFIG_FILE_PATTERN } from "@nadle/project-resolver";
 import { type NadleCLIOptions } from "./types.js";
 import { Messages } from "../utilities/messages.js";
 import { SupportLogLevels } from "../utilities/consola.js";
-import { SupportReporters } from "../reporting/reporters.js";
 import { ConfigurationError } from "../utilities/nadle-error.js";
 
 export const CLIOptions = {
@@ -129,8 +128,7 @@ export const CLIOptions = {
 		options: {
 			type: "string",
 			defaultDescription: "default",
-			choices: SupportReporters,
-			description: "Output reporter: 'default' (human) or 'agent' (compact, plain, for agents/scripts)"
+			description: "Output reporter: a built-in ('default'/'agent') or a plugin-registered reporter name"
 		}
 	},
 	cache: {

--- a/packages/nadle/src/core/options/types.ts
+++ b/packages/nadle/src/core/options/types.ts
@@ -1,7 +1,6 @@
 import { type Project } from "@nadle/project-resolver";
 
 import { type SupportLogLevel } from "../utilities/consola.js";
-import { type SupportReporter } from "../reporting/reporters.js";
 import { type ResolvedTask } from "../interfaces/resolved-task.js";
 
 /**
@@ -15,12 +14,12 @@ export interface NadleBaseOptions {
 
 	/** Show footer in output. */
 	readonly footer?: boolean;
+	/** Output reporter to use: a built-in (`default`/`agent`) or a plugin-registered reporter name. */
+	readonly reporter?: string;
 	/** Enable or disable parallel task execution. */
 	readonly parallel?: boolean;
 	/** Maximum number of cache entries to keep per task. Oldest are evicted when exceeded. */
 	readonly maxCacheEntries?: number;
-	/** Output reporter to use. */
-	readonly reporter?: SupportReporter;
 	/** Log level for reporting. */
 	readonly logLevel?: SupportLogLevel;
 	/** Minimum number of worker threads (number or string, e.g., "50%"). */

--- a/packages/nadle/src/core/plugins/index.ts
+++ b/packages/nadle/src/core/plugins/index.ts
@@ -1,0 +1,1 @@
+export * from "./plugin.js";

--- a/packages/nadle/src/core/plugins/index.ts
+++ b/packages/nadle/src/core/plugins/index.ts
@@ -1,1 +1,2 @@
+export * from "./use.js";
 export * from "./plugin.js";

--- a/packages/nadle/src/core/plugins/plugin-listener.ts
+++ b/packages/nadle/src/core/plugins/plugin-listener.ts
@@ -1,9 +1,11 @@
 import { type ExecutionContext } from "../context.js";
 import { type Listener } from "../interfaces/listener.js";
 import { type PluginRegistry } from "./plugin-registry.js";
-import { type PluginHooks, type RunHookContext } from "./plugin.js";
+import { type RegisteredTask } from "../interfaces/registered-task.js";
+import { type PluginHooks, type RunHookContext, type TaskHookContext } from "./plugin.js";
 
 type RunHook = "beforeAll" | "afterAll";
+type TaskHook = "beforeTask" | "afterTask";
 
 /**
  * Bridges nadle's lifecycle events to plugin hooks (all on the main thread).
@@ -27,6 +29,43 @@ export class PluginListener implements Listener {
 
 	public async onExecutionFailed(error: unknown): Promise<void> {
 		await this.dispatchSafe("afterAll", { error, outcome: "failed" });
+	}
+
+	public async onTaskStart(task: RegisteredTask, threadId: number): Promise<void> {
+		await this.dispatchTaskSafe("beforeTask", task, { threadId });
+	}
+
+	public async onTaskFinish(task: RegisteredTask): Promise<void> {
+		await this.dispatchTaskSafe("afterTask", task, { result: "done" });
+	}
+
+	public async onTaskFailed(task: RegisteredTask): Promise<void> {
+		await this.dispatchTaskSafe("afterTask", task, { result: "failed" });
+	}
+
+	public async onTaskUpToDate(task: RegisteredTask): Promise<void> {
+		await this.dispatchTaskSafe("afterTask", task, { result: "up-to-date" });
+	}
+
+	public async onTaskRestoreFromCache(task: RegisteredTask): Promise<void> {
+		await this.dispatchTaskSafe("afterTask", task, { result: "from-cache" });
+	}
+
+	public async onTaskCanceled(task: RegisteredTask): Promise<void> {
+		await this.dispatchTaskSafe("afterTask", task, { result: "canceled" });
+	}
+
+	private async dispatchTaskSafe(hook: TaskHook, task: RegisteredTask, extra: Partial<TaskHookContext<unknown>>): Promise<void> {
+		for (const { plugin, options } of this.registry.getOrdered()) {
+			const fn = (plugin.hooks as PluginHooks<unknown> | undefined)?.[hook];
+			const ctx: TaskHookContext<unknown> = { task, pluginOptions: options, logger: this.context.logger, ...extra };
+
+			try {
+				await fn?.(ctx);
+			} catch (error) {
+				this.context.logger.warn(`Plugin ${plugin.name} ${hook} hook failed: ${error instanceof Error ? error.message : String(error)}`);
+			}
+		}
 	}
 
 	private buildContext(extra: Partial<RunHookContext<unknown>>, options: unknown): RunHookContext<unknown> {

--- a/packages/nadle/src/core/plugins/plugin-listener.ts
+++ b/packages/nadle/src/core/plugins/plugin-listener.ts
@@ -1,0 +1,54 @@
+import { type ExecutionContext } from "../context.js";
+import { type Listener } from "../interfaces/listener.js";
+import { type PluginRegistry } from "./plugin-registry.js";
+import { type PluginHooks, type RunHookContext } from "./plugin.js";
+
+type RunHook = "beforeAll" | "afterAll";
+
+/**
+ * Bridges nadle's lifecycle events to plugin hooks (all on the main thread).
+ * `beforeAll` (onExecutionStart) is allowed to throw and abort the run; `afterAll`
+ * (onExecutionFinish/Failed) errors are caught and downgraded to a warning so
+ * teardown never turns a settled run red.
+ */
+export class PluginListener implements Listener {
+	public constructor(
+		private readonly context: ExecutionContext,
+		private readonly registry: PluginRegistry
+	) {}
+
+	public async onExecutionStart(): Promise<void> {
+		await this.dispatch("beforeAll", {});
+	}
+
+	public async onExecutionFinish(): Promise<void> {
+		await this.dispatchSafe("afterAll", { outcome: "success" });
+	}
+
+	public async onExecutionFailed(error: unknown): Promise<void> {
+		await this.dispatchSafe("afterAll", { error, outcome: "failed" });
+	}
+
+	private buildContext(extra: Partial<RunHookContext<unknown>>, options: unknown): RunHookContext<unknown> {
+		return { pluginOptions: options, logger: this.context.logger, tasks: this.context.taskRegistry.tasks, ...extra };
+	}
+
+	private async dispatch(hook: RunHook, extra: Partial<RunHookContext<unknown>>): Promise<void> {
+		for (const { plugin, options } of this.registry.getOrdered()) {
+			const fn = (plugin.hooks as PluginHooks<unknown> | undefined)?.[hook];
+			await fn?.(this.buildContext(extra, options));
+		}
+	}
+
+	private async dispatchSafe(hook: RunHook, extra: Partial<RunHookContext<unknown>>): Promise<void> {
+		for (const { plugin, options } of this.registry.getOrdered()) {
+			const fn = (plugin.hooks as PluginHooks<unknown> | undefined)?.[hook];
+
+			try {
+				await fn?.(this.buildContext(extra, options));
+			} catch (error) {
+				this.context.logger.warn(`Plugin ${plugin.name} ${hook} hook failed: ${error instanceof Error ? error.message : String(error)}`);
+			}
+		}
+	}
+}

--- a/packages/nadle/src/core/plugins/plugin-registry.ts
+++ b/packages/nadle/src/core/plugins/plugin-registry.ts
@@ -1,5 +1,5 @@
-import { type NadlePlugin } from "./plugin.js";
 import { ConfigurationError } from "../utilities/nadle-error.js";
+import { type NadlePlugin, type PluginReporter } from "./plugin.js";
 
 interface AppliedPlugin {
 	readonly options: unknown;
@@ -7,9 +7,11 @@ interface AppliedPlugin {
 }
 
 const ENFORCE_ORDER = { pre: 0, post: 2, normal: 1 } as const;
+const BUILTIN_REPORTERS = new Set(["default", "agent"]);
 
 export class PluginRegistry {
 	private readonly applied = new Map<string, AppliedPlugin>();
+	private readonly reporters = new Map<string, PluginReporter["create"]>();
 
 	public apply(plugin: NadlePlugin<never>, options?: unknown): void {
 		const existing = this.applied.get(plugin.name);
@@ -24,7 +26,27 @@ export class PluginRegistry {
 			throw new ConfigurationError(`Plugin ${plugin.name} is already applied with different options.`);
 		}
 
+		for (const reporter of plugin.reporters ?? []) {
+			this.registerReporter(reporter);
+		}
+
 		this.applied.set(plugin.name, { plugin, options });
+	}
+
+	private registerReporter(reporter: PluginReporter): void {
+		if (BUILTIN_REPORTERS.has(reporter.name) || this.reporters.has(reporter.name)) {
+			throw new ConfigurationError(`Reporter name "${reporter.name}" is already registered.`);
+		}
+
+		this.reporters.set(reporter.name, reporter.create);
+	}
+
+	public getReporter(name: string): PluginReporter["create"] | undefined {
+		return this.reporters.get(name);
+	}
+
+	public getReporterNames(): string[] {
+		return [...this.reporters.keys()];
 	}
 
 	public getApplied(): AppliedPlugin[] {

--- a/packages/nadle/src/core/plugins/plugin-registry.ts
+++ b/packages/nadle/src/core/plugins/plugin-registry.ts
@@ -1,0 +1,66 @@
+import { type NadlePlugin } from "./plugin.js";
+import { ConfigurationError } from "../utilities/nadle-error.js";
+
+interface AppliedPlugin {
+	readonly options: unknown;
+	readonly plugin: NadlePlugin<never>;
+}
+
+const ENFORCE_ORDER = { pre: 0, post: 2, normal: 1 } as const;
+
+export class PluginRegistry {
+	private readonly applied = new Map<string, AppliedPlugin>();
+
+	public apply(plugin: NadlePlugin<never>, options?: unknown): void {
+		const existing = this.applied.get(plugin.name);
+
+		if (existing) {
+			// Re-applying the same plugin with identical options is a no-op (so a
+			// meta-plugin and the user can both apply it); differing options is ambiguous.
+			if (deepEqual(existing.options, options)) {
+				return;
+			}
+
+			throw new ConfigurationError(`Plugin ${plugin.name} is already applied with different options.`);
+		}
+
+		this.applied.set(plugin.name, { plugin, options });
+	}
+
+	public getApplied(): AppliedPlugin[] {
+		return [...this.applied.values()];
+	}
+
+	public getOrdered(): AppliedPlugin[] {
+		// Stable sort by enforce group (pre → normal → post); application order is
+		// preserved within each group because Array.prototype.sort is stable.
+		return this.getApplied().sort((a, b) => ENFORCE_ORDER[a.plugin.enforce ?? "normal"] - ENFORCE_ORDER[b.plugin.enforce ?? "normal"]);
+	}
+}
+
+/** Structural, key-order-insensitive equality for plugin option objects. */
+function deepEqual(a: unknown, b: unknown): boolean {
+	if (a === b) {
+		return true;
+	}
+
+	if (typeof a !== "object" || typeof b !== "object" || a === null || b === null) {
+		return false;
+	}
+
+	if (Array.isArray(a) || Array.isArray(b)) {
+		return arrayEqual(a, b);
+	}
+
+	return objectEqual(a as Record<string, unknown>, b as Record<string, unknown>);
+}
+
+function arrayEqual(a: unknown, b: unknown): boolean {
+	return Array.isArray(a) && Array.isArray(b) && a.length === b.length && a.every((item, index) => deepEqual(item, b[index]));
+}
+
+function objectEqual(a: Record<string, unknown>, b: Record<string, unknown>): boolean {
+	const aKeys = Object.keys(a);
+
+	return aKeys.length === Object.keys(b).length && aKeys.every((key) => key in b && deepEqual(a[key], b[key]));
+}

--- a/packages/nadle/src/core/plugins/plugin.ts
+++ b/packages/nadle/src/core/plugins/plugin.ts
@@ -1,0 +1,62 @@
+import { type Task } from "../interfaces/task.js";
+import { type ExecutionContext } from "../context.js";
+import { type Logger } from "../interfaces/logger.js";
+import { type Listener } from "../interfaces/listener.js";
+import { type Resolver, type Awaitable } from "../utilities/types.js";
+import { type RegisteredTask } from "../interfaces/registered-task.js";
+import { type TaskConfiguration } from "../interfaces/task-configuration.js";
+
+/** A task type a plugin contributes; registered as tasks.register(name, task, optionsResolver).config(config). */
+export interface PluginTask {
+	readonly name: string;
+	readonly task: Task<never> | Task;
+	readonly config?: TaskConfiguration;
+	readonly optionsResolver?: Resolver;
+}
+
+/** A reporter a plugin contributes; `create` returns a Listener (like DefaultReporter). */
+export interface PluginReporter {
+	readonly name: string;
+	readonly create: (context: ExecutionContext) => Listener;
+}
+
+/** Context shared by run-level hooks (beforeAll/afterAll). */
+export interface RunHookContext<Options> {
+	readonly logger: Logger;
+	readonly error?: unknown;
+	readonly pluginOptions: Options;
+	readonly outcome?: "success" | "failed";
+	readonly tasks: readonly RegisteredTask[];
+}
+
+/** Context shared by task-level hooks (beforeTask/afterTask). */
+export interface TaskHookContext<Options> {
+	readonly logger: Logger;
+	readonly error?: unknown;
+	readonly threadId?: number;
+	readonly task: RegisteredTask;
+	readonly pluginOptions: Options;
+	readonly result?: "done" | "failed" | "up-to-date" | "from-cache" | "canceled";
+}
+
+/** Optional lifecycle hooks. All run on the main thread. */
+export interface PluginHooks<Options> {
+	readonly afterAll?: (ctx: RunHookContext<Options>) => Awaitable<void>;
+	readonly beforeAll?: (ctx: RunHookContext<Options>) => Awaitable<void>;
+	readonly afterTask?: (ctx: TaskHookContext<Options>) => Awaitable<void>;
+	readonly beforeTask?: (ctx: TaskHookContext<Options>) => Awaitable<void>;
+}
+
+/** A nadle plugin. Applied via use(plugin, options?). */
+export interface NadlePlugin<Options = void> {
+	readonly name: string;
+	readonly enforce?: "pre" | "post";
+	readonly hooks?: PluginHooks<Options>;
+	readonly tasks?: readonly PluginTask[];
+	readonly reporters?: readonly PluginReporter[];
+}
+
+/** Identity helper for authoring a plugin with full type inference (mirrors defineTask). */
+export function definePlugin<Options = void>(plugin: NadlePlugin<Options>): NadlePlugin<Options> {
+	return plugin;
+}

--- a/packages/nadle/src/core/plugins/plugin.ts
+++ b/packages/nadle/src/core/plugins/plugin.ts
@@ -1,62 +1,93 @@
 import { type Task } from "../interfaces/task.js";
-import { type ExecutionContext } from "../context.js";
 import { type Logger } from "../interfaces/logger.js";
 import { type Listener } from "../interfaces/listener.js";
 import { type Resolver, type Awaitable } from "../utilities/types.js";
 import { type RegisteredTask } from "../interfaces/registered-task.js";
 import { type TaskConfiguration } from "../interfaces/task-configuration.js";
 
-/** A task type a plugin contributes; registered as tasks.register(name, task, optionsResolver).config(config). */
+/** What a plugin-contributed reporter receives. The full execution context is structurally assignable to this. */
+export interface ReporterContext {
+	/** The core logger. */
+	readonly logger: Logger;
+}
+
+/** A task type a plugin contributes; registered as `tasks.register(name, task, optionsResolver).config(config)`. */
 export interface PluginTask {
+	/** The name users register / invoke the task under. */
 	readonly name: string;
+	/** The task definition (a `Task` object, as produced by `defineTask`). */
 	readonly task: Task<never> | Task;
+	/** Optional task configuration (inputs, outputs, dependsOn, group, …). */
 	readonly config?: TaskConfiguration;
+	/** Optional resolver for the task's options. */
 	readonly optionsResolver?: Resolver;
 }
 
-/** A reporter a plugin contributes; `create` returns a Listener (like DefaultReporter). */
+/** A reporter a plugin contributes; selected by name via `--reporter <name>`. */
 export interface PluginReporter {
+	/** The name users select this reporter by. Must not collide with `default`/`agent`. */
 	readonly name: string;
-	readonly create: (context: ExecutionContext) => Listener;
+	/** Factory returning the reporter (a `Listener`), given the reporter context. */
+	readonly create: (context: ReporterContext) => Listener;
 }
 
-/** Context shared by run-level hooks (beforeAll/afterAll). */
+/** Context passed to run-level hooks (`beforeAll`/`afterAll`). */
 export interface RunHookContext<Options> {
+	/** The core logger (respects `--log-level` and the active reporter). */
 	readonly logger: Logger;
+	/** The error — present only in `afterAll` when `outcome` is `"failed"`. */
 	readonly error?: unknown;
+	/** The options this plugin was applied with. */
 	readonly pluginOptions: Options;
+	/** The run outcome — present only in `afterAll`. */
 	readonly outcome?: "success" | "failed";
+	/** The tasks scheduled for this run. */
 	readonly tasks: readonly RegisteredTask[];
 }
 
-/** Context shared by task-level hooks (beforeTask/afterTask). */
+/** Context passed to task-level hooks (`beforeTask`/`afterTask`). */
 export interface TaskHookContext<Options> {
+	/** The core logger (respects `--log-level` and the active reporter). */
 	readonly logger: Logger;
+	/** The error — present only in `afterTask` when `result` is `"failed"`. */
 	readonly error?: unknown;
+	/** The worker thread id — present in `beforeTask` (meaningless under the inline executor). */
 	readonly threadId?: number;
+	/** The task this hook fires for. */
 	readonly task: RegisteredTask;
+	/** The options this plugin was applied with. */
 	readonly pluginOptions: Options;
+	/** How the task settled — present only in `afterTask`. */
 	readonly result?: "done" | "failed" | "up-to-date" | "from-cache" | "canceled";
 }
 
-/** Optional lifecycle hooks. All run on the main thread. */
+/** Optional plugin lifecycle hooks. All run on the main thread. */
 export interface PluginHooks<Options> {
+	/** Runs once after the run settles (success or failure). */
 	readonly afterAll?: (ctx: RunHookContext<Options>) => Awaitable<void>;
+	/** Runs once before scheduling. Throwing aborts the run. */
 	readonly beforeAll?: (ctx: RunHookContext<Options>) => Awaitable<void>;
+	/** Runs after a task settles, for every outcome (see `ctx.result`). */
 	readonly afterTask?: (ctx: TaskHookContext<Options>) => Awaitable<void>;
+	/** Runs before a task actually executes (not fired for cache hits). */
 	readonly beforeTask?: (ctx: TaskHookContext<Options>) => Awaitable<void>;
 }
 
-/** A nadle plugin. Applied via use(plugin, options?). */
+/** A nadle plugin. Apply it in `nadle.config.ts` with `use(plugin, options?)`. */
 export interface NadlePlugin<Options = void> {
+	/** Unique plugin name, used for dedup and error messages. */
 	readonly name: string;
+	/** Optional ordering: `pre` plugins run before normal, `post` after. */
 	readonly enforce?: "pre" | "post";
+	/** Lifecycle hooks this plugin registers. */
 	readonly hooks?: PluginHooks<Options>;
+	/** Task types this plugin contributes. */
 	readonly tasks?: readonly PluginTask[];
+	/** Custom reporters this plugin contributes. */
 	readonly reporters?: readonly PluginReporter[];
 }
 
-/** Identity helper for authoring a plugin with full type inference (mirrors defineTask). */
+/** Identity helper for authoring a plugin with full type inference (mirrors `defineTask`). */
 export function definePlugin<Options = void>(plugin: NadlePlugin<Options>): NadlePlugin<Options> {
 	return plugin;
 }

--- a/packages/nadle/src/core/plugins/use.ts
+++ b/packages/nadle/src/core/plugins/use.ts
@@ -1,0 +1,29 @@
+import { tasks } from "../registration/api.js";
+import { getCurrentInstance } from "../nadle-context.js";
+import { type PluginTask, type NadlePlugin } from "./plugin.js";
+import { ConfigurationError } from "../utilities/nadle-error.js";
+
+/**
+ * Apply a plugin during config load: record it (and its options) in the plugin
+ * registry and register any task types it contributes. Call from `nadle.config.ts`.
+ */
+export function use<Options = void>(plugin: NadlePlugin<Options>, options?: Options): void {
+	if (typeof plugin !== "object" || plugin === null || typeof plugin.name !== "string" || plugin.name.length === 0) {
+		throw new ConfigurationError("use() expects a plugin object with a non-empty string name.");
+	}
+
+	const { pluginRegistry } = getCurrentInstance();
+	pluginRegistry.apply(plugin as NadlePlugin<never>, options);
+
+	for (const pluginTask of plugin.tasks ?? []) {
+		registerPluginTask(pluginTask);
+	}
+}
+
+function registerPluginTask({ name, task, config, optionsResolver }: PluginTask): void {
+	const builder = optionsResolver === undefined ? tasks.register(name, task as never) : tasks.register(name, task as never, optionsResolver);
+
+	if (config !== undefined) {
+		builder.config(config);
+	}
+}

--- a/packages/nadle/test/__configs__/plugin-basic.ts
+++ b/packages/nadle/test/__configs__/plugin-basic.ts
@@ -6,7 +6,9 @@ const plugin = definePlugin({
 	name: "marker",
 	hooks: {
 		afterAll: async () => Fs.appendFile("hooks.log", "afterAll\n"),
-		beforeAll: async () => Fs.appendFile("hooks.log", "beforeAll\n")
+		beforeAll: async () => Fs.appendFile("hooks.log", "beforeAll\n"),
+		beforeTask: async (ctx) => Fs.appendFile("hooks.log", `beforeTask:${ctx.task.name}\n`),
+		afterTask: async (ctx) => Fs.appendFile("hooks.log", `afterTask:${ctx.task.name}:${ctx.result}\n`)
 	}
 });
 

--- a/packages/nadle/test/__configs__/plugin-basic.ts
+++ b/packages/nadle/test/__configs__/plugin-basic.ts
@@ -1,0 +1,15 @@
+import Fs from "node:fs/promises";
+
+import { use, tasks, definePlugin } from "nadle";
+
+const plugin = definePlugin({
+	name: "marker",
+	hooks: {
+		afterAll: async () => Fs.appendFile("hooks.log", "afterAll\n"),
+		beforeAll: async () => Fs.appendFile("hooks.log", "beforeAll\n")
+	}
+});
+
+use(plugin);
+
+tasks.register("hello", () => {});

--- a/packages/nadle/test/__configs__/plugin-reporter.ts
+++ b/packages/nadle/test/__configs__/plugin-reporter.ts
@@ -1,0 +1,17 @@
+import { use, tasks, definePlugin } from "nadle";
+
+use(
+	definePlugin({
+		name: "json-plugin",
+		reporters: [
+			{
+				name: "json",
+				create: (context) => ({
+					onExecutionFinish: () => context.logger.log("JSON_REPORTER_ACTIVE")
+				})
+			}
+		]
+	})
+);
+
+tasks.register("hello", () => {});

--- a/packages/nadle/test/__snapshots__/options/help.test.ts.snap
+++ b/packages/nadle/test/__snapshots__/options/help.test.ts.snap
@@ -55,8 +55,8 @@ Miscellaneous options:
 Options:
       --graph     Print the task dependency graph instead of executing (tree or mermaid)
                                                            [string] [choices: "", "tree", "mermaid"]
-      --reporter  Output reporter: 'default' (human) or 'agent' (compact, plain, for agents/scripts)
-                                           [string] [choices: "default", "agent"] [default: default]
+      --reporter  Output reporter: a built-in ('default'/'agent') or a plugin-registered reporter
+                  name                                                   [string] [default: default]
 
 Examples:
   nadle test -- -u  Run the test task, passing -u through to its underlying command

--- a/packages/nadle/test/options/plugin-reporter.test.ts
+++ b/packages/nadle/test/options/plugin-reporter.test.ts
@@ -1,0 +1,28 @@
+import { it, expect, describe } from "vitest";
+import { settle, fixture, getStderr, readConfig, withGeneratedFixture } from "setup";
+
+const files = fixture()
+	.packageJson("plugin-reporter")
+	.configRaw(await readConfig("plugin-reporter.ts"))
+	.build();
+
+describe("plugin reporter", () => {
+	it("selects a plugin-contributed reporter by name", () =>
+		withGeneratedFixture({
+			files,
+			testFn: async ({ exec }) => {
+				const result = await settle(exec`hello --reporter json`);
+				expect(result.stdout).toContain("JSON_REPORTER_ACTIVE");
+			}
+		}));
+
+	it("errors with the available reporters on an unknown name", () =>
+		withGeneratedFixture({
+			files,
+			testFn: async ({ exec }) => {
+				const stderr = await getStderr(exec`hello --reporter nope`);
+				expect(stderr).toContain("Unknown reporter");
+				expect(stderr).toContain("json");
+			}
+		}));
+});

--- a/packages/nadle/test/options/plugin.test.ts
+++ b/packages/nadle/test/options/plugin.test.ts
@@ -1,0 +1,24 @@
+import Path from "node:path";
+import Fs from "node:fs/promises";
+
+import { it, expect, describe } from "vitest";
+import { settle, fixture, readConfig, withGeneratedFixture } from "setup";
+
+const files = fixture()
+	.packageJson("plugin-basic")
+	.configRaw(await readConfig("plugin-basic.ts"))
+	.build();
+
+describe("plugins", () => {
+	it("fires beforeAll and afterAll around a run", () =>
+		withGeneratedFixture({
+			files,
+			testFn: async ({ cwd, exec }) => {
+				const result = await settle(exec`hello`);
+				expect(result.exitCode).toBe(0);
+
+				const log = await Fs.readFile(Path.join(cwd, "hooks.log"), "utf8");
+				expect(log).toBe("beforeAll\nafterAll\n");
+			}
+		}));
+});

--- a/packages/nadle/test/options/plugin.test.ts
+++ b/packages/nadle/test/options/plugin.test.ts
@@ -18,7 +18,21 @@ describe("plugins", () => {
 				expect(result.exitCode).toBe(0);
 
 				const log = await Fs.readFile(Path.join(cwd, "hooks.log"), "utf8");
-				expect(log).toBe("beforeAll\nafterAll\n");
+				const lines = log.trim().split("\n");
+				expect(lines[0]).toBe("beforeAll");
+				expect(lines.at(-1)).toBe("afterAll");
+			}
+		}));
+
+	it("fires beforeTask and afterTask around an executed task", () =>
+		withGeneratedFixture({
+			files,
+			testFn: async ({ cwd, exec }) => {
+				await settle(exec`hello`);
+
+				const log = await Fs.readFile(Path.join(cwd, "hooks.log"), "utf8");
+				expect(log).toContain("beforeTask:hello");
+				expect(log).toContain("afterTask:hello:done");
 			}
 		}));
 });

--- a/packages/nadle/test/types/plugin.test-d.ts
+++ b/packages/nadle/test/types/plugin.test-d.ts
@@ -1,0 +1,15 @@
+import { it, expectTypeOf } from "vitest";
+import { definePlugin, type NadlePlugin } from "nadle";
+
+it("threads the Options generic into hooks", () => {
+	const plugin = definePlugin<{ threshold: number }>({
+		name: "timing",
+		hooks: {
+			beforeTask: (ctx) => {
+				expectTypeOf(ctx.pluginOptions).toEqualTypeOf<{ threshold: number }>();
+			}
+		}
+	});
+
+	expectTypeOf(plugin).toMatchTypeOf<NadlePlugin<{ threshold: number }>>();
+});

--- a/packages/nadle/test/unit/lazy-config.test.ts
+++ b/packages/nadle/test/unit/lazy-config.test.ts
@@ -26,7 +26,7 @@ describe("lazy task configuration (#647)", () => {
 		const registry = new TaskRegistry();
 		let calls = 0;
 
-		runWithInstance({ taskRegistry: registry, fileOptionRegistry: {} as never }, () => {
+		runWithInstance({ taskRegistry: registry, pluginRegistry: {} as never, fileOptionRegistry: {} as never }, () => {
 			registry.onConfigureWorkspace("root");
 
 			tasks.register("build").config(() => {

--- a/packages/nadle/test/unit/plugin-listener.test.ts
+++ b/packages/nadle/test/unit/plugin-listener.test.ts
@@ -1,0 +1,62 @@
+import { it, vi, expect, describe } from "vitest";
+
+import { PluginListener } from "../../src/core/plugins/plugin-listener.js";
+import { PluginRegistry } from "../../src/core/plugins/plugin-registry.js";
+
+const fakeContext = (warn = vi.fn()) =>
+	({ taskRegistry: { tasks: [] }, logger: { warn, log: vi.fn(), info: vi.fn(), error: vi.fn(), debug: vi.fn() } }) as never;
+
+describe("PluginListener", () => {
+	it("dispatches beforeAll in pre then normal then post order", async () => {
+		const calls: string[] = [];
+		const registry = new PluginRegistry();
+		registry.apply({ name: "post", enforce: "post", hooks: { beforeAll: () => void calls.push("post") } });
+		registry.apply({ name: "normal", hooks: { beforeAll: () => void calls.push("normal") } });
+		registry.apply({ name: "pre", enforce: "pre", hooks: { beforeAll: () => void calls.push("pre") } });
+
+		await new PluginListener(fakeContext(), registry).onExecutionStart();
+
+		expect(calls).toEqual(["pre", "normal", "post"]);
+	});
+
+	it("lets a throwing beforeAll propagate (aborts the run)", async () => {
+		const registry = new PluginRegistry();
+		registry.apply({
+			name: "boom",
+			hooks: {
+				beforeAll: () => {
+					throw new Error("nope");
+				}
+			}
+		});
+
+		await expect(new PluginListener(fakeContext(), registry).onExecutionStart()).rejects.toThrow("nope");
+	});
+
+	it("catches a throwing afterAll and downgrades to a warning", async () => {
+		const warn = vi.fn();
+		const registry = new PluginRegistry();
+		registry.apply({
+			name: "boom",
+			hooks: {
+				afterAll: () => {
+					throw new Error("teardown");
+				}
+			}
+		});
+
+		await expect(new PluginListener(fakeContext(warn), registry).onExecutionFinish()).resolves.toBeUndefined();
+		expect(warn).toHaveBeenCalled();
+	});
+
+	it("passes outcome and error to afterAll on the failure path", async () => {
+		let received: { error?: unknown; outcome?: string } = {};
+		const registry = new PluginRegistry();
+		registry.apply({ name: "tap", hooks: { afterAll: (ctx) => void (received = { error: ctx.error, outcome: ctx.outcome }) } });
+
+		await new PluginListener(fakeContext(), registry).onExecutionFailed(new Error("boom"));
+
+		expect(received.outcome).toBe("failed");
+		expect((received.error as Error).message).toBe("boom");
+	});
+});

--- a/packages/nadle/test/unit/plugin-listener.test.ts
+++ b/packages/nadle/test/unit/plugin-listener.test.ts
@@ -49,6 +49,52 @@ describe("PluginListener", () => {
 		expect(warn).toHaveBeenCalled();
 	});
 
+	it("maps onTaskStart to beforeTask and the terminal events to afterTask with a result", async () => {
+		const results: string[] = [];
+		const registry = new PluginRegistry();
+		registry.apply({
+			name: "tap",
+			hooks: {
+				beforeTask: (ctx) => void results.push(`before:${ctx.task.id}`),
+				afterTask: (ctx) => void results.push(`after:${ctx.task.id}:${ctx.result}`)
+			}
+		});
+		const listener = new PluginListener(fakeContext(), registry);
+		const task = { id: "build", label: "build" } as never;
+
+		await listener.onTaskStart(task, 1);
+		await listener.onTaskFinish(task);
+		await listener.onTaskUpToDate(task);
+		await listener.onTaskRestoreFromCache(task);
+		await listener.onTaskFailed(task);
+		await listener.onTaskCanceled(task);
+
+		expect(results).toEqual([
+			"before:build",
+			"after:build:done",
+			"after:build:up-to-date",
+			"after:build:from-cache",
+			"after:build:failed",
+			"after:build:canceled"
+		]);
+	});
+
+	it("catches a throwing beforeTask and downgrades to a warning (does not abort)", async () => {
+		const warn = vi.fn();
+		const registry = new PluginRegistry();
+		registry.apply({
+			name: "boom",
+			hooks: {
+				beforeTask: () => {
+					throw new Error("task hook");
+				}
+			}
+		});
+
+		await expect(new PluginListener(fakeContext(warn), registry).onTaskStart({ id: "x", label: "x" } as never, 1)).resolves.toBeUndefined();
+		expect(warn).toHaveBeenCalled();
+	});
+
 	it("passes outcome and error to afterAll on the failure path", async () => {
 		let received: { error?: unknown; outcome?: string } = {};
 		const registry = new PluginRegistry();

--- a/packages/nadle/test/unit/plugin-registry.test.ts
+++ b/packages/nadle/test/unit/plugin-registry.test.ts
@@ -1,0 +1,50 @@
+import { it, expect, describe } from "vitest";
+
+import { PluginRegistry } from "../../src/core/plugins/plugin-registry.js";
+
+const plugin = (name: string, enforce?: "pre" | "post") => ({ name, enforce, hooks: {} });
+
+describe("PluginRegistry", () => {
+	it("stores an applied plugin with its options", () => {
+		const registry = new PluginRegistry();
+		registry.apply(plugin("a"), { x: 1 });
+
+		expect(registry.getApplied().map((entry) => entry.plugin.name)).toEqual(["a"]);
+		expect(registry.getApplied()[0].options).toEqual({ x: 1 });
+	});
+
+	it("is a no-op when the same plugin is applied with deep-equal options", () => {
+		const registry = new PluginRegistry();
+		const p = plugin("a");
+		registry.apply(p, { x: 1 });
+		registry.apply(p, { x: 1 });
+
+		expect(registry.getApplied()).toHaveLength(1);
+	});
+
+	it("treats key-reordered options as equal (no-op)", () => {
+		const registry = new PluginRegistry();
+		const p = plugin("a");
+		registry.apply(p, { x: 1, y: 2 });
+		registry.apply(p, { y: 2, x: 1 });
+
+		expect(registry.getApplied()).toHaveLength(1);
+	});
+
+	it("throws when the same plugin name is applied with different options", () => {
+		const registry = new PluginRegistry();
+		registry.apply(plugin("a"), { x: 1 });
+
+		expect(() => registry.apply(plugin("a"), { x: 2 })).toThrow(/already applied/);
+	});
+
+	it("orders plugins pre then normal then post, application order within each group", () => {
+		const registry = new PluginRegistry();
+		registry.apply(plugin("normal1"));
+		registry.apply(plugin("post1", "post"));
+		registry.apply(plugin("pre1", "pre"));
+		registry.apply(plugin("normal2"));
+
+		expect(registry.getOrdered().map((entry) => entry.plugin.name)).toEqual(["pre1", "normal1", "normal2", "post1"]);
+	});
+});

--- a/packages/nadle/test/unit/plugin-registry.test.ts
+++ b/packages/nadle/test/unit/plugin-registry.test.ts
@@ -38,6 +38,28 @@ describe("PluginRegistry", () => {
 		expect(() => registry.apply(plugin("a"), { x: 2 })).toThrow(/already applied/);
 	});
 
+	it("registers a reporter factory and looks it up by name", () => {
+		const registry = new PluginRegistry();
+		const create = () => ({}) as never;
+		registry.apply({ name: "json-plugin", reporters: [{ create, name: "json" }] });
+
+		expect(registry.getReporter("json")).toBe(create);
+		expect(registry.getReporter("missing")).toBeUndefined();
+	});
+
+	it("errors when two plugins register the same reporter name", () => {
+		const registry = new PluginRegistry();
+		registry.apply({ name: "a", reporters: [{ name: "json", create: () => ({}) as never }] });
+
+		expect(() => registry.apply({ name: "b", reporters: [{ name: "json", create: () => ({}) as never }] })).toThrow(/reporter/i);
+	});
+
+	it("rejects a reporter that shadows a built-in name", () => {
+		const registry = new PluginRegistry();
+
+		expect(() => registry.apply({ name: "a", reporters: [{ name: "default", create: () => ({}) as never }] })).toThrow(/reporter/i);
+	});
+
 	it("orders plugins pre then normal then post, application order within each group", () => {
 		const registry = new PluginRegistry();
 		registry.apply(plugin("normal1"));

--- a/packages/nadle/test/unit/use.test.ts
+++ b/packages/nadle/test/unit/use.test.ts
@@ -1,0 +1,66 @@
+import { it, expect, describe } from "vitest";
+import { type Project } from "@nadle/project-resolver";
+
+import { use } from "../../src/core/plugins/use.js";
+import { runWithInstance } from "../../src/core/nadle-context.js";
+import { PluginRegistry } from "../../src/core/plugins/plugin-registry.js";
+import { TaskRegistry } from "../../src/core/registration/task-registry.js";
+
+const project = {
+	workspaces: [],
+	packageManager: "pnpm",
+	currentWorkspaceId: "root",
+	rootWorkspace: {
+		label: "",
+		id: "root",
+		relativePath: "",
+		dependencies: [],
+		absolutePath: "/repo",
+		configFilePath: "/repo/nadle.config.ts",
+		packageJson: { name: "root", version: "0.0.0" }
+	}
+} as unknown as Project;
+
+function withInstance(fn: () => void) {
+	const taskRegistry = new TaskRegistry();
+	const pluginRegistry = new PluginRegistry();
+	taskRegistry.onConfigureWorkspace("root");
+	runWithInstance({ taskRegistry, pluginRegistry, fileOptionRegistry: {} as never }, fn);
+
+	return { taskRegistry, pluginRegistry };
+}
+
+describe("use", () => {
+	it("records the plugin and its options in the registry", () => {
+		const { pluginRegistry } = withInstance(() => {
+			use({ hooks: {}, name: "timing" }, { threshold: 5 });
+		});
+
+		expect(pluginRegistry.getApplied()).toHaveLength(1);
+		expect(pluginRegistry.getApplied()[0].options).toEqual({ threshold: 5 });
+	});
+
+	it("rejects a malformed plugin (missing name)", () => {
+		expect(() =>
+			withInstance(() => {
+				use({} as never);
+			})
+		).toThrow(/plugin/i);
+	});
+
+	it("registers a contributed task type with its config", () => {
+		const noop = { run: () => {} };
+		const { taskRegistry } = withInstance(() => {
+			use({
+				name: "docker",
+				tasks: [{ task: noop, name: "dockerBuild", config: { group: "docker" } }]
+			});
+		});
+
+		taskRegistry.configure(project);
+
+		const [task] = taskRegistry.getTaskByName("dockerBuild");
+		expect(task).toBeDefined();
+		expect(task.configResolver().group).toBe("docker");
+	});
+});

--- a/spec/11-events.md
+++ b/spec/11-events.md
@@ -69,6 +69,18 @@ The duration timer is unreferenced so it does not prevent the process from exiti
 
 ## Custom Listeners
 
-Custom listeners are not directly supported through the public API in the current
-implementation. The event emitter is initialized with a fixed set of listeners
-(ExecutionTracker and DefaultReporter).
+The core registers a fixed set of listeners (ExecutionTracker and the active reporter).
+User-facing extension is through the **plugin system**: a plugin applied with `use()`
+contributes lifecycle hooks that the core dispatches on the main thread via an internal
+listener. The hooks map to events as follows:
+
+| Plugin hook  | Event(s)                                                                                                                          |
+| ------------ | --------------------------------------------------------------------------------------------------------------------------------- |
+| `beforeAll`  | `onExecutionStart` (may throw to abort the run)                                                                                   |
+| `afterAll`   | `onExecutionFinish` / `onExecutionFailed` (errors downgraded to a warning)                                                        |
+| `beforeTask` | `onTaskStart` (fires only for tasks that actually execute, not cache hits)                                                        |
+| `afterTask`  | `onTaskFinish` / `onTaskFailed` / `onTaskUpToDate` / `onTaskRestoreFromCache` / `onTaskCanceled` (errors downgraded to a warning) |
+
+Hooks run in plugin order, grouped by the optional `enforce` (`pre` → normal → `post`).
+Because `beforeTask` is skipped for cache hits while `afterTask` always fires, the two are
+not a guaranteed pair. Plugins may also contribute task types and reporters.

--- a/spec/13-reporting.md
+++ b/spec/13-reporting.md
@@ -12,6 +12,13 @@ The output style is selected by the `reporter` option (`--reporter`):
 | `default` | Humans (default)  | Welcome banner, colored task status messages, optional live footer, optional summary table.    |
 | `agent`   | AI agents/scripts | Compact, plain (no color/banner/footer/spinner): one stable line per task plus a summary line. |
 
+The reporter name space is open: in addition to the two built-ins, a plugin may contribute
+a named reporter (a listener factory), selected by the same `--reporter <name>` option.
+Exactly one reporter is active per run (a plugin reporter replaces the default). A plugin
+reporter may not shadow a built-in name, and an unknown reporter name is a configuration
+error listing the available reporters. See the plugin system for how reporters are
+contributed.
+
 The remaining sections of this document describe the `default` reporter. The `agent`
 reporter is specified below.
 

--- a/spec/CHANGELOG.md
+++ b/spec/CHANGELOG.md
@@ -8,6 +8,17 @@ Versioning follows [Semantic Versioning](https://semver.org/):
 - **MINOR**: New concept, new section, or materially expanded rules
 - **PATCH**: Clarifications, corrections, wording improvements
 
+## 3.7.0 — 2026-06-13
+
+### Added
+
+- 11-events / 13-reporting: Plugin system. A plugin (applied with `use(plugin, options?)`
+  in config) contributes task types, lifecycle hooks (`beforeAll`/`afterAll`/`beforeTask`/
+  `afterTask`, dispatched main-thread from the existing events; `beforeAll` may abort,
+  teardown errors downgrade to warnings; `beforeTask` is skipped for cache hits), and
+  custom reporters (selected by `--reporter <name>`, opening the previously-closed reporter
+  name space). Hook order follows an optional `enforce: "pre" | "post"`.
+
 ## 3.6.0 — 2026-06-13
 
 ### Added

--- a/spec/README.md
+++ b/spec/README.md
@@ -1,6 +1,6 @@
 # Nadle Specification
 
-**Version**: 3.6.0
+**Version**: 3.7.0
 
 This directory contains the language-agnostic specification for Nadle, a type-safe,
 Gradle-inspired task runner for Node.js.


### PR DESCRIPTION
## Summary

Implements the plugin system (#641) — the core of the Distribution pillar. A published package can contribute **task types**, **lifecycle hooks**, and **custom reporters** to a build, applied explicitly via `use()` in `nadle.config.ts`.

```ts
import { use } from "nadle";
import { myPlugin } from "my-nadle-plugin";

use(myPlugin, { /* typed options */ });
```

## What's included (core spec P1–P3)

- **`definePlugin` + `use(plugin, options?)`** — apply a plugin during config load. Dedup: same plugin + equal options = no-op, differing = error.
- **Task types** — `tasks: [{ name, task, optionsResolver, config }]` routed through the real `tasks.register().config()` path, so contributed tasks keep the full config surface (inputs/outputs/dependsOn).
- **Lifecycle hooks** — `beforeAll`/`afterAll`/`beforeTask`/`afterTask`, all **main-thread**, dispatched by an internal `PluginListener` over the existing event seam. `beforeAll` may throw to abort; teardown errors downgrade to warnings; `beforeTask` is skipped for cache hits (so before/after are not a guaranteed pair); `afterTask` covers every outcome incl. `canceled`. Order follows `enforce: "pre" | "post"`.
- **Custom reporters** — `reporters: [{ name, create }]`; `--reporter <name>` widened from the closed enum to any registered name, with a clear error listing available reporters.

No worker / event-emitter / `WorkerParams` changes — everything rides the  +  seams.

## Design provenance

Brainstormed → two adversarial self-review rounds (cut the original worker-thread hooks as all-risk-no-reward; fixed the abort/green-to-red semantics and the cache-hit asymmetry) → pressure-tested against Vite/Rollup/ESLint/Gradle/esbuild/Vitest (adopted Vite-style `enforce`; kept `use()` per nadle's imperative Gradle-style config). Specs on main: `docs/superpowers/specs/2026-06-13-plugin-system-design.md` (+ auto-discovery sub-spec), plan: `docs/superpowers/plans/2026-06-13-plugin-system.md`.

## Public API / surface

Exports `definePlugin`, `use`, `NadlePlugin`, `PluginHooks`, `RunHookContext`, `TaskHookContext`, `PluginTask`, `PluginReporter`, `ReporterContext`, and (newly public, plugin authors need them) `Listener`, `RegisteredTask`, `TaskIdentifier`. `index.api.md` regenerated, warning- and undocumented-free. Reporter factory takes a narrow public `ReporterContext` rather than leaking the internal `ExecutionContext`.

## Tests

- Unit: `plugin-registry` (dedup/ordering/reporter registration), `use` (apply + task-type registration), `plugin-listener` (hook dispatch, ordering, abort vs downgrade, per-task result mapping).
- Integration: `options/plugin` (beforeAll/afterAll/beforeTask/afterTask fire around a real run), `options/plugin-reporter` (select by name, unknown-name error).
- Spec bumped to 3.7.0 (11-events, 13-reporting); docs in config-reference.

Out of scope (deferred): worker-process hooks, auto-discovery (separate sub-spec, #644), plugin-to-plugin deps.

Closes #641.

🤖 Generated with [Claude Code](https://claude.com/claude-code)