### PR TITLE
chore: self-host on keyed register API

### DIFF
--- a/nadle.config.ts
+++ b/nadle.config.ts
@@ -2,59 +2,62 @@ import { tasks, Inputs, Outputs, PnpmTask, PnpxTask, DeleteTask } from "./node_m
 
 // --- Maintenance ---
 
-tasks
-	.register("clean", DeleteTask, {
+tasks.register("clean", {
+	run: DeleteTask,
+	group: "Maintenance",
+	description: "Delete all build artifacts and temp directories",
+	options: {
 		paths: ["**/lib/**", "**/build/**", "**/__temp__/**", "packages/docs/docs/api/**", "packages/docs/.docusaurus/**", "packages/docs/static/spec/**"]
-	})
-	.config({ group: "Maintenance", description: "Delete all build artifacts and temp directories" });
+	}
+});
 
 // --- Checking ---
 
-tasks
-	.register("spell", PnpxTask, {
-		command: "cspell",
-		args: ["**", "--quiet", "--gitignore", "--cache", "--cache-location", "node_modules/.cache/cspell/.cspellcache"]
-	})
-	.config({
-		group: "Checking",
-		description: "Check spelling across all files"
-	});
-
-tasks
-	.register("eslint", PnpxTask, {
-		command: "eslint",
-		args: [".", "--quiet", "--cache", "--cache-location", "node_modules/.cache/eslint/"]
-	})
-	.config({
-		group: "Checking",
-		dependsOn: ["compile"],
-		description: "Lint all files with ESLint"
-	});
-
-tasks
-	.register("prettier", PnpxTask, {
-		command: "prettier",
-		args: ["--experimental-cli", "--check", "."]
-	})
-	.config({ group: "Checking", description: "Check formatting with Prettier" });
-
-tasks.register("knip", PnpmTask, { args: ["-r", "-F", "nadle", "-F", "create-nadle", "exec", "knip"] }).config({
+tasks.register("spell", {
+	run: PnpxTask,
 	group: "Checking",
-	description: "Find unused dependencies and exports"
+	description: "Check spelling across all files",
+	options: { command: "cspell", args: ["**", "--quiet", "--gitignore", "--cache", "--cache-location", "node_modules/.cache/cspell/.cspellcache"] }
 });
 
-tasks.register("validate", PnpxTask, { command: "tsx", args: "./src/index.ts" }).config({
+tasks.register("eslint", {
+	run: PnpxTask,
+	group: "Checking",
+	dependsOn: ["compile"],
+	description: "Lint all files with ESLint",
+	options: { command: "eslint", args: [".", "--quiet", "--cache", "--cache-location", "node_modules/.cache/eslint/"] }
+});
+
+tasks.register("prettier", {
+	run: PnpxTask,
+	group: "Checking",
+	description: "Check formatting with Prettier",
+	options: { command: "prettier", args: ["--experimental-cli", "--check", "."] }
+});
+
+tasks.register("knip", {
+	run: PnpmTask,
+	group: "Checking",
+	description: "Find unused dependencies and exports",
+	options: { args: ["-r", "-F", "nadle", "-F", "create-nadle", "exec", "knip"] }
+});
+
+tasks.register("validate", {
+	run: PnpxTask,
 	group: "Checking",
 	workingDir: "./packages/validators",
-	description: "Run package validators"
+	description: "Run package validators",
+	options: { command: "tsx", args: "./src/index.ts" }
 });
 
-tasks.register("checkLinks", PnpxTask, { command: "remark", args: ["--quiet", "--frail", "spec/"] }).config({
+tasks.register("checkLinks", {
+	run: PnpxTask,
 	group: "Checking",
+	options: { command: "remark", args: ["--quiet", "--frail", "spec/"] },
 	description: "Check for broken Markdown links and anchors in the spec"
 });
 
-tasks.register("check").config({
+tasks.register("check", {
 	group: "Checking",
 	description: "Run all checks (spell, lint, format, knip, validate, links)",
 	dependsOn: ["spell", "eslint", "prettier", "knip", "validate", "checkLinks"]
@@ -62,17 +65,21 @@ tasks.register("check").config({
 
 // --- Building (nadle-specific, kept here due to workspace self-reference limitation) ---
 
-tasks.register("typecheck", PnpxTask, { command: "tsgo", args: ["-b", "--noEmit"] }).config({
+tasks.register("typecheck", {
+	run: PnpxTask,
 	group: "Building",
 	// Depends on bundle: test files import "nadle"/"@nadle/language-server", whose .d.ts
 	// are emitted by tsup (bundle), not by compile. Without this, typecheck can race ahead
 	// of bundle on a clean build and fail to resolve those package types.
 	dependsOn: ["compile", "bundle"],
-	description: "Type-check all project references"
+	description: "Type-check all project references",
+	options: { command: "tsgo", args: ["-b", "--noEmit"] }
 });
 
-tasks.register("compile", PnpxTask, { command: "tsgo", args: ["-b", "./tsconfig.compile.json"] }).config({
+tasks.register("compile", {
+	run: PnpxTask,
 	group: "Building",
+	options: { command: "tsgo", args: ["-b", "./tsconfig.compile.json"] },
 	description: "Compile and type-check all tsgo-built packages in one pass",
 	outputs: [Outputs.dirs("packages/kernel/lib", "packages/project-resolver/lib", "packages/create-nadle/lib", "packages/eslint-plugin/lib")],
 	inputs: [
@@ -81,9 +88,11 @@ tasks.register("compile", PnpxTask, { command: "tsgo", args: ["-b", "./tsconfig.
 	]
 });
 
-tasks.register("bundle", PnpxTask, { command: "tsup" }).config({
+tasks.register("bundle", {
+	run: PnpxTask,
 	group: "Building",
 	dependsOn: ["compile"],
+	options: { command: "tsup" },
 	description: "Bundle all tsup-based packages in one pass",
 	outputs: [Outputs.dirs("packages/nadle/lib", "packages/language-server/lib", "packages/vscode-extension/lib")],
 	inputs: [
@@ -92,7 +101,7 @@ tasks.register("bundle", PnpxTask, { command: "tsup" }).config({
 	]
 });
 
-tasks.register("build").config({
+tasks.register("build", {
 	group: "Building",
 	dependsOn: ["compile", "typecheck", "bundle"],
 	description: "Compile, type-check, and bundle all packages"
@@ -100,33 +109,31 @@ tasks.register("build").config({
 
 // --- Testing (nadle-specific, kept here due to workspace self-reference limitation) ---
 
-tasks.register("testUnit", PnpxTask, { args: ["run"], command: "vitest" }).config({
+tasks.register("testUnit", {
+	run: PnpxTask,
 	group: "Testing",
 	dependsOn: ["bundle"],
+	options: { args: ["run"], command: "vitest" },
 	description: "Run all vitest projects (filter via passthrough, e.g. nadle testUnit -- --project kernel)"
 });
 
-tasks.register("test").config({
-	group: "Testing",
-	dependsOn: ["typecheck", "testUnit"],
-	description: "Run all tests and checks"
-});
+tasks.register("test", { group: "Testing", dependsOn: ["typecheck", "testUnit"], description: "Run all tests and checks" });
 
 // --- Formatting ---
 
-tasks.register("fixEslint", PnpxTask, { command: "eslint", args: [".", "--quiet", "--fix"] }).config({
+tasks.register("fixEslint", {
+	run: PnpxTask,
 	group: "Formatting",
 	dependsOn: ["compile"],
-	description: "Fix lint issues with ESLint"
+	description: "Fix lint issues with ESLint",
+	options: { command: "eslint", args: [".", "--quiet", "--fix"] }
 });
 
-tasks.register("fixPrettier", PnpxTask, { command: "prettier", args: ["--experimental-cli", "--write", "."] }).config({
+tasks.register("fixPrettier", {
+	run: PnpxTask,
 	group: "Formatting",
-	description: "Format all files with Prettier"
+	description: "Format all files with Prettier",
+	options: { command: "prettier", args: ["--experimental-cli", "--write", "."] }
 });
 
-tasks.register("format").config({
-	group: "Formatting",
-	dependsOn: ["fixEslint", "fixPrettier"],
-	description: "Fix lint and format all files"
-});
+tasks.register("format", { group: "Formatting", dependsOn: ["fixEslint", "fixPrettier"], description: "Fix lint and format all files" });

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
 		"husky": "^9.1.7",
 		"jiti": "^2.7.0",
 		"knip": "^6.16.1",
-		"nadle": "^0.5.3",
+		"nadle": "https://pkg.pr.new/nadlejs/nadle@185f0cc",
 		"prettier": "^3.8.4",
 		"remark-cli": "^12.0.1",
 		"remark-validate-links": "^13.1.0",

--- a/packages/docs/nadle.config.ts
+++ b/packages/docs/nadle.config.ts
@@ -1,29 +1,37 @@
 import { tasks, Inputs, Outputs, PnpxTask } from "../../node_modules/nadle/lib/index.js";
 
-tasks.register("buildSpec", PnpxTask, { command: "tsx", args: "scripts/build-spec.ts" }).config({
+tasks.register("buildSpec", {
+	run: PnpxTask,
 	group: "Building",
 	outputs: [Outputs.dirs("static/spec")],
 	description: "Build spec HTML from markdown",
+	options: { command: "tsx", args: "scripts/build-spec.ts" },
 	inputs: [Inputs.files("../../spec/*.md"), Inputs.files("scripts/build-spec.ts")]
 });
 
-tasks.register("buildCliReference", PnpxTask, { command: "tsx", args: "scripts/build-cli-reference.ts" }).config({
+tasks.register("buildCliReference", {
+	run: PnpxTask,
 	group: "Building",
 	outputs: [Outputs.files("docs/cli-reference.md")],
 	description: "Build CLI reference markdown from source",
+	options: { command: "tsx", args: "scripts/build-cli-reference.ts" },
 	inputs: [Inputs.files("../nadle/src/core/options/cli-options.ts"), Inputs.files("scripts/build-cli-reference.ts")]
 });
 
-tasks.register("prepareAPIMarkdown", PnpxTask, { command: "tsx", args: "scripts/adjust-api-markdown.ts" }).config({
+tasks.register("prepareAPIMarkdown", {
+	run: PnpxTask,
 	group: "Building",
 	dependsOn: ["packages:nadle:generateMarkdown"],
-	description: "Prepare API markdown for docusaurus"
+	description: "Prepare API markdown for docusaurus",
+	options: { command: "tsx", args: "scripts/adjust-api-markdown.ts" }
 });
 
-tasks.register("buildSite", PnpxTask, { args: "build", command: "docusaurus" }).config({
+tasks.register("buildSite", {
+	run: PnpxTask,
 	group: "Building",
 	outputs: [Outputs.dirs("build")],
 	description: "Build documentation site",
+	options: { args: "build", command: "docusaurus" },
 	dependsOn: ["prepareAPIMarkdown", "buildSpec", "buildCliReference"],
 	inputs: [Inputs.dirs("src", "docs", "static"), Inputs.files("docusaurus.config.ts", "sidebars.ts")]
 });

--- a/packages/examples/basic/nadle.config.ts
+++ b/packages/examples/basic/nadle.config.ts
@@ -4,14 +4,19 @@ configure({
 	logLevel: "debug"
 });
 
-tasks
-	.register("hello", async () => {
+tasks.register("hello", {
+	group: "Greetings",
+	description: "Say hello",
+	run: async () => {
 		console.log("Hello from Nadle!");
-	})
-	.config({ group: "Greetings", description: "Say hello" });
+	}
+});
 
-tasks
-	.register("goodbye", () => {
+tasks.register("goodbye", {
+	group: "Greetings",
+	dependsOn: ["hello"],
+	description: "Say goodbye",
+	run: () => {
 		console.log("Goodbye, Nadle!");
-	})
-	.config({ group: "Greetings", dependsOn: ["hello"], description: "Say goodbye" });
+	}
+});

--- a/packages/nadle/nadle.config.ts
+++ b/packages/nadle/nadle.config.ts
@@ -1,23 +1,15 @@
-// Self-host config bootstraps on the published nadle (old .config() API); the local build's
-// index.d.ts (new keyed API) shadows it via package self-reference, so it cannot typecheck
-// against the local types. ts-nocheck suppresses that; migrates post-publish. ban-ts-comment
-// is disabled here because the file must stay in the tsconfig for eslint's project service.
-// eslint-disable-next-line @typescript-eslint/ban-ts-comment
-// @ts-nocheck
 import Path from "node:path";
 import Fs from "node:fs/promises";
 
 import { tasks, Inputs, Outputs, PnpxTask } from "../../node_modules/nadle/lib/index.js";
 
-tasks.register("build").config({
-	group: "Building",
-	dependsOn: ["root:bundle"],
-	description: "Bundle nadle (delegates to root bundle)"
-});
+tasks.register("build", { group: "Building", dependsOn: ["root:bundle"], description: "Bundle nadle (delegates to root bundle)" });
 
-tasks.register("generateMarkdown", PnpxTask, { command: "typedoc" }).config({
+tasks.register("generateMarkdown", {
+	run: PnpxTask,
 	group: "Building",
 	dependsOn: ["build"],
+	options: { command: "typedoc" },
 	outputs: [Outputs.dirs("../docs/docs/api")],
 	description: "Generate API markdown with typedoc",
 	inputs: [Inputs.dirs("lib"), Inputs.files("typedoc.json")]
@@ -25,16 +17,21 @@ tasks.register("generateMarkdown", PnpxTask, { command: "typedoc" }).config({
 
 // --- Testing (nadle-specific, kept here due to workspace self-reference limitation) ---
 
-tasks.register("testAPI", PnpxTask, { args: ["run"], command: "api-extractor" }).config({
+tasks.register("testAPI", {
+	run: PnpxTask,
 	group: "Testing",
 	dependsOn: ["build"],
 	outputs: [Outputs.dirs("build/api")],
+	options: { args: ["run"], command: "api-extractor" },
 	description: "Verify API surface with api-extractor",
 	inputs: [Inputs.files("lib/index.d.ts", "api-extractor.json", "../../api-extractor.json", "index.api.md")]
 });
 
-tasks
-	.register("testNoWarningsAndUndocumentedAPI", async () => {
+tasks.register("testNoWarningsAndUndocumentedAPI", {
+	group: "Testing",
+	dependsOn: ["testAPI"],
+	description: "Ensure no API warnings or undocumented items",
+	run: async () => {
 		const apiContent = await Fs.readFile(Path.join(import.meta.dirname, "index.api.md"), "utf-8");
 
 		if (apiContent.includes("Warning:")) {
@@ -44,23 +41,17 @@ tasks
 		if (apiContent.includes("undocumented")) {
 			throw new Error(`API documentation contains undocumented items`);
 		}
-	})
-	.config({
-		group: "Testing",
-		dependsOn: ["testAPI"],
-		description: "Ensure no API warnings or undocumented items"
-	});
-
-tasks.register("test").config({
-	group: "Testing",
-	description: "Run all tests and checks",
-	dependsOn: ["testAPI", "testNoWarningsAndUndocumentedAPI"]
+	}
 });
+
+tasks.register("test", { group: "Testing", description: "Run all tests and checks", dependsOn: ["testAPI", "testNoWarningsAndUndocumentedAPI"] });
 
 // --- Maintenance (nadle-specific) ---
 
-tasks.register("updateAPI", PnpxTask, { command: "api-extractor", args: ["run", "--local"] }).config({
+tasks.register("updateAPI", {
+	run: PnpxTask,
 	group: "Maintenance",
 	dependsOn: ["build"],
-	description: "Update API report locally"
+	description: "Update API report locally",
+	options: { command: "api-extractor", args: ["run", "--local"] }
 });

--- a/packages/sample-app/nadle.config.ts
+++ b/packages/sample-app/nadle.config.ts
@@ -1,7 +1,6 @@
 import Process from "node:process";
 
-import { Inputs } from "nadle";
-import { tasks, Outputs, PnpxTask, CopyTask, type Task, configure } from "nadle";
+import { lazy, tasks, Inputs, Outputs, PnpxTask, CopyTask, type Task, configure } from "nadle";
 
 import { createTask } from "./create-task.js";
 
@@ -13,22 +12,27 @@ configure({
 /**
  * Basic tasks
  */
-tasks
-	.register("hello", async () => {
+tasks.register("hello", {
+	group: "Greetings",
+	description: "Say hello",
+	run: async () => {
 		console.log("Hello from Nadle!");
-	})
-	.config({ group: "Greetings", description: "Say hello" });
+	}
+});
 
-tasks
-	.register("goodbye", () => {
+tasks.register("goodbye", {
+	group: "Greetings",
+	dependsOn: ["hello"],
+	description: "Say goodbye",
+	run: () => {
 		console.log("Goodbye, Nadle!");
-	})
-	.config({ group: "Greetings", dependsOn: ["hello"], description: "Say goodbye" });
+	}
+});
 
 /**
  * Copy task
  */
-tasks.register("copy", CopyTask, { to: "dist/", from: "assets/" }).config({ dependsOn: ["prepare"] });
+tasks.register("copy", { run: CopyTask, dependsOn: ["prepare"], options: { to: "dist/", from: "assets/" } });
 
 tasks.register("prepare", async () => {
 	console.log("Preparing...");
@@ -38,17 +42,19 @@ tasks.register("prepare", async () => {
  * Error handling
  */
 
-tasks
-	.register("throwable", () => {
+tasks.register("throwable", {
+	dependsOn: ["prepare", "hello"],
+	run: () => {
 		throw new Error("This is an error");
-	})
-	.config({ dependsOn: ["prepare", "hello"] });
+	}
+});
 
-tasks
-	.register("post-throwable", () => {
+tasks.register("post-throwable", {
+	dependsOn: ["throwable"],
+	run: () => {
 		console.log("It should not reach here");
-	})
-	.config({ dependsOn: ["throwable"] });
+	}
+});
 
 /**
  * Regular tasks
@@ -57,42 +63,48 @@ tasks.register("node", () => {
 	console.log("Setup node...");
 });
 
-tasks
-	.register("install", () => {
+tasks.register("install", {
+	dependsOn: ["node"],
+	run: () => {
 		console.log("Installing npm...");
-	})
-	.config({ dependsOn: ["node"] });
+	}
+});
 
-tasks
-	.register("compileTs", PnpxTask, {
-		command: "tsc",
-		args: ["--project", "tsconfig.src.json"]
-	})
-	.config({ dependsOn: ["install"], outputs: [Outputs.dirs("dist")], inputs: [Inputs.files("src/**/*.ts")] });
+tasks.register("compileTs", {
+	run: PnpxTask,
+	dependsOn: ["install"],
+	outputs: [Outputs.dirs("dist")],
+	inputs: [Inputs.files("src/**/*.ts")],
+	options: { command: "tsc", args: ["--project", "tsconfig.src.json"] }
+});
 
-tasks
-	.register("compileSvg", () => {
+tasks.register("compileSvg", {
+	dependsOn: ["install"],
+	run: () => {
 		console.log("Compiling svg...");
-	})
-	.config({ dependsOn: ["install"] });
+	}
+});
 
-tasks
-	.register("compile", () => {
+tasks.register("compile", {
+	dependsOn: ["compileSvg", "compileTs"],
+	run: () => {
 		console.log("Compiling...");
-	})
-	.config({ dependsOn: ["compileSvg", "compileTs"] });
+	}
+});
 
-tasks
-	.register("test", () => {
+tasks.register("test", {
+	dependsOn: ["install"],
+	run: () => {
 		console.log("Running tests...");
-	})
-	.config({ dependsOn: ["install"] });
+	}
+});
 
-tasks
-	.register("build", () => {
+tasks.register("build", {
+	dependsOn: ["test", "compile"],
+	run: () => {
 		console.log("Building...");
-	})
-	.config({ dependsOn: ["test", "compile"] });
+	}
+});
 
 /**
  * Progressive tasks
@@ -101,56 +113,67 @@ tasks
 tasks.register(...createTask("task-A-0", { subTaskCount: 3, subTaskDuration: 1500 }));
 tasks.register(...createTask("task-A-1", { subTaskCount: 3, subTaskDuration: 2000 }));
 tasks.register(...createTask("task-A-2", { subTaskCount: 3, subTaskDuration: 1200 }));
-tasks.register(...createTask("task-A", { subTaskCount: 3, subTaskDuration: 1000 })).config({ dependsOn: ["task-A-0", "task-A-1", "task-A-2"] });
+tasks.register("task-A", {
+	dependsOn: ["task-A-0", "task-A-1", "task-A-2"],
+	run: createTask("task-A", { subTaskCount: 3, subTaskDuration: 1000 })[1]
+});
 
 tasks.register(...createTask("task-B-0", { subTaskCount: 3, subTaskDuration: 1300 }));
 tasks.register(...createTask("task-B-1", { subTaskCount: 3, subTaskDuration: 1700 }));
 tasks.register(...createTask("task-B-2", { subTaskCount: 3, subTaskDuration: 1400 }));
-tasks.register(...createTask("task-B", { subTaskCount: 3, subTaskDuration: 1500 })).config({ dependsOn: ["task-B-0", "task-B-1", "task-B-2"] });
+tasks.register("task-B", {
+	dependsOn: ["task-B-0", "task-B-1", "task-B-2"],
+	run: createTask("task-B", { subTaskCount: 3, subTaskDuration: 1500 })[1]
+});
 
-tasks.register(...createTask("task-C-0", { subTaskCount: 3, subTaskDuration: 1200 })).config({ dependsOn: ["task-A", "task-B"] });
-tasks.register(...createTask("task-C-1", { subTaskCount: 3, subTaskDuration: 1500 })).config({ dependsOn: ["task-A", "task-B"] });
-tasks.register(...createTask("task-C-2", { subTaskCount: 3, subTaskDuration: 1300 })).config({ dependsOn: ["task-A", "task-B"] });
-tasks.register(...createTask("task-C-3", { subTaskCount: 3, subTaskDuration: 1300 })).config({ dependsOn: ["task-A", "task-B"] });
-tasks.register(...createTask("task-C-4", { subTaskCount: 3, subTaskDuration: 1300 })).config({ dependsOn: ["task-A", "task-B"] });
-tasks.register(...createTask("task-C-5", { subTaskCount: 3, subTaskDuration: 1300 })).config({ dependsOn: ["task-A", "task-B"] });
-tasks
-	.register(...createTask("task-C", { subTaskCount: 3, subTaskDuration: 1000 }))
-	.config({ dependsOn: ["task-A", "task-B", "task-C-0", "task-C-1", "task-C-2", "task-C-3", "task-C-4", "task-C-5"] });
+tasks.register("task-C-0", { dependsOn: ["task-A", "task-B"], run: createTask("task-C-0", { subTaskCount: 3, subTaskDuration: 1200 })[1] });
+tasks.register("task-C-1", { dependsOn: ["task-A", "task-B"], run: createTask("task-C-1", { subTaskCount: 3, subTaskDuration: 1500 })[1] });
+tasks.register("task-C-2", { dependsOn: ["task-A", "task-B"], run: createTask("task-C-2", { subTaskCount: 3, subTaskDuration: 1300 })[1] });
+tasks.register("task-C-3", { dependsOn: ["task-A", "task-B"], run: createTask("task-C-3", { subTaskCount: 3, subTaskDuration: 1300 })[1] });
+tasks.register("task-C-4", { dependsOn: ["task-A", "task-B"], run: createTask("task-C-4", { subTaskCount: 3, subTaskDuration: 1300 })[1] });
+tasks.register("task-C-5", { dependsOn: ["task-A", "task-B"], run: createTask("task-C-5", { subTaskCount: 3, subTaskDuration: 1300 })[1] });
+tasks.register("task-C", {
+	run: createTask("task-C", { subTaskCount: 3, subTaskDuration: 1000 })[1],
+	dependsOn: ["task-A", "task-B", "task-C-0", "task-C-1", "task-C-2", "task-C-3", "task-C-4", "task-C-5"]
+});
 
 /**
  * Cycle tasks
  */
-tasks.register("cycle-1").config({ dependsOn: ["cycle-2"] });
-tasks.register("cycle-2").config({ dependsOn: ["cycle-3"] });
-tasks.register("cycle-3").config({ dependsOn: ["cycle-4"] });
-tasks.register("cycle-4").config({ dependsOn: ["cycle-5"] });
-tasks.register("cycle-5").config({ dependsOn: ["cycle-2"] });
+tasks.register("cycle-1", { dependsOn: ["cycle-2"] });
+tasks.register("cycle-2", { dependsOn: ["cycle-3"] });
+tasks.register("cycle-3", { dependsOn: ["cycle-4"] });
+tasks.register("cycle-4", { dependsOn: ["cycle-5"] });
+tasks.register("cycle-5", { dependsOn: ["cycle-2"] });
 
-tasks.register("firstTask", () => console.log("firstTask")).config({ env: { FIRST_TASK_ENV: "first task env" } });
+tasks.register("firstTask", { run: () => console.log("firstTask"), env: { FIRST_TASK_ENV: "first task env" } });
 
 const MyTask: Task = {
 	run: () => console.log(Process.env.FIRST_TASK_ENV)
 };
 
-tasks.register("secondTask", MyTask, {}).config(() => ({ env: { SECOND_TASK_ENV: "second task env" } }));
+tasks.register(
+	"secondTask",
+	lazy(() => ({ run: MyTask, options: {}, env: { SECOND_TASK_ENV: "second task env" } }))
+);
 
-tasks
-	.register("printWorkingDir", ({ context }) => {
+tasks.register("printWorkingDir", {
+	workingDir: "../..",
+	run: ({ context }) => {
 		console.log(`Current working directory: ${context.workingDir}`);
-	})
-	.config({
-		workingDir: "../.."
-	});
+	}
+});
 
 tasks.register("base");
-tasks
-	.register("fast", async () => {
+tasks.register("fast", {
+	dependsOn: ["base"],
+	run: async () => {
 		await new Promise((r) => setTimeout(r, 2000));
-	})
-	.config({ dependsOn: ["base"] });
-tasks
-	.register("slow", async () => {
+	}
+});
+tasks.register("slow", {
+	dependsOn: ["base"],
+	run: async () => {
 		await new Promise((r) => setTimeout(r, 3000));
-	})
-	.config({ dependsOn: ["base"] });
+	}
+});

--- a/packages/vscode-extension/nadle.config.ts
+++ b/packages/vscode-extension/nadle.config.ts
@@ -1,21 +1,21 @@
 import { tasks, Inputs, Outputs, ExecTask, PnpxTask } from "../../node_modules/nadle/lib/index.js";
 
-tasks.register("copy-server", ExecTask, { command: "node", args: ["scripts/copy-server.mjs"] }).config({
+tasks.register("copy-server", {
+	run: ExecTask,
 	group: "Building",
 	dependsOn: ["root:bundle"],
 	outputs: [Outputs.dirs("server")],
 	description: "Copy LSP server into extension",
+	options: { command: "node", args: ["scripts/copy-server.mjs"] },
 	inputs: [Inputs.dirs("../language-server/lib"), Inputs.files("scripts/copy-server.mjs")]
 });
 
-tasks.register("build").config({
-	group: "Building",
-	dependsOn: ["copy-server"],
-	description: "Build vscode extension"
-});
+tasks.register("build", { group: "Building", dependsOn: ["copy-server"], description: "Build vscode extension" });
 
-tasks.register("package", PnpxTask, { command: "vsce", args: "package" }).config({
+tasks.register("package", {
+	run: PnpxTask,
 	group: "Building",
 	dependsOn: ["build"],
+	options: { command: "vsce", args: "package" },
 	description: "Package vscode extension (.vsix)"
 });

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -67,8 +67,8 @@ importers:
         specifier: ^6.16.1
         version: 6.16.1
       nadle:
-        specifier: ^0.5.3
-        version: 0.5.3(@types/react@19.2.17)
+        specifier: https://pkg.pr.new/nadlejs/nadle@185f0cc
+        version: https://pkg.pr.new/nadlejs/nadle@185f0cc(@types/react@19.2.17)
       prettier:
         specifier: ^3.8.4
         version: 3.8.4
@@ -2717,8 +2717,9 @@ packages:
     peerDependencies:
       eslint: ^9.30.1
 
-  '@nadle/kernel@0.0.2':
-    resolution: {integrity: sha512-J43dusMefpYeHx3jKKjGlvYZBYAEsGmmQDK4u4eeagJUsanuw18eKFSTt2mw0OaOqgNPvUWxFnXvXi52+W+BCA==}
+  '@nadle/kernel@https://pkg.pr.new/nadlejs/nadle/@nadle/kernel@185f0cc544fbec238cc6fd971165e3c853dcd538':
+    resolution: {integrity: sha512-0/20Dbx1ISJKsLXQ0HjY0MgHi87i4l3XzGr6OBgPviabdX1p+C52MqnW62yZUTZVXvvDmRXA2jTyIT6n4HJsow==, tarball: https://pkg.pr.new/nadlejs/nadle/@nadle/kernel@185f0cc544fbec238cc6fd971165e3c853dcd538}
+    version: 0.0.2
     engines: {node: '>=22'}
 
   '@nadle/prettier-config@0.0.5':
@@ -2727,8 +2728,9 @@ packages:
     peerDependencies:
       prettier: ^3.6.2
 
-  '@nadle/project-resolver@0.0.3':
-    resolution: {integrity: sha512-kElU5QIcRdR0y3ZkjfvaGDBqvEHlxrMzMF10Uq2ikgSGgnA6RD62qYFzp/0acNzTMS54euj1AMyS5kcDTTsBPA==}
+  '@nadle/project-resolver@https://pkg.pr.new/nadlejs/nadle/@nadle/project-resolver@185f0cc544fbec238cc6fd971165e3c853dcd538':
+    resolution: {integrity: sha512-lpLS/6A1xxJjM0ZNcCnqfz5IkoyOIMJIsjxNG0/annpKM0qWlRX/5TVJSoxkPfWWd9bR/2pkxpk+u0qz1vMKeQ==, tarball: https://pkg.pr.new/nadlejs/nadle/@nadle/project-resolver@185f0cc544fbec238cc6fd971165e3c853dcd538}
+    version: 0.0.3
     engines: {node: '>=22'}
     hasBin: true
 
@@ -7205,8 +7207,9 @@ packages:
   mz@2.7.0:
     resolution: {integrity: sha512-z81GNO7nnYMEhrGh9LeymoE4+Yr0Wn5McHIZMK5cfQCl+NDX08sCZgUc9/6MHni9IWuFLm1Z3HTCXu2z9fN62Q==}
 
-  nadle@0.5.3:
-    resolution: {integrity: sha512-wz8O/FGCNe9YqGhmUoKn7BBtYoN41Aol6fkEs03QFbC/8qEj5a/9wDpzgjP7paH/0mk1/k5lTCWavIZckPnNkw==}
+  nadle@https://pkg.pr.new/nadlejs/nadle@185f0cc:
+    resolution: {integrity: sha512-MkB3PYHd/UCJG4n16in0yonD7g99YN+wVqpEB6uzX6i7QFZUfTt5m44oAPryFRfrca2/JHbVOU2QQ7ccAiqFPw==, tarball: https://pkg.pr.new/nadlejs/nadle@185f0cc}
+    version: 0.5.3
     engines: {node: '>=22'}
     hasBin: true
 
@@ -12916,17 +12919,17 @@ snapshots:
       - typescript
       - vitest
 
-  '@nadle/kernel@0.0.2': {}
+  '@nadle/kernel@https://pkg.pr.new/nadlejs/nadle/@nadle/kernel@185f0cc544fbec238cc6fd971165e3c853dcd538': {}
 
   '@nadle/prettier-config@0.0.5(prettier@3.8.4)':
     dependencies:
       prettier: 3.8.4
 
-  '@nadle/project-resolver@0.0.3':
+  '@nadle/project-resolver@https://pkg.pr.new/nadlejs/nadle/@nadle/project-resolver@185f0cc544fbec238cc6fd971165e3c853dcd538':
     dependencies:
       '@manypkg/find-root': 3.1.0
       '@manypkg/tools': 2.1.2
-      '@nadle/kernel': 0.0.2
+      '@nadle/kernel': https://pkg.pr.new/nadlejs/nadle/@nadle/kernel@185f0cc544fbec238cc6fd971165e3c853dcd538
       find-up: 8.0.0
 
   '@nadle/ts-config@0.0.2': {}
@@ -18214,10 +18217,11 @@ snapshots:
       object-assign: 4.1.1
       thenify-all: 1.6.0
 
-  nadle@0.5.3(@types/react@19.2.17):
+  nadle@https://pkg.pr.new/nadlejs/nadle@185f0cc(@types/react@19.2.17):
     dependencies:
-      '@nadle/kernel': 0.0.2
-      '@nadle/project-resolver': 0.0.3
+      '@nadle/kernel': https://pkg.pr.new/nadlejs/nadle/@nadle/kernel@185f0cc544fbec238cc6fd971165e3c853dcd538
+      '@nadle/project-resolver': https://pkg.pr.new/nadlejs/nadle/@nadle/project-resolver@185f0cc544fbec238cc6fd971165e3c853dcd538
+      chokidar: 5.0.0
       consola: 3.4.2
       execa: 9.6.1
       fast-glob: 3.3.3

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -12,7 +12,11 @@ minimumReleaseAgeExclude:
   - "@typescript/native-preview*"
   - "@nadle/kernel@0.0.2"
   - "@nadle/project-resolver@0.0.3"
-  - nadle@0.5.3
+
+# The self-host nadle devDependency is a pkg.pr.new snapshot (transient URL) of the
+# keyed-spec API merge; its transitive @nadle/kernel / @nadle/project-resolver resolve
+# via pkg.pr.new URLs (exotic subdeps), so allow them. Revert once 0.6.0 is on npm.
+blockExoticSubdeps: false
 
 # Only esbuild needs its install script; the rest were silently skipped
 # under pnpm 10 as well and work fine without building.


### PR DESCRIPTION
## What

Self-hosts the nadle monorepo on the **keyed-spec task registration API** merged in #688.

- Bumps the bootstrap `nadle` devDependency from `^0.5.3` (old `.config()` API) to the
  pkg.pr.new snapshot of the merge commit: `https://pkg.pr.new/nadlejs/nadle@185f0cc`.
- Migrates the 6 self-host `nadle.config.ts` files to the keyed form
  (`tasks.register(name, { run, options, ...config })`, `lazy()` for deferred config)
  using the bundled `scripts/codemod-register-api.ts`, plus manual fixes for the
  `sample-app` `createTask(...)` tuple-spread + `.config()` sites.
- Removes the `// @ts-nocheck` + `// eslint-disable-next-line @typescript-eslint/ban-ts-comment`
  workarounds from `packages/nadle/nadle.config.ts` — the config now typechecks clean against
  the new types.

Closes #689.

## Why a pkg.pr.new snapshot

The repo builds itself, so its own configs must match the API of the installed `nadle`.
0.6.0 (keyed API) is not yet published to npm, so the bootstrap dep points at the
pkg.pr.new per-commit snapshot of the merge build as an interim measure.

## Verification (self-host pipeline on the new bin)

- `nadle --list` — parses all migrated keyed configs (root + docs + vscode + nadle).
- `nadle compile` and `nadle bundle` — succeed.
- `nadle check` — spell, eslint, prettier, knip, validate, checkLinks all pass.

## Lockfile notes

- `blockExoticSubdeps: false` added to `pnpm-workspace.yaml` — the snapshot's transitive
  `@nadle/kernel` / `@nadle/project-resolver` resolve via pkg.pr.new URLs (exotic subdeps).
- Genuine `integrity` sha512 injected into the `nadle@` and `@nadle/kernel@` lockfile
  tarball entries (pkg.pr.new's CDN serves no checksum header, so pnpm can't record one;
  the values are real content hashes of the exact tarballs, verified by reproducing the
  `@nadle/project-resolver` integrity pnpm recorded itself). Without these, cold frozen
  CI installs fail.
- The `nadle@0.5.3` entry was dropped from `minimumReleaseAgeExclude` (URL deps aren't
  release-age-gated).

## Follow-up

The `nadle` devDep is a **transient pkg.pr.new URL**. Swap it for the real published
version once `nadle@0.6.0` is on npm, and revert `blockExoticSubdeps` + the manual
lockfile integrity entries.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
