### PR TITLE
feat: agent-friendly docs (copy-page + inline agent prompts)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,3 +35,6 @@ packages/vscode-extension/server
 # typescript
 *.tsbuildinfo
 tsconfig.vitest-temp.json
+
+# brainstorm/visual-companion scratch
+.superpowers/

--- a/docs/superpowers/plans/2026-06-15-agent-friendly-docs.md
+++ b/docs/superpowers/plans/2026-06-15-agent-friendly-docs.md
@@ -1,0 +1,420 @@
+# Agent-Friendly nadle.dev Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add a site-wide "Copy page" (as Markdown) button to every doc page on nadle.dev, plus inline `<AgentPrompt>` blocks that copy a ready-made agent instruction on the setup/migrate/caching/plugin guides.
+
+**Architecture:** Two independent React/MDX units in `packages/docs/src/`. `CopyPageButton` fetches the current route's generated `.md` (the llms-txt plugin emits `/docs/foo` → `/docs/foo.md` at the same path) and writes it to the clipboard, with a page-URL fallback. It's rendered above every doc article via a swizzled `theme/DocItem/Content`. `AgentPrompt` is a small MDX component (registered globally via swizzled `theme/MDXComponents`) that renders its children as a copyable prompt block. Neither depends on the other. No build-plugin changes — the `.md` sources already exist.
+
+**Tech Stack:** Docusaurus 3, React 18, `@mdx-js/react`, TypeScript, `clsx`, Docusaurus CSS modules. Docs build/lint via the repo's `nadle` tasks; this package has no unit-test suite (verification is build + manual), matching repo norms.
+
+**Spec:** `docs/superpowers/specs/2026-06-15-agent-friendly-docs-design.md`
+
+**Conventions verified:** `theme/Footer/index.tsx` is already swizzled (precedent). Per-page Markdown is served at `route + ".md"` (confirmed: `/docs/why-nadle` → `build/docs/why-nadle.md`). The keyed-spec register API (post-#688) is the current API — prompts must use it.
+
+**Build/verify note:** the self-host `nadle` runner works post-#693. Build the docs site with `pnpm nadle packages:docs:buildSite`; run the dev server with the docs package's `start` script. Run commands from the repo root.
+
+---
+
+## File Structure
+
+- `packages/docs/src/components/CopyPageButton/index.tsx` — the button + copy logic (fetch `.md`, clipboard, fallback, "Copied!" state). One unit.
+- `packages/docs/src/components/CopyPageButton/styles.module.css` — its styles.
+- `packages/docs/src/theme/DocItem/Content/index.tsx` — swizzled wrapper that renders `<CopyPageButton/>` above the original doc content.
+- `packages/docs/src/components/AgentPrompt/index.tsx` — the inline prompt block.
+- `packages/docs/src/components/AgentPrompt/styles.module.css` — its styles.
+- `packages/docs/src/theme/MDXComponents.tsx` — registers `AgentPrompt` globally so MDX/MD pages can use `<AgentPrompt>` without importing.
+- MDX edits: `getting-started/installation.md`, a migration guide, `guides/configuring-task.md`, `guides/authoring-plugin.md` — add one `<AgentPrompt>` each.
+
+---
+
+## Task 1: CopyPageButton component
+
+**Files:**
+- Create: `packages/docs/src/components/CopyPageButton/index.tsx`
+- Create: `packages/docs/src/components/CopyPageButton/styles.module.css`
+
+- [ ] **Step 1: Create the styles module**
+
+`packages/docs/src/components/CopyPageButton/styles.module.css`:
+```css
+.button {
+	display: inline-flex;
+	align-items: center;
+	gap: 0.4rem;
+	padding: 0.25rem 0.7rem;
+	font-size: 0.8rem;
+	font-weight: 600;
+	color: var(--ifm-color-emphasis-800);
+	background: var(--ifm-color-emphasis-100);
+	border: 1px solid var(--ifm-color-emphasis-300);
+	border-radius: 6px;
+	cursor: pointer;
+	transition: background 0.15s ease;
+}
+.button:hover {
+	background: var(--ifm-color-emphasis-200);
+}
+.copied {
+	color: var(--ifm-color-success);
+	border-color: var(--ifm-color-success);
+}
+```
+
+- [ ] **Step 2: Create the component**
+
+`packages/docs/src/components/CopyPageButton/index.tsx`:
+```tsx
+import React, { useState } from "react";
+import { useLocation } from "@docusaurus/router";
+import styles from "./styles.module.css";
+
+type Status = "idle" | "copied" | "linked";
+
+export default function CopyPageButton(): React.ReactElement {
+	const { pathname } = useLocation();
+	const [status, setStatus] = useState<Status>("idle");
+
+	async function handleCopy(): Promise<void> {
+		const mdUrl = pathname.replace(/\/$/, "") + ".md";
+		try {
+			const response = await fetch(mdUrl);
+			if (!response.ok) {
+				throw new Error(`status ${response.status}`);
+			}
+			const markdown = await response.text();
+			await navigator.clipboard.writeText(markdown);
+			setStatus("copied");
+		} catch {
+			// Fallback: copy the page URL so the agent can fetch it.
+			await navigator.clipboard.writeText(window.location.href);
+			setStatus("linked");
+		}
+		setTimeout(() => setStatus("idle"), 2000);
+	}
+
+	const label = status === "copied" ? "Copied!" : status === "linked" ? "Link copied" : "Copy page";
+
+	return (
+		<button
+			type="button"
+			className={status === "idle" ? styles.button : `${styles.button} ${styles.copied}`}
+			onClick={handleCopy}
+			title="Copy this page as Markdown for an AI agent"
+		>
+			📋 {label}
+		</button>
+	);
+}
+```
+
+- [ ] **Step 3: Type-check the component**
+
+Run: `pnpm --filter @nadle/internal-docs exec tsc --noEmit` (or the docs package's typecheck script — check `packages/docs/package.json` scripts; if none, `cd packages/docs && pnpm exec tsc --noEmit`)
+Expected: no type errors in the new files.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add packages/docs/src/components/CopyPageButton
+git commit -m "feat: CopyPageButton component for docs"
+```
+
+---
+
+## Task 2: Swizzle DocItem/Content to render the button
+
+**Files:**
+- Create: `packages/docs/src/theme/DocItem/Content/index.tsx`
+
+- [ ] **Step 1: Create the swizzled wrapper**
+
+`packages/docs/src/theme/DocItem/Content/index.tsx`:
+```tsx
+import React from "react";
+import Content from "@theme-original/DocItem/Content";
+import type ContentType from "@theme/DocItem/Content";
+import type { WrapperProps } from "@docusaurus/types";
+import CopyPageButton from "@site/src/components/CopyPageButton";
+import styles from "./styles.module.css";
+
+type Props = WrapperProps<typeof ContentType>;
+
+export default function ContentWrapper(props: Props): React.ReactElement {
+	return (
+		<>
+			<div className={styles.actions}>
+				<CopyPageButton />
+			</div>
+			<Content {...props} />
+		</>
+	);
+}
+```
+
+- [ ] **Step 2: Create its styles**
+
+`packages/docs/src/theme/DocItem/Content/styles.module.css`:
+```css
+.actions {
+	display: flex;
+	justify-content: flex-end;
+	margin-bottom: 0.5rem;
+}
+```
+
+- [ ] **Step 3: Build the site to verify the swizzle resolves**
+
+Run: `pnpm nadle packages:docs:buildSite`
+Expected: build succeeds; no "component not found" / swizzle errors. (`@theme-original/DocItem/Content` must resolve — it's a standard Docusaurus theme component.)
+
+- [ ] **Step 4: Manually verify in the dev server**
+
+Run: `cd packages/docs && pnpm start` (or the package's dev script), open any `/docs/*` page.
+Expected: a "Copy page" button appears at the top-right of the article. Click it → paste into an editor → the page's Markdown appears. (If `.md` 404s in dev, the fallback copies the URL — that's acceptable; the `.md` is generated in the production build.)
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add packages/docs/src/theme/DocItem/Content
+git commit -m "feat: render Copy page button on every doc page"
+```
+
+---
+
+## Task 3: AgentPrompt component
+
+**Files:**
+- Create: `packages/docs/src/components/AgentPrompt/index.tsx`
+- Create: `packages/docs/src/components/AgentPrompt/styles.module.css`
+
+- [ ] **Step 1: Create the styles (minimal admonition aesthetic — green left border)**
+
+`packages/docs/src/components/AgentPrompt/styles.module.css`:
+```css
+.block {
+	border-left: 3px solid var(--ifm-color-success);
+	background: var(--ifm-color-emphasis-100);
+	border-radius: 0 8px 8px 0;
+	padding: 0.9rem 1rem;
+	margin: 1.2rem 0;
+}
+.header {
+	display: flex;
+	align-items: center;
+	justify-content: space-between;
+	margin-bottom: 0.5rem;
+}
+.label {
+	font-size: 0.7rem;
+	font-weight: 700;
+	text-transform: uppercase;
+	letter-spacing: 0.5px;
+	color: var(--ifm-color-emphasis-700);
+}
+.copy {
+	display: inline-flex;
+	align-items: center;
+	gap: 0.3rem;
+	padding: 0.2rem 0.6rem;
+	font-size: 0.75rem;
+	color: var(--ifm-color-success-dark);
+	background: transparent;
+	border: 1px solid var(--ifm-color-success);
+	border-radius: 6px;
+	cursor: pointer;
+}
+.body {
+	margin: 0;
+	font-family: var(--ifm-font-family-monospace);
+	font-size: 0.85rem;
+	line-height: 1.5;
+	color: var(--ifm-color-emphasis-900);
+	white-space: pre-wrap;
+}
+```
+
+- [ ] **Step 2: Create the component**
+
+`packages/docs/src/components/AgentPrompt/index.tsx`:
+```tsx
+import React, { useRef, useState } from "react";
+import styles from "./styles.module.css";
+
+interface AgentPromptProps {
+	/** The prompt text. Provided as children so it reads naturally in MDX. */
+	readonly children: React.ReactNode;
+}
+
+export default function AgentPrompt({ children }: AgentPromptProps): React.ReactElement {
+	const bodyRef = useRef<HTMLParagraphElement>(null);
+	const [copied, setCopied] = useState(false);
+
+	async function handleCopy(): Promise<void> {
+		const text = bodyRef.current?.textContent?.trim() ?? "";
+		await navigator.clipboard.writeText(text);
+		setCopied(true);
+		setTimeout(() => setCopied(false), 2000);
+	}
+
+	return (
+		<div className={styles.block}>
+			<div className={styles.header}>
+				<span className={styles.label}>Prompt for your AI agent</span>
+				<button type="button" className={styles.copy} onClick={handleCopy}>
+					📋 {copied ? "Copied!" : "Copy"}
+				</button>
+			</div>
+			<p ref={bodyRef} className={styles.body}>
+				{children}
+			</p>
+		</div>
+	);
+}
+```
+
+- [ ] **Step 3: Type-check**
+
+Run: `cd packages/docs && pnpm exec tsc --noEmit`
+Expected: no type errors.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add packages/docs/src/components/AgentPrompt
+git commit -m "feat: AgentPrompt inline copyable prompt component"
+```
+
+---
+
+## Task 4: Register AgentPrompt globally for MDX
+
+**Files:**
+- Create: `packages/docs/src/theme/MDXComponents.tsx`
+
+- [ ] **Step 1: Create the MDXComponents swizzle**
+
+`packages/docs/src/theme/MDXComponents.tsx`:
+```tsx
+import MDXComponents from "@theme-original/MDXComponents";
+import AgentPrompt from "@site/src/components/AgentPrompt";
+
+export default {
+	...MDXComponents,
+	AgentPrompt
+};
+```
+
+This makes `<AgentPrompt>` usable in any `.md`/`.mdx` page without an explicit import.
+
+- [ ] **Step 2: Build to verify registration**
+
+Run: `pnpm nadle packages:docs:buildSite`
+Expected: build succeeds. (No page uses `<AgentPrompt>` yet, so this just verifies the swizzle resolves.)
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add packages/docs/src/theme/MDXComponents.tsx
+git commit -m "feat: register AgentPrompt as a global MDX component"
+```
+
+---
+
+## Task 5: Add AgentPrompt blocks to the four scenario pages
+
+**Files:**
+- Modify: `packages/docs/docs/getting-started/installation.md`
+- Modify: `packages/docs/docs/guides/configuring-task.md`
+- Modify: `packages/docs/docs/guides/authoring-plugin.md`
+- Modify: the migration guide page — if one exists under `packages/docs/docs/`, use it; if not, add the block to `getting-started/installation.md` under a "Migrating an existing project" subsection and note that issue #650 (migration guides) will expand it.
+
+- [ ] **Step 1: Find the exact insertion points**
+
+Run: `cd packages/docs && grep -rn "^# \|^## " docs/getting-started/installation.md docs/guides/configuring-task.md docs/guides/authoring-plugin.md`
+Expected: lists the headings so you place each block under the most relevant section. Also run `ls docs/guides docs/getting-started` to confirm whether a migration page exists.
+
+- [ ] **Step 2: Add the setup prompt to `installation.md`**
+
+After the install/verify section, insert:
+```mdx
+<AgentPrompt>
+Set up Nadle in this repository. Install `nadle` as a dev dependency, create a `nadle.config.ts` at the project root that registers a `build` task running `tsc` and a `test` task that depends on `build`, then run `nadle build` to verify it works. Use the keyed task spec form: `tasks.register("build", { run: ExecTask, options: { command: "tsc" } })`.
+</AgentPrompt>
+```
+
+- [ ] **Step 3: Add the migration prompt**
+
+On the migration page (or the installation migration subsection):
+```mdx
+<AgentPrompt>
+Migrate this repository's npm scripts to Nadle. For each script in package.json, register an equivalent Nadle task in `nadle.config.ts` using the keyed spec form (`tasks.register("name", { run: ExecTask, options: { command, args } })`), preserve the original behavior, wire up `dependsOn` where one script calls another, and leave the npm scripts in place until I confirm the Nadle tasks work.
+</AgentPrompt>
+```
+
+- [ ] **Step 4: Add the caching prompt to `configuring-task.md`**
+
+Under the inputs/outputs/caching section:
+```mdx
+<AgentPrompt>
+Add caching to my Nadle `build` task so it is skipped when its inputs are unchanged. Declare `inputs` for the source files and config it reads, and `outputs` for the directory it produces, using `Inputs.files(...)` / `Outputs.dirs(...)` in the task's keyed spec. Then explain how to verify a cache hit.
+</AgentPrompt>
+```
+
+- [ ] **Step 5: Add the plugin prompt to `authoring-plugin.md`**
+
+Under the plugin-authoring intro:
+```mdx
+<AgentPrompt>
+Scaffold a Nadle plugin in this repository using `definePlugin`. It should contribute one custom task (built with `defineTask`) and one reporter, and export the plugin so it can be applied with `use(...)` in `nadle.config.ts`. Follow the keyed task spec API.
+</AgentPrompt>
+```
+
+- [ ] **Step 6: Build + link check**
+
+Run: `pnpm nadle packages:docs:buildSite`
+Then: `pnpm nadle checkLinks`
+Expected: build succeeds (the global `<AgentPrompt>` renders on all four pages); no broken links/anchors.
+
+- [ ] **Step 7: Manually verify**
+
+Run the dev server, open each of the four pages, confirm the green prompt block renders and its Copy button copies the prompt text (paste to check).
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add packages/docs/docs
+git commit -m "docs: add agent-prompt blocks to setup, migrate, caching, plugin guides"
+```
+
+---
+
+## Task 6: Final verification
+
+- [ ] **Step 1: Full docs build + checks**
+
+Run: `pnpm nadle packages:docs:buildSite`
+Run: `pnpm nadle checkLinks`
+Run: `cd packages/docs && pnpm exec tsc --noEmit`
+Run: `pnpm exec eslint packages/docs/src --quiet`
+Expected: all green. Fix any prettier/eslint drift on the new files (`pnpm exec prettier --write packages/docs/src`).
+
+- [ ] **Step 2: Manual smoke test**
+
+Dev server: confirm (a) every doc page shows "Copy page" and it copies the page Markdown in a production build (`buildSite` then serve the `build/` dir, since `.md` files only exist after build), (b) the four pages show working AgentPrompt blocks.
+
+- [ ] **Step 3: Commit any cleanup**
+
+```bash
+git add -A
+git commit -m "chore: lint/format agent-docs components"
+```
+
+---
+
+## Self-Review
+
+- **Spec coverage:** Component 1 (Copy page) → Tasks 1-2. Component 2 (AgentPrompt) → Tasks 3-4. The 4 scenarios → Task 5. Error handling (clipboard fail, `.md` 404 → URL fallback) → Task 1 Step 2. Site-wide via swizzle → Task 2. Global MDX registration → Task 4. Build/checkLinks/manual verification → Task 6. No open-in-assistant (dropped from spec) — correctly absent.
+- **Placeholder scan:** the migration-page target is conditional (use existing page or add a subsection) — resolved with an explicit either/or instruction + the #650 note, not a TBD. All code blocks are complete.
+- **Type consistency:** `CopyPageButton` default export ← imported in `DocItem/Content`; `AgentPrompt` default export ← imported in `MDXComponents`; prop name `children` consistent. CSS module class names (`button`/`copied`, `block`/`header`/`label`/`copy`/`body`, `actions`) match between each `.tsx` and its `.module.css`.
+- **Known unknown for the implementer:** the docs package's exact typecheck/start script names — Task 1 Step 3 / Task 2 Step 4 say to check `packages/docs/package.json` scripts (don't assume). The `@nadle/internal-docs` filter name is a guess; verify the real package name.

