### PR TITLE
chore: bump size-limit to 210 KB for the plugin system

### DIFF
--- a/packages/nadle/package.json
+++ b/packages/nadle/package.json
@@ -101,7 +101,7 @@
 	"size-limit": [
 		{
 			"path": "lib/**",
-			"limit": "190 KB",
+			"limit": "210 KB",
 			"name": "bundled",
 			"brotli": false
 		}


### PR DESCRIPTION
The plugin system (#676) added ~8.5 KB; the bundle is now 198.55 KB, over the 190 KB ceiling, so main's Size Limit check is red. Bump to 210 KB (legitimate feature growth, with headroom).

Follow-up to #676.

🤖 Generated with [Claude Code](https://claude.com/claude-code)