### PR TITLE
test: complete sub-workspace duplicate-task test (#416)

### DIFF
--- a/packages/docs/sidebars.ts
+++ b/packages/docs/sidebars.ts
@@ -36,8 +36,8 @@ const sidebars: SidebarsConfig = {
 				"guides/configuring-nadle",
 				"guides/eslint-plugin",
 				{
-					label: "Migrating",
 					type: "category",
+					label: "Migrating",
 					items: [
 						"guides/migrating/from-npm-scripts",
 						"guides/migrating/from-turborepo",

--- a/packages/nadle/test/errors.test.ts
+++ b/packages/nadle/test/errors.test.ts
@@ -1,5 +1,5 @@
 import { it, expect, describe } from "vitest";
-import { exec, fixture, readConfig, expectFail, withGeneratedFixture } from "setup";
+import { exec, fixture, readConfig, expectFail, withFixture, workspaceFixture, withGeneratedFixture } from "setup";
 
 const duplicateTasksFiles = fixture()
 	.packageJson("duplicate-tasks")
@@ -15,10 +15,19 @@ describe("when register two tasks with the same name", () => {
 			}
 		}));
 
-	// TODO(#416): mirror the root-workspace duplicate-task case above for a
-	// sub-workspace — register the same task name twice inside a package of a
-	// monorepo fixture and assert "Task <name> already registered in workspace <id>".
-	it.todo("should throw error within workspace");
+	it("should throw error within workspace", () =>
+		withFixture({
+			fixtureDir: "monorepo",
+			testFn: async ({ exec }) => {
+				await expect(() => exec`build`).rejects.toThrow(`Task hello already registered in workspace packages:one`);
+			},
+			files: workspaceFixture({
+				root: { tasks: [{ name: "build" }] },
+				workspaces: {
+					"packages/one": { rawConfig: 'import { tasks } from "nadle";\n\ntasks.register("hello");\ntasks.register("hello");\n' }
+				}
+			})
+		}));
 });
 
 describe("when a task fails", () => {

--- a/packages/nadle/test/features/workspaces/workspaces-alias.test.ts
+++ b/packages/nadle/test/features/workspaces/workspaces-alias.test.ts
@@ -58,8 +58,9 @@ describe("workspaces alias", () => {
 		});
 	});
 
-	// TODO(#416): assert alias validation rejects invalid configs — duplicate
-	// aliases mapping to different workspaces, an alias colliding with a real
-	// workspace id, and an alias for a non-existent path should each error.
+	// TODO(#698): blocked on alias validation not existing yet. Once #698 adds
+	// semantic validation, assert it rejects invalid configs — duplicate aliases
+	// mapping to different workspaces, an alias colliding with a real workspace id,
+	// and an alias for a non-existent path should each error.
 	it.todo("rejects invalid alias configuration");
 });

--- a/packages/nadle/test/features/workspaces/workspaces-detection.test.ts
+++ b/packages/nadle/test/features/workspaces/workspaces-detection.test.ts
@@ -3,9 +3,10 @@ import { PACKAGE_JSON } from "@nadle/project-resolver";
 import { expectPass, withFixture, CONFIG_FILE, PNPM_WORKSPACE, createPackageJson, createPnpmWorkspace } from "setup";
 
 describe("workspaces detection", () => {
-	// TODO(#416): a monorepo whose pnpm-workspace matches exactly one package
-	// currently errors during detection. Decide the intended behavior (treat as
-	// a valid single-workspace monorepo vs. a clear error message) and assert it.
+	// TODO(#699): blocked on a behavior decision. A monorepo whose pnpm-workspace
+	// matches exactly one package currently errors during detection. Once #699
+	// settles the intended behavior (valid single-workspace monorepo vs. a clear
+	// error message), assert it.
 	it.todo("single workspace in monorepo");
 
 	it("one package", async () => {


### PR DESCRIPTION
Works #416. That issue's checklist had drifted — 3 of its 5 named files (`log-level.test.ts`, `exclude.test.ts`, `profiling-summary.test.ts`) no longer exist, and 2 of the 3 remaining `it.todo`s are actually features/decisions, not unskippable tests.

## What this PR does
- **Implements** the one genuine test-completion: `errors.test.ts` — registering the same task name twice inside a **sub-workspace** throws `Task <name> already registered in workspace packages:one`, mirroring the existing root-workspace case.
- **Repoints** the other two todos at dedicated issues, since each needs real work first:
  - #698 — alias-config validation doesn't exist yet (`createAliasResolver` does no semantic checks; `assertAlias` only checks shape).
  - #699 — single-package-monorepo detection needs a behavior decision (valid vs. clear error).
- **Fixes** a `perfectionist/sort-objects` lint error in `docs/sidebars.ts` (type before label) left over from the migration-guides PR #696.

## Verification
- `vitest run --project nadle errors` → 3 passed (incl. the new case).
- eslint + prettier clean; pre-commit `nadle check` passes.

Once #698 and #699 land, their deferred `it.todo`s can be implemented and #416 fully closed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)