### PR TITLE
fix: alias language-server banner imports to avoid duplicate fileURLToPath

### DIFF
--- a/tsup.config.ts
+++ b/tsup.config.ts
@@ -29,7 +29,7 @@ export default defineConfig([
 		dts: { entry: "packages/language-server/src/index.ts", compilerOptions: { rootDir: "packages/language-server/src" } },
 		noExternal: ["vscode-languageserver", "vscode-languageserver-textdocument", "typescript", "@nadle/kernel", "@nadle/project-resolver"],
 		banner: {
-			js: "#!/usr/bin/env node\nimport { createRequire } from 'module'; import { fileURLToPath } from 'url'; import { dirname } from 'path'; const require = createRequire(import.meta.url); const __filename = fileURLToPath(import.meta.url); const __dirname = dirname(__filename);"
+			js: "#!/usr/bin/env node\nimport { createRequire } from 'module'; import { fileURLToPath as _banner_fileURLToPath } from 'url'; import { dirname as _banner_dirname } from 'path'; const require = createRequire(import.meta.url); const __filename = _banner_fileURLToPath(import.meta.url); const __dirname = _banner_dirname(__filename);"
 		}
 	},
 	{


### PR DESCRIPTION
Ports the original `fix/language-server-duplicate-import` forward. That branch edited `packages/language-server/tsup.config.ts`, which was removed when the build pipeline was unified into the root `tsup.config.ts` — so the stale branch could not merge. The same collision bug lived on at the new location.

## Problem
The language-server bundle banner imported `fileURLToPath` (from `url`) and `dirname` (from `path`) at top level. Bundled dependencies (`locate-path`, `unicorn-magic`) emit identical imports, causing duplicate-import collisions in the output.

## Fix
Alias the banner imports to `_banner_fileURLToPath` / `_banner_dirname` in root `tsup.config.ts`.

## Verification
- `nadle bundle` → success.
- Built `server.js` confirmed: banner import now aliased; the bundled-dep `fileURLToPath` import no longer collides.

🤖 Generated with [Claude Code](https://claude.com/claude-code)