--- a/docs/superpowers/specs/2026-06-15-agent-friendly-docs-design.md
+++ b/docs/superpowers/specs/2026-06-15-agent-friendly-docs-design.md
@@ -81,7 +81,10 @@ the CLI).
 | Author a plugin | `guides/authoring-plugin.md` | Scaffold a nadle plugin with a task + reporter using `definePlugin` |
 
 Prompts are written in the keyed-spec API (post-#688) and must stay accurate to the
-shipped API.
+shipped API. **Each prompt instructs the agent to first read the authoritative
+docs** — fetch `https://nadle.dev/llms.txt` (or the relevant `/docs` page) — so the
+agent grounds itself in the current API rather than relying on stale model
+knowledge. This reuses the already-generated `llms.txt` (#664).
 
 ## Architecture / files
 

--- a/docs/superpowers/specs/2026-06-15-agent-friendly-docs-design.md
+++ b/docs/superpowers/specs/2026-06-15-agent-friendly-docs-design.md
@@ -2,7 +2,7 @@
 
 **Status:** Approved (user approved 2026-06-15).
 **Scope:** The Docusaurus docs site (`packages/docs/`). Make nadle.dev usable by AI
-coding agents: copy a page as Markdown / open it in an assistant, and copy curated
+coding agents: copy a page as Markdown, and copy curated
 agent-instruction prompts for common scenarios.
 **Out of scope (follow-up issue):** an Nx-style CLI (`create-nadle --ai`) that
 scaffolds `AGENTS.md`/`CLAUDE.md` into a user repo. Bigger build; deferred.
@@ -12,9 +12,9 @@ scaffolds `AGENTS.md`/`CLAUDE.md` into a user repo. Bigger build; deferred.
 When a developer uses an AI coding agent (Claude Code, Cursor, Copilot, …) and wants
 nadle in their project, give them two frictionless on-ramps from the docs:
 
-1. **Copy/open any doc page as Markdown** — one click to grab the current page as
-   clean Markdown (to paste into an agent) or open it pre-loaded in Claude/ChatGPT.
-   The emerging standard (Nx, Anthropic, Vercel docs all do this).
+1. **Copy any doc page as Markdown** — one click to grab the current page as clean
+   Markdown to paste into an agent. The emerging standard (Nx, Anthropic, Vercel
+   docs all do this). (No "open in Claude/ChatGPT" deep links — out of scope.)
 2. **Copy a ready-made agent prompt** — inline blocks on key guides that copy a
    natural-language instruction *to* an agent ("Set up Nadle in this repo: …"), so
    the user pastes it into their assistant and the agent does the work.
@@ -32,21 +32,17 @@ already shipped (#664–#668). This design adds the *interactive* layer on top.
 
 ## Component 1 — "Copy page" affordance (site-wide)
 
-A small action group rendered at the top of every doc article (right of the H1),
-via a swizzled Docusaurus `DocItem` (or `DocItem/Content` wrapper) theme component:
+A single **Copy page** button rendered at the top of every doc article (right of
+the H1), via a swizzled Docusaurus `DocItem` (or `DocItem/Content` wrapper) theme
+component:
 
 ```
-┌ Configuring Tasks ─────────────────── [📋 Copy page] [↗ Open in ▾] ┐
+┌ Configuring Tasks ───────────────────────────────── [📋 Copy page] ┐
 ```
 
 - **Copy page** — copies the current page's Markdown to the clipboard. Source: the
   page's generated `.md` (from the llms-txt plugin) fetched at click time, or the
   raw frontmatter+body if simpler. Falls back to copying a link if fetch fails.
-- **Open in ▾** — a small menu: **Open in Claude**, **Open in ChatGPT**. Each opens
-  the assistant with a pre-filled prompt that references the page URL + asks the
-  assistant to read it (e.g. `https://claude.ai/new?q=<encoded prompt incl. page URL>`).
-  Use each vendor's documented deep-link query param; if a vendor lacks one, omit
-  that entry rather than guess.
 
 Behavior:
 - Shows a transient "Copied!" state on success.
@@ -92,16 +88,16 @@ shipped API.
 - `packages/docs/src/theme/DocItem/Content/index.tsx` (swizzled) — renders the
   Component-1 action group above the article body. Wraps the original component;
   does not fork the whole DocItem.
-- `packages/docs/src/components/CopyPageButton/` — the copy-page + open-in-assistant
-  logic (clipboard, fetch the page `.md`, vendor deep links). One focused unit.
+- `packages/docs/src/components/CopyPageButton/` — the copy-page logic (clipboard,
+  fetch the page `.md`, URL fallback). One focused unit.
 - `packages/docs/src/components/AgentPrompt/` — the inline prompt block (Component 2).
 - MDX edits: add `<AgentPrompt>` to the 4 scenario pages (import auto-available via
   `@theme` or a global MDX scope registration in `docusaurus.config`/`MDXComponents`).
 - No change to the llms-txt plugin config; it already produces the Markdown sources.
 
 Each component is independently understandable: `CopyPageButton` knows "given the
-current page, produce its Markdown + assistant links"; `AgentPrompt` knows "render
-this text as a copyable prompt." Neither depends on the other.
+current page, copy its Markdown"; `AgentPrompt` knows "render this text as a
+copyable prompt." Neither depends on the other.
 
 ## Data flow
 
@@ -109,8 +105,6 @@ this text as a copyable prompt." Neither depends on the other.
   read a frontmatter/route-mapped path the llms-txt plugin emits) → `fetch()` →
   `navigator.clipboard.writeText(markdown)` → "Copied!" toast. On fetch failure,
   copy the canonical page URL instead and label it accordingly.
-- **Open in assistant:** click → build the vendor URL with an encoded prompt that
-  includes the page URL → `window.open`.
 - **Agent prompt:** click → `navigator.clipboard.writeText(promptText)` → "Copied!".
 
 ## Error handling
@@ -118,7 +112,6 @@ this text as a copyable prompt." Neither depends on the other.
 - Clipboard API unavailable / denied → fall back to selecting the text + a "press
   ⌘C" hint, or a `document.execCommand('copy')` fallback.
 - `.md` fetch fails (offline, 404) → copy the page URL, toast "Link copied".
-- Missing vendor deep-link → that menu entry is omitted at build, never a dead click.
 
 ## Testing
 
@@ -128,8 +121,7 @@ this text as a copyable prompt." Neither depends on the other.
   the dev server is acceptable for a docs-only feature (matches repo norms — docs
   have no unit suite today).
 - Manual: load a page, click Copy page → paste shows the page Markdown; click an
-  AgentPrompt Copy → paste shows the prompt text; Open-in-Claude opens with the
-  prompt pre-filled.
+  AgentPrompt Copy → paste shows the prompt text.
 
 ## Alternatives considered
 

--- a/docs/superpowers/specs/2026-06-15-agent-friendly-docs-design.md
+++ b/docs/superpowers/specs/2026-06-15-agent-friendly-docs-design.md
@@ -1,0 +1,150 @@
+# Agent-Friendly nadle.dev Design
+
+**Status:** Approved (user approved 2026-06-15).
+**Scope:** The Docusaurus docs site (`packages/docs/`). Make nadle.dev usable by AI
+coding agents: copy a page as Markdown / open it in an assistant, and copy curated
+agent-instruction prompts for common scenarios.
+**Out of scope (follow-up issue):** an Nx-style CLI (`create-nadle --ai`) that
+scaffolds `AGENTS.md`/`CLAUDE.md` into a user repo. Bigger build; deferred.
+
+## Goal
+
+When a developer uses an AI coding agent (Claude Code, Cursor, Copilot, …) and wants
+nadle in their project, give them two frictionless on-ramps from the docs:
+
+1. **Copy/open any doc page as Markdown** — one click to grab the current page as
+   clean Markdown (to paste into an agent) or open it pre-loaded in Claude/ChatGPT.
+   The emerging standard (Nx, Anthropic, Vercel docs all do this).
+2. **Copy a ready-made agent prompt** — inline blocks on key guides that copy a
+   natural-language instruction *to* an agent ("Set up Nadle in this repo: …"), so
+   the user pastes it into their assistant and the agent does the work.
+
+These compose: (1) is site-wide and cheap; (2) is scenario-specific and curated.
+
+## Existing foundation (reuse, don't rebuild)
+
+`@signalwire/docusaurus-plugin-llms-txt` is already configured
+(`docusaurus.config.ts`) and emits per-page Markdown plus `llms.txt` /
+`llms-full.txt` at build. So **every doc page already has a Markdown
+representation** the copy/open affordances can point at. The agent quickstart
+(`docs/getting-started/quickstart-for-agents.md`) and AI-crawler `robots.txt`
+already shipped (#664–#668). This design adds the *interactive* layer on top.
+
+## Component 1 — "Copy page" affordance (site-wide)
+
+A small action group rendered at the top of every doc article (right of the H1),
+via a swizzled Docusaurus `DocItem` (or `DocItem/Content` wrapper) theme component:
+
+```
+┌ Configuring Tasks ─────────────────── [📋 Copy page] [↗ Open in ▾] ┐
+```
+
+- **Copy page** — copies the current page's Markdown to the clipboard. Source: the
+  page's generated `.md` (from the llms-txt plugin) fetched at click time, or the
+  raw frontmatter+body if simpler. Falls back to copying a link if fetch fails.
+- **Open in ▾** — a small menu: **Open in Claude**, **Open in ChatGPT**. Each opens
+  the assistant with a pre-filled prompt that references the page URL + asks the
+  assistant to read it (e.g. `https://claude.ai/new?q=<encoded prompt incl. page URL>`).
+  Use each vendor's documented deep-link query param; if a vendor lacks one, omit
+  that entry rather than guess.
+
+Behavior:
+- Shows a transient "Copied!" state on success.
+- Lives in one component file; appears on all `docs/**` pages automatically.
+- Degrades gracefully without JS (the buttons simply don't render or are inert).
+
+## Component 2 — Inline agent-prompt block (`<AgentPrompt>`)
+
+A reusable MDX component dropped into specific guide pages:
+
+```mdx
+<AgentPrompt title="Set up Nadle">
+Set up Nadle in this repository. Install it as a dev dependency, create a
+`nadle.config.ts` at the root with a `build` task that runs `tsc` and a `test`
+task that depends on `build`, then run `nadle build` to verify.
+</AgentPrompt>
+```
+
+Renders as a minimal admonition-style block (Docusaurus `:::tip` aesthetic — green
+left border) with an uppercase "Prompt for your AI agent" label and a **Copy**
+button (chosen layout: mockup option C). The copied text is the prompt body
+verbatim (Markdown stripped to plain text on copy).
+
+**Why a component, not raw code fences:** centralizes the copy UX + label, keeps
+prompts visually distinct from runnable code blocks, and lets the prompts be linted
+later (a future ESLint/test could assert each prompt's claimed commands still match
+the CLI).
+
+### Scenarios shipped (one `<AgentPrompt>` each, on the relevant page)
+
+| Scenario | Page | Prompt gist |
+|---|---|---|
+| Setup | `getting-started/installation.md` (or quickstart-for-agents) | Install nadle, create a minimal `nadle.config.ts`, run a task to verify |
+| Migrate | a migration guide page (new or existing per #650) | Migrate this repo's npm scripts to nadle tasks, preserving behavior |
+| Common tasks | `guides/configuring-task.md` / caching guide | Add caching (inputs/outputs) to an existing task so unchanged inputs skip |
+| Author a plugin | `guides/authoring-plugin.md` | Scaffold a nadle plugin with a task + reporter using `definePlugin` |
+
+Prompts are written in the keyed-spec API (post-#688) and must stay accurate to the
+shipped API.
+
+## Architecture / files
+
+- `packages/docs/src/theme/DocItem/Content/index.tsx` (swizzled) — renders the
+  Component-1 action group above the article body. Wraps the original component;
+  does not fork the whole DocItem.
+- `packages/docs/src/components/CopyPageButton/` — the copy-page + open-in-assistant
+  logic (clipboard, fetch the page `.md`, vendor deep links). One focused unit.
+- `packages/docs/src/components/AgentPrompt/` — the inline prompt block (Component 2).
+- MDX edits: add `<AgentPrompt>` to the 4 scenario pages (import auto-available via
+  `@theme` or a global MDX scope registration in `docusaurus.config`/`MDXComponents`).
+- No change to the llms-txt plugin config; it already produces the Markdown sources.
+
+Each component is independently understandable: `CopyPageButton` knows "given the
+current page, produce its Markdown + assistant links"; `AgentPrompt` knows "render
+this text as a copyable prompt." Neither depends on the other.
+
+## Data flow
+
+- **Copy page:** click → resolve current page's `.md` URL (derive from the route, or
+  read a frontmatter/route-mapped path the llms-txt plugin emits) → `fetch()` →
+  `navigator.clipboard.writeText(markdown)` → "Copied!" toast. On fetch failure,
+  copy the canonical page URL instead and label it accordingly.
+- **Open in assistant:** click → build the vendor URL with an encoded prompt that
+  includes the page URL → `window.open`.
+- **Agent prompt:** click → `navigator.clipboard.writeText(promptText)` → "Copied!".
+
+## Error handling
+
+- Clipboard API unavailable / denied → fall back to selecting the text + a "press
+  ⌘C" hint, or a `document.execCommand('copy')` fallback.
+- `.md` fetch fails (offline, 404) → copy the page URL, toast "Link copied".
+- Missing vendor deep-link → that menu entry is omitted at build, never a dead click.
+
+## Testing
+
+- Docs build green (`buildSite`) + `checkLinks` (no broken anchors introduced).
+- A lightweight component test (if the docs package has a test setup) for
+  `AgentPrompt` rendering its body + copy handler; otherwise manual verification via
+  the dev server is acceptable for a docs-only feature (matches repo norms — docs
+  have no unit suite today).
+- Manual: load a page, click Copy page → paste shows the page Markdown; click an
+  AgentPrompt Copy → paste shows the prompt text; Open-in-Claude opens with the
+  prompt pre-filled.
+
+## Alternatives considered
+
+- **Dedicated `/prompts` gallery page** instead of inline blocks — rejected earlier
+  by the user; inline keeps prompts in context next to the human docs.
+- **CLI scaffold (`create-nadle --ai`)** — the Nx approach (`npx nx
+  configure-ai-agents`). Most "magic" but the largest build (create-nadle work, an
+  AGENTS.md template, cross-tool support). Deferred to a follow-up issue; the
+  copy-page + prompt blocks deliver the agent on-ramp with zero new runtime tooling.
+- **Tabbed "Agent prompt / Commands" block** (mockup B) — rejected: the user wants
+  agent-instruction prompts, not raw command duplication; the page already shows
+  runnable commands in normal code fences.
+
+## Out of scope (future)
+
+- `create-nadle --ai` / AGENTS.md scaffolding command (separate issue).
+- An MCP server for nadle (Nx ships one; far larger, separate effort).
+- Auto-linting prompts against the live CLI surface.

--- a/packages/docs/docs/getting-started/installation.md
+++ b/packages/docs/docs/getting-started/installation.md
@@ -54,6 +54,10 @@ nadle --version
 
 You should see the current version of Nadle printed to your terminal.
 
+<AgentPrompt>
+Set up Nadle in this repository. First read the Nadle docs for the current API — fetch https://nadle.dev/llms.txt (or browse https://nadle.dev/docs). Then install `nadle` as a dev dependency, create a `nadle.config.ts` at the project root that registers a `build` task running `tsc` and a `test` task that depends on `build`, and run `nadle build` to verify. Use the keyed task spec form: `tasks.register("build", { run: ExecTask, options: { command: "tsc" } })`.
+</AgentPrompt>
+
 ## Write nadle.config.ts
 
 The `nadle.config.ts` file serves as the central entry point for defining and organizing your Nadle tasks.
@@ -102,3 +106,12 @@ Goodbye, Nadle!
 
 RUN SUCCESSFUL in 505ms (2 tasks executed)
 ```
+
+## Migrating an existing project
+
+Already have npm scripts? Hand this prompt to your AI agent to convert them to Nadle tasks.
+(Dedicated migration guides — from npm scripts, Turborepo, Nx, and Makefile — are tracked in [#650](https://github.com/nadlejs/nadle/issues/650).)
+
+<AgentPrompt>
+Migrate this repository's npm scripts to Nadle. First read the Nadle docs for the current API — fetch https://nadle.dev/llms.txt (or browse https://nadle.dev/docs). Then, for each script in package.json, register an equivalent Nadle task in `nadle.config.ts` using the keyed spec form (`tasks.register("name", { run: ExecTask, options: { command, args } })`), preserve the original behavior, wire up `dependsOn` where one script calls another, and leave the npm scripts in place until I confirm the Nadle tasks work.
+</AgentPrompt>

--- a/packages/docs/docs/guides/authoring-plugin.md
+++ b/packages/docs/docs/guides/authoring-plugin.md
@@ -10,6 +10,10 @@ A plugin packages reusable behavior so other projects can enable it with a singl
 `definePlugin` helper, which gives you full type inference for the plugin's
 options.
 
+<AgentPrompt>
+Scaffold a Nadle plugin in this repository using `definePlugin`. First read the Nadle docs for the current API — fetch https://nadle.dev/llms.txt (or browse https://nadle.dev/docs/guides/authoring-plugin). It should contribute one custom task (built with `defineTask`) and one reporter, and export the plugin so it can be applied with `use(...)` in `nadle.config.ts`. Follow the keyed task spec API.
+</AgentPrompt>
+
 ```ts
 import { definePlugin } from "nadle";
 

--- a/packages/docs/docs/guides/configuring-task.md
+++ b/packages/docs/docs/guides/configuring-task.md
@@ -152,6 +152,10 @@ tasks.register("build", {
 });
 ```
 
+<AgentPrompt>
+Add caching to my Nadle `build` task so it is skipped when its inputs are unchanged. First read the Nadle docs for the current API — fetch https://nadle.dev/llms.txt (or browse https://nadle.dev/docs/guides/configuring-task). Then declare `inputs` for the source files and config it reads, and `outputs` for the directory it produces, using `Inputs.files(...)` / `Outputs.dirs(...)` in the task's keyed spec, and explain how to verify a cache hit.
+</AgentPrompt>
+
 ## timeout
 
 - **Type:** `number` (milliseconds, positive integer)

--- a/packages/docs/src/components/AgentPrompt/index.tsx
+++ b/packages/docs/src/components/AgentPrompt/index.tsx
@@ -1,0 +1,35 @@
+import React, { useRef, useState } from "react";
+
+import styles from "./styles.module.css";
+
+interface AgentPromptProps {
+	/** The prompt text. Provided as children so it reads naturally in MDX. */
+	readonly children: React.ReactNode;
+}
+
+export default function AgentPrompt({ children }: AgentPromptProps): React.ReactElement {
+	const bodyRef = useRef<HTMLParagraphElement>(null);
+	const [copied, setCopied] = useState(false);
+
+	async function handleCopy(): Promise<void> {
+		const text = bodyRef.current?.textContent?.trim() ?? "";
+
+		await navigator.clipboard.writeText(text);
+		setCopied(true);
+		setTimeout(() => setCopied(false), 2000);
+	}
+
+	return (
+		<div className={styles.block}>
+			<div className={styles.header}>
+				<span className={styles.label}>Prompt for your AI agent</span>
+				<button type="button" className={styles.copy} onClick={handleCopy}>
+					📋 {copied ? "Copied!" : "Copy"}
+				</button>
+			</div>
+			<p ref={bodyRef} className={styles.body}>
+				{children}
+			</p>
+		</div>
+	);
+}

--- a/packages/docs/src/components/AgentPrompt/styles.module.css
+++ b/packages/docs/src/components/AgentPrompt/styles.module.css
@@ -1,0 +1,40 @@
+.block {
+	border-left: 3px solid var(--ifm-color-success);
+	background: var(--ifm-color-emphasis-100);
+	border-radius: 0 8px 8px 0;
+	padding: 0.9rem 1rem;
+	margin: 1.2rem 0;
+}
+.header {
+	display: flex;
+	align-items: center;
+	justify-content: space-between;
+	margin-bottom: 0.5rem;
+}
+.label {
+	font-size: 0.7rem;
+	font-weight: 700;
+	text-transform: uppercase;
+	letter-spacing: 0.5px;
+	color: var(--ifm-color-emphasis-700);
+}
+.copy {
+	display: inline-flex;
+	align-items: center;
+	gap: 0.3rem;
+	padding: 0.2rem 0.6rem;
+	font-size: 0.75rem;
+	color: var(--ifm-color-success-dark);
+	background: transparent;
+	border: 1px solid var(--ifm-color-success);
+	border-radius: 6px;
+	cursor: pointer;
+}
+.body {
+	margin: 0;
+	font-family: var(--ifm-font-family-monospace);
+	font-size: 0.85rem;
+	line-height: 1.5;
+	color: var(--ifm-color-emphasis-900);
+	white-space: pre-wrap;
+}

--- a/packages/docs/src/components/CopyPageButton/index.tsx
+++ b/packages/docs/src/components/CopyPageButton/index.tsx
@@ -1,0 +1,47 @@
+import React, { useState } from "react";
+import { useLocation } from "@docusaurus/router";
+
+import styles from "./styles.module.css";
+
+type Status = "idle" | "copied" | "linked";
+
+export default function CopyPageButton(): React.ReactElement {
+	const { pathname } = useLocation();
+	const [status, setStatus] = useState<Status>("idle");
+
+	async function handleCopy(): Promise<void> {
+		const mdUrl = pathname.replace(/\/$/, "") + ".md";
+
+		try {
+			const response = await fetch(mdUrl);
+
+			if (!response.ok) {
+				throw new Error(`status ${response.status}`);
+			}
+
+			const markdown = await response.text();
+
+			await navigator.clipboard.writeText(markdown);
+			setStatus("copied");
+		} catch {
+			// Fallback: copy the page URL so the agent can fetch it itself.
+			await navigator.clipboard.writeText(window.location.href);
+			setStatus("linked");
+		}
+
+		setTimeout(() => setStatus("idle"), 2000);
+	}
+
+	const label = status === "copied" ? "Copied!" : status === "linked" ? "Link copied" : "Copy page";
+
+	return (
+		<button
+			type="button"
+			className={status === "idle" ? styles.button : `${styles.button} ${styles.copied}`}
+			onClick={handleCopy}
+			title="Copy this page as Markdown for an AI agent"
+		>
+			📋 {label}
+		</button>
+	);
+}

--- a/packages/docs/src/components/CopyPageButton/styles.module.css
+++ b/packages/docs/src/components/CopyPageButton/styles.module.css
@@ -1,0 +1,21 @@
+.button {
+	display: inline-flex;
+	align-items: center;
+	gap: 0.4rem;
+	padding: 0.25rem 0.7rem;
+	font-size: 0.8rem;
+	font-weight: 600;
+	color: var(--ifm-color-emphasis-800);
+	background: var(--ifm-color-emphasis-100);
+	border: 1px solid var(--ifm-color-emphasis-300);
+	border-radius: 6px;
+	cursor: pointer;
+	transition: background 0.15s ease;
+}
+.button:hover {
+	background: var(--ifm-color-emphasis-200);
+}
+.copied {
+	color: var(--ifm-color-success);
+	border-color: var(--ifm-color-success);
+}

--- a/packages/docs/src/theme/DocItem/Content/index.tsx
+++ b/packages/docs/src/theme/DocItem/Content/index.tsx
@@ -1,0 +1,21 @@
+import React from "react";
+import Content from "@theme-original/DocItem/Content";
+import type ContentType from "@theme/DocItem/Content";
+import type { WrapperProps } from "@docusaurus/types";
+
+import CopyPageButton from "../../../components/CopyPageButton";
+
+import styles from "./styles.module.css";
+
+type Props = WrapperProps<typeof ContentType>;
+
+export default function ContentWrapper(props: Props): React.ReactElement {
+	return (
+		<>
+			<div className={styles.actions}>
+				<CopyPageButton />
+			</div>
+			<Content {...props} />
+		</>
+	);
+}

--- a/packages/docs/src/theme/DocItem/Content/styles.module.css
+++ b/packages/docs/src/theme/DocItem/Content/styles.module.css
@@ -1,0 +1,5 @@
+.actions {
+	display: flex;
+	justify-content: flex-end;
+	margin-bottom: 0.5rem;
+}

--- a/packages/docs/src/theme/MDXComponents.tsx
+++ b/packages/docs/src/theme/MDXComponents.tsx
@@ -1,0 +1,8 @@
+import MDXComponents from "@theme-original/MDXComponents";
+
+import AgentPrompt from "../components/AgentPrompt";
+
+export default {
+	...MDXComponents,
+	AgentPrompt
+};


### PR DESCRIPTION
Makes nadle.dev usable by AI coding agents, in two ways.

## 1. "Copy page" button — every doc page
A small button at the top-right of each doc article copies the page as clean **Markdown** (fetched from the llms-txt-generated `<route>.md`, with a page-URL fallback if the fetch fails). Paste it into any coding agent. Rendered site-wide via a swizzled `theme/DocItem/Content`.

## 2. Inline `<AgentPrompt>` blocks — key guides
A reusable MDX component (green admonition style) that copies a ready-made **instruction for your AI agent**. Added to four scenarios:
- **Setup** + **Migrate** — `getting-started/installation.md`
- **Caching** — `guides/configuring-task.md`
- **Author a plugin** — `guides/authoring-plugin.md`

Each prompt tells the agent to **first read `https://nadle.dev/llms.txt`** (or the relevant `/docs` page) so it grounds in the current keyed-spec API instead of stale model knowledge. Registered globally via an `MDXComponents` swizzle, so `<AgentPrompt>` works in any `.md`/`.mdx` page.

## Notes
- No new build tooling — reuses the already-configured `@signalwire/docusaurus-plugin-llms-txt` Markdown output (#664).
- "Open in Claude/ChatGPT" deep links were considered and dropped (out of scope).
- A follow-up could add an Nx-style `create-nadle --ai` scaffold (separate issue).

## Verification
`packages:docs:buildSite` succeeds (114 docs processed, swizzles + `<AgentPrompt>` render), `checkLinks` clean, docs `tsc --noEmit` clean, eslint clean. Manually tested on the dev server.

Design + plan: `docs/superpowers/specs/2026-06-15-agent-friendly-docs-design.md`, `docs/superpowers/plans/2026-06-15-agent-friendly-docs.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